### PR TITLE
Expose channel and group config when writing

### DIFF
--- a/examples/multi_dt_example.rs
+++ b/examples/multi_dt_example.rs
@@ -4,7 +4,8 @@
 
 use mf4_rs::writer::MdfWriter;
 use mf4_rs::blocks::channel_block::ChannelBlock;
-use mf4_rs::blocks::common::{DataType};
+use mf4_rs::blocks::channel_group_block::ChannelGroupBlock;
+use mf4_rs::blocks::common::DataType;
 use mf4_rs::parsing::decoder::DecodedValue;
 use mf4_rs::error::MdfError;
 
@@ -15,21 +16,24 @@ fn main() -> Result<(), MdfError> {
 
     // Single data group with two channel groups
     let dg_id = writer.add_data_group(None)?;
-    let cg1_id = writer.add_channel_group(&dg_id, None)?;
-    let cg2_id = writer.add_channel_group(&dg_id, Some(&cg1_id))?;
+    let cg_block = ChannelGroupBlock::default();
+    let cg1_id = writer.add_channel_group(&dg_id, None, &cg_block)?;
+    let cg2_id = writer.add_channel_group(&dg_id, Some(&cg1_id), &cg_block)?;
 
     // Define one channel in each channel group
     let mut ch1 = ChannelBlock::default();
     ch1.byte_offset = 0;
     ch1.bit_count = 32;
     ch1.data_type = DataType::UnsignedIntegerLE;
-    writer.add_channel(&cg1_id, None, Some("Group1_Signal"), 0, 32)?;
+    ch1.name = Some("Group1_Signal".to_string());
+    writer.add_channel(&cg1_id, None, &ch1)?;
 
     let mut ch2 = ChannelBlock::default();
     ch2.byte_offset = 0;
     ch2.bit_count = 32;
     ch2.data_type = DataType::UnsignedIntegerLE;
-    writer.add_channel(&cg2_id, None, Some("Group2_Signal"), 0, 32)?;
+    ch2.name = Some("Group2_Signal".to_string());
+    writer.add_channel(&cg2_id, None, &ch2)?;
 
     // Start DT blocks for each channel group
     writer.start_data_block(&dg_id, &cg1_id, 0, &[ch1.clone()])?;

--- a/examples/write_read_example.rs
+++ b/examples/write_read_example.rs
@@ -1,5 +1,6 @@
 use mf4_rs::writer::MdfWriter;
 use mf4_rs::blocks::channel_block::ChannelBlock;
+use mf4_rs::blocks::channel_group_block::ChannelGroupBlock;
 use mf4_rs::blocks::common::DataType;
 use mf4_rs::parsing::decoder::DecodedValue;
 use mf4_rs::api::mdf::MDF;
@@ -10,13 +11,15 @@ fn main() -> Result<(), MdfError> {
     let mut writer = MdfWriter::new("write_read_example.mf4")?;
     let (_id, _hd) = writer.init_mdf_file()?;
     let dg_id = writer.add_data_group(None)?;
-    let cg_id = writer.add_channel_group(&dg_id, None)?;
+    let cg_block = ChannelGroupBlock::default();
+    let cg_id = writer.add_channel_group(&dg_id, None, &cg_block)?;
 
     let mut ch = ChannelBlock::default();
     ch.byte_offset = 0;
     ch.bit_count = 32;
     ch.data_type = DataType::UnsignedIntegerLE;
-    writer.add_channel(&cg_id, None, Some("Signal"), 0, 32)?;
+    ch.name = Some("Signal".to_string());
+    writer.add_channel(&cg_id, None, &ch)?;
 
     writer.start_data_block(&dg_id, &cg_id, 0, &[ch.clone()])?;
     for i in 0u32..1_000 {


### PR DESCRIPTION
## Summary
- refactor `add_channel_group` and `add_channel` so callers provide ready blocks
- adjust `write_simple_mdf_file` helper
- update all examples to use the new API

## Testing
- `cargo test --quiet`
- `cargo test --examples --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684523a0abd8832ba68e85beabb87ffc