### PR TITLE
Refactor multi group example

### DIFF
--- a/examples/write_multi_groups.rs
+++ b/examples/write_multi_groups.rs
@@ -1,0 +1,57 @@
+use mf4_rs::error::MdfError;
+use mf4_rs::writer::MdfWriter;
+use mf4_rs::blocks::channel_block::ChannelBlock;
+use mf4_rs::blocks::channel_group_block::ChannelGroupBlock;
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::api::mdf::MDF;
+
+fn write_simple_mdf_file_multi(file_path: &str, groups: &[Vec<ChannelBlock>]) -> Result<(), MdfError> {
+    let mut writer = MdfWriter::new(file_path)?;
+    let (_id, _hd) = writer.init_mdf_file()?;
+    let dg_id = writer.add_data_group(None)?;
+    let cg_block = ChannelGroupBlock::default();
+
+    let mut prev_cg: Option<String> = None;
+    for channels in groups {
+        let cg_id = writer.add_channel_group(&dg_id, prev_cg.as_deref(), &cg_block)?;
+        prev_cg = Some(cg_id.clone());
+
+        let mut prev_cn: Option<String> = None;
+        for ch in channels {
+            let cn_id = writer.add_channel(&cg_id, prev_cn.as_deref(), ch)?;
+            prev_cn = Some(cn_id);
+        }
+    }
+
+    writer.finalize()
+}
+
+fn main() -> Result<(), MdfError> {
+    // Prepare two channel groups with different channels
+    let mut ch1 = ChannelBlock::default();
+    ch1.byte_offset = 0;
+    ch1.bit_count = 32;
+    ch1.data_type = DataType::UnsignedIntegerLE;
+    ch1.name = Some("Speed".into());
+
+    let mut ch2 = ch1.clone();
+    ch2.byte_offset = 4;
+    ch2.name = Some("RPM".into());
+
+    let mut ch3 = ChannelBlock::default();
+    ch3.byte_offset = 0;
+    ch3.bit_count = 16;
+    ch3.data_type = DataType::UnsignedIntegerLE;
+    ch3.name = Some("Temperature".into());
+
+    let groups = vec![vec![ch1, ch2], vec![ch3]];
+
+    // Write file with helper
+    write_simple_mdf_file_multi("multi_groups.mf4", &groups)?;
+
+    // Parse using this crate
+    let mdf = MDF::from_file("multi_groups.mf4")?;
+    println!("Groups: {}", mdf.channel_groups().len());
+
+    Ok(())
+}

--- a/src/writer/mdf_writer.rs
+++ b/src/writer/mdf_writer.rs
@@ -558,13 +558,13 @@ impl MdfWriter {
     pub fn write_simple_mdf_file(file_path: &str) -> Result<(), MdfError> {
         // Create a new MDF writer
         let mut writer = MdfWriter::new(file_path)?;
-        
+
         // Initialize with ID and HD blocks
         let (_id_pos, _hd_pos) = writer.init_mdf_file()?;
-        
+
         // Add a data group
         let dg_id = writer.add_data_group(None)?;
-        
+
         // Add a channel group to the data group
         let cg_block = ChannelGroupBlock::default();
         let cg_id = writer.add_channel_group(&dg_id, None, &cg_block)?;
@@ -582,8 +582,9 @@ impl MdfWriter {
         ch2.data_type = DataType::UnsignedIntegerLE;
         ch2.name = Some("Channel 2".to_string());
         let _cn2_id = writer.add_channel(&cg_id, Some(&cn1_id), &ch2)?;
-        
+
         // Finalize the file
         writer.finalize()
     }
+
 }


### PR DESCRIPTION
## Summary
- move multi group write helper into the example
- drop python validation from example

## Testing
- `cargo check`
- `cargo run --example write_multi_groups`
- `python3 - <<'PY'
import asammdf
mdf = asammdf.MDF('multi_groups.mf4')
print(len(mdf.groups))
PY`


------
https://chatgpt.com/codex/tasks/task_e_684535340fbc832b9f51a49c1cfc031b