### PR TITLE
Add value-to-text conversions example

### DIFF
--- a/src/blocks/conversion/types.rs
+++ b/src/blocks/conversion/types.rs
@@ -48,4 +48,23 @@ impl ConversionType {
             other => ConversionType::Unknown(other),
         }
     }
+
+    /// Convert the `ConversionType` to its numeric representation.
+    pub fn to_u8(self) -> u8 {
+        match self {
+            ConversionType::Identity => 0,
+            ConversionType::Linear => 1,
+            ConversionType::Rational => 2,
+            ConversionType::Algebraic => 3,
+            ConversionType::TableLookupInterp => 4,
+            ConversionType::TableLookupNoInterp => 5,
+            ConversionType::RangeLookup => 6,
+            ConversionType::ValueToText => 7,
+            ConversionType::RangeToText => 8,
+            ConversionType::TextToValue => 9,
+            ConversionType::TextToText => 10,
+            ConversionType::BitfieldText => 11,
+            ConversionType::Unknown(v) => v,
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow ConversionType -> u8
- implement ConversionBlock::to_bytes
- add MdfWriter::add_value_to_text_conversion helper
- extend multi_groups_with_data example with mixed types and asammdf check

## Testing
- `cargo check`
- `cargo run --example multi_groups_with_data`

------
https://chatgpt.com/codex/tasks/task_e_6845403eb4a8832ba318e7a703cdb0a1