### PR TITLE
Fix value-to-text conversion

### DIFF
--- a/src/writer/mdf_writer.rs
+++ b/src/writer/mdf_writer.rs
@@ -363,11 +363,12 @@ impl MdfWriter {
             cc_ref: refs,
             cc_type: ConversionType::ValueToText,
             cc_precision: 0,
-            cc_flags: 0,
+            // Value‑to‑text conversions store a physical range even if unused
+            cc_flags: 0b10,
             cc_ref_count: (mapping.len() + 1) as u16,
             cc_val_count: mapping.len() as u16,
-            cc_phy_range_min: None,
-            cc_phy_range_max: None,
+            cc_phy_range_min: Some(0.0),
+            cc_phy_range_max: Some(0.0),
             cc_val: vals,
             formula: None,
         };


### PR DESCRIPTION
## Summary
- ensure value-to-text conversion blocks include a physical range
- output shows Status samples as text when read with `asammdf`

## Testing
- `cargo test`
- `cargo run --example multi_groups_with_data`

------
https://chatgpt.com/codex/tasks/task_e_684543f43d50832b9634f2f7ddec5d1f