### PR TITLE
Add multi-group data example without Python check

### DIFF
--- a/examples/multi_groups_with_data.rs
+++ b/examples/multi_groups_with_data.rs
@@ -1,0 +1,84 @@
+use mf4_rs::writer::MdfWriter;
+use mf4_rs::blocks::channel_block::ChannelBlock;
+use mf4_rs::blocks::channel_group_block::ChannelGroupBlock;
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::api::mdf::MDF;
+use mf4_rs::error::MdfError;
+
+fn main() -> Result<(), MdfError> {
+    // Create writer and basic structure
+    let mut writer = MdfWriter::new("multi_group_data.mf4")?;
+    let (_id, _hd) = writer.init_mdf_file()?;
+    let dg_id = writer.add_data_group(None)?;
+    let cg_block = ChannelGroupBlock::default();
+
+    // -------- Channel Group 1 with 2 channels --------
+    let cg1_id = writer.add_channel_group(&dg_id, None, &cg_block)?;
+    let mut ch1 = ChannelBlock::default();
+    ch1.byte_offset = 0;
+    ch1.bit_count = 32;
+    ch1.data_type = DataType::UnsignedIntegerLE;
+    ch1.name = Some("Speed".into());
+    let mut ch2 = ch1.clone();
+    ch2.byte_offset = 4;
+    ch2.name = Some("RPM".into());
+    let cn1_id = writer.add_channel(&cg1_id, None, &ch1)?;
+    writer.add_channel(&cg1_id, Some(&cn1_id), &ch2)?;
+
+    // -------- Channel Group 2 with 2 channels --------
+    let cg2_id = writer.add_channel_group(&dg_id, Some(&cg1_id), &cg_block)?;
+    let mut ch3 = ChannelBlock::default();
+    ch3.byte_offset = 0;
+    ch3.bit_count = 16;
+    ch3.data_type = DataType::UnsignedIntegerLE;
+    ch3.name = Some("Temperature".into());
+    let mut ch4 = ch3.clone();
+    ch4.byte_offset = 2;
+    ch4.name = Some("Pressure".into());
+    let cn3_id = writer.add_channel(&cg2_id, None, &ch3)?;
+    writer.add_channel(&cg2_id, Some(&cn3_id), &ch4)?;
+
+    // -------- Write sample data for both groups --------
+    writer.start_data_block(&dg_id, &cg1_id, 0, &[ch1.clone(), ch2.clone()])?;
+    writer.start_data_block(&dg_id, &cg2_id, 0, &[ch3.clone(), ch4.clone()])?;
+    for i in 0u32..100 {
+        writer.write_record(
+            &cg1_id,
+            &[
+                DecodedValue::UnsignedInteger(i.into()),
+                DecodedValue::UnsignedInteger((i * 2).into()),
+            ],
+        )?;
+        writer.write_record(
+            &cg2_id,
+            &[
+                DecodedValue::UnsignedInteger((i + 50).into()),
+                DecodedValue::UnsignedInteger((i + 100).into()),
+            ],
+        )?;
+    }
+    writer.finish_data_block(&cg1_id)?;
+    writer.finish_data_block(&cg2_id)?;
+    writer.finalize()?;
+
+    // -------- Verify using the crate parser --------
+    let mdf = MDF::from_file("multi_group_data.mf4")?;
+    println!("Our parser found {} channel groups", mdf.channel_groups().len());
+    for (idx, group) in mdf.channel_groups().iter().enumerate() {
+        let chans = group.channels();
+        print!("  Group {} has {} channels", idx + 1, chans.len());
+        if let Some(ch) = chans.first() {
+            let values = ch.values()?;
+            println!(" and {} records", values.len());
+        } else {
+            println!();
+        }
+    }
+
+    // Optionally verify with tools like `asammdf` using Python
+    // (not shown here)
+
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- show how to write and read multiple groups with data
- keep example self-contained by dropping Python verification

## Testing
- `cargo check --examples`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684539f1971c832b87e3d1a1652846b1