### PR TITLE
Refactor API to use builder closures

### DIFF
--- a/examples/large_data.rs
+++ b/examples/large_data.rs
@@ -1,0 +1,36 @@
+use mf4_rs::writer::MdfWriter;
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::error::MdfError;
+
+fn main() -> Result<(), MdfError> {
+    let mut writer = MdfWriter::new("large_data.mf4")?;
+    writer.init_mdf_file()?;
+    let cg_id = writer.add_channel_group(None, |_| {})?;
+
+    let mut prev: Option<String> = None;
+    for idx in 0..4 {
+        let id = writer.add_channel(&cg_id, prev.as_deref(), |ch| {
+            ch.data_type = DataType::UnsignedIntegerLE;
+            ch.name = Some(format!("Ch{}", idx + 1));
+            ch.bit_count = 64;
+        })?;
+        prev = Some(id);
+    }
+
+    writer.start_data_block_for_cg(&cg_id, 0)?;
+    for i in 0u64..150_000 {
+        writer.write_record(
+            &cg_id,
+            &[
+                DecodedValue::UnsignedInteger(i),
+                DecodedValue::UnsignedInteger(i + 1),
+                DecodedValue::UnsignedInteger(i + 2),
+                DecodedValue::UnsignedInteger(i + 3),
+            ],
+        )?;
+    }
+    writer.finish_data_block(&cg_id)?;
+    writer.finalize()?;
+    Ok(())
+}

--- a/examples/multi_groups_with_data.rs
+++ b/examples/multi_groups_with_data.rs
@@ -1,6 +1,4 @@
 use mf4_rs::writer::MdfWriter;
-use mf4_rs::blocks::channel_block::ChannelBlock;
-use mf4_rs::blocks::channel_group_block::ChannelGroupBlock;
 use mf4_rs::blocks::common::DataType;
 use mf4_rs::parsing::decoder::DecodedValue;
 use mf4_rs::api::mdf::MDF;
@@ -10,42 +8,37 @@ fn main() -> Result<(), MdfError> {
     // Create writer and base structure
     let mut writer = MdfWriter::new("multi_group_data.mf4")?;
     let (_id, _hd) = writer.init_mdf_file()?;
-    let cg_block = ChannelGroupBlock::default();
-
     // -------- Channel Group 1 with 2 channels --------
-    let cg1_id = writer.add_channel_group(None, &cg_block)?;
-    let mut ch1 = ChannelBlock::default();
-    ch1.data_type = DataType::UnsignedIntegerLE;
-    ch1.name = Some("Speed".into());
-    let cn1_id = writer.add_channel(&cg1_id, None, &ch1)?;
+    let cg1_id = writer.add_channel_group(None, |_| {})?;
+    let cn1_id = writer.add_channel(&cg1_id, None, |ch| {
+        ch.data_type = DataType::UnsignedIntegerLE;
+        ch.name = Some("Speed".into());
+    })?;
 
-    let mut ch2 = ChannelBlock::default();
-    ch2.data_type = DataType::UnsignedIntegerLE;
-    ch2.name = Some("RPM".into());
-    writer.add_channel(&cg1_id, Some(&cn1_id), &ch2)?;
+    writer.add_channel(&cg1_id, Some(&cn1_id), |ch| {
+        ch.data_type = DataType::UnsignedIntegerLE;
+        ch.name = Some("RPM".into());
+    })?;
 
     // -------- Channel Group 2 with 3 channels --------
     // A new data group is created automatically
-    let cg2_id = writer.add_channel_group(None, &cg_block)?;
-    let mut ch3 = ChannelBlock::default();
-    ch3.data_type = DataType::SignedIntegerLE;
-    ch3.name = Some("Temperature".into());
+    let cg2_id = writer.add_channel_group(None, |_| {})?;
 
-    let mut ch4 = ChannelBlock::default();
-    ch4.data_type = DataType::FloatLE;
-    ch4.name = Some("Pressure".into());
+    let cn3_id = writer.add_channel(&cg2_id, None, |ch| {
+        ch.data_type = DataType::SignedIntegerLE;
+        ch.name = Some("Temperature".into());
+    })?;
+    let cn4_id = writer.add_channel(&cg2_id, Some(&cn3_id), |ch| {
+        ch.data_type = DataType::FloatLE;
+        ch.name = Some("Pressure".into());
+    })?;
 
-    // Value to text conversion for a status channel
+    let cn5_id = writer.add_channel(&cg2_id, Some(&cn4_id), |ch| {
+        ch.data_type = DataType::UnsignedIntegerLE;
+        ch.name = Some("Status".into());
+    })?;
     let status_map = [(0i64, "OK"), (1i64, "WARN")];
-    let (_cc_id, cc_pos) = writer.add_value_to_text_conversion(&status_map, "UNKNOWN")?;
-    let mut ch5 = ChannelBlock::default();
-    ch5.data_type = DataType::UnsignedIntegerLE;
-    ch5.name = Some("Status".into());
-    ch5.conversion_addr = cc_pos;
-
-    let cn3_id = writer.add_channel(&cg2_id, None, &ch3)?;
-    let cn4_id = writer.add_channel(&cg2_id, Some(&cn3_id), &ch4)?;
-    writer.add_channel(&cg2_id, Some(&cn4_id), &ch5)?;
+    writer.add_value_to_text_conversion(&status_map, "UNKNOWN", Some(&cn5_id))?;
 
     // -------- Write sample data for both groups --------
     writer.start_data_block_for_cg(&cg1_id, 0)?;


### PR DESCRIPTION
## Summary
- allow configuring `ChannelGroupBlock` and `ChannelBlock` via closures
- link conversion blocks directly to a channel
- update examples to new API and add a large data demo

## Testing
- `cargo build --examples`
- `cargo test`
- `cargo run --example large_data`
- `python3 - <<'PY'
from asammdf import MDF
try:
    MDF('large_data.mf4')
except Exception as e:
    print('Error', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68454eed6f84832b88401c545c401e6b