### PR TITLE
Add MF4 cut by time example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# mf4-rs
+
+This crate provides basic read and write support for the ASAM MDF 4 format.
+
+## Examples
+
+Run `cargo run --example cut_file` to create a small MF4 file and cut it
+between two timestamps. The resulting file can be verified with tools such as
+`asammdf`.
+

--- a/examples/cut_file.rs
+++ b/examples/cut_file.rs
@@ -1,0 +1,43 @@
+use mf4_rs::writer::MdfWriter;
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::error::MdfError;
+use mf4_rs::cut::cut_mdf_by_time;
+
+fn main() -> Result<(), MdfError> {
+    let input = "cut_example_input.mf4";
+    let output = "cut_example_output.mf4";
+
+    // create a simple MF4 file with a time channel and a value channel
+    let mut writer = MdfWriter::new(input)?;
+    writer.init_mdf_file()?;
+    let cg_id = writer.add_channel_group(None, |_| {})?;
+    let time_id = writer.add_channel(&cg_id, None, |ch| {
+        ch.data_type = DataType::FloatLE;
+        ch.name = Some("Time".into());
+        ch.bit_count = 64;
+    })?;
+    writer.add_channel(&cg_id, Some(&time_id), |ch| {
+        ch.data_type = DataType::UnsignedIntegerLE;
+        ch.name = Some("Val".into());
+        ch.bit_count = 32;
+    })?;
+    writer.start_data_block_for_cg(&cg_id, 0)?;
+    for i in 0u64..10 {
+        writer.write_record(
+            &cg_id,
+            &[
+                DecodedValue::Float(i as f64 * 0.1),
+                DecodedValue::UnsignedInteger(i),
+            ],
+        )?;
+    }
+    writer.finish_data_block(&cg_id)?;
+    writer.finalize()?;
+
+    // cut between 0.3 and 0.6 seconds
+    cut_mdf_by_time(input, output, 0.3, 0.6)?;
+
+    println!("Created {} and {}", input, output);
+    Ok(())
+}

--- a/src/blocks/common.rs
+++ b/src/blocks/common.rs
@@ -109,7 +109,7 @@ pub trait BlockParse<'a>: Sized {
     fn from_bytes(bytes: &'a [u8]) -> Result<Self, MdfError>;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DataType {
     UnsignedIntegerLE,
     UnsignedIntegerBE,

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -1,0 +1,137 @@
+use crate::error::MdfError;
+use crate::parsing::mdf_file::MdfFile;
+use crate::parsing::decoder::{decode_channel_value, DecodedValue};
+use crate::blocks::channel_block::ChannelBlock;
+use crate::blocks::common::read_string_block;
+use crate::blocks::common::DataType;
+use crate::writer::MdfWriter;
+
+/// Cut a segment of an MDF file given start and end times (in the unit
+/// of the time channel).
+///
+/// This function creates a new MDF file at `output_path` that contains the same
+/// structure as the input but only records whose timestamp lies within the
+/// `[start_time, end_time]` range.
+///
+/// The implementation looks for a channel named "time" (case insensitive) or a
+/// channel using the `CanOpenTime` data type to determine the timestamp of each
+/// record.
+pub fn cut_mdf_by_time(
+    input_path: &str,
+    output_path: &str,
+    start_time: f64,
+    end_time: f64,
+) -> Result<(), MdfError> {
+    let mdf = MdfFile::parse_from_file(input_path)?;
+    let mut writer = MdfWriter::new(output_path)?;
+    writer.init_mdf_file()?;
+
+    for dg in &mdf.data_groups {
+        let mut prev_cg: Option<String> = None;
+        for cg in &dg.channel_groups {
+            let cg_id = writer.add_channel_group(prev_cg.as_deref(), |_| {})?;
+            prev_cg = Some(cg_id.clone());
+
+            let mut prev_cn: Option<String> = None;
+            let mut channel_blocks: Vec<ChannelBlock> = Vec::new();
+            for ch in &cg.raw_channels {
+                let block = ch.block.clone();
+                let id = writer.add_channel(&cg_id, prev_cn.as_deref(), |c| {
+                    *c = block.clone();
+                })?;
+                prev_cn = Some(id);
+                channel_blocks.push(block);
+            }
+
+            // Prepare iterators over raw records for each channel
+            let mut iters = Vec::new();
+            for ch in &cg.raw_channels {
+                iters.push(ch.records(dg, cg, &mdf.mmap)?);
+            }
+
+            // Identify the time channel index
+            let mut time_idx: Option<usize> = None;
+            for (idx, ch) in cg.raw_channels.iter().enumerate() {
+                if ch.block.data_type == DataType::CanOpenTime {
+                    time_idx = Some(idx);
+                    break;
+                }
+                if let Ok(Some(name)) = read_string_block(&mdf.mmap, ch.block.name_addr) {
+                    if name.to_lowercase().contains("time") {
+                        time_idx = Some(idx);
+                        break;
+                    }
+                }
+            }
+            let time_idx = match time_idx {
+                Some(i) => i,
+                None => {
+                    // No time channel found; copy all records
+                    writer.start_data_block_for_cg(&cg_id, dg.block.record_id_len)?;
+                    loop {
+                        let mut rec = Vec::with_capacity(iters.len());
+                        for it in iters.iter_mut() {
+                            match it.next() {
+                                Some(Ok(r)) => rec.push(r),
+                                Some(Err(e)) => return Err(e),
+                                None => { rec.clear(); break; }
+                            }
+                        }
+                        if rec.is_empty() { break; }
+                        let mut vals = Vec::new();
+                        for (slice, ch) in rec.into_iter().zip(channel_blocks.iter()) {
+                            let dv = decode_channel_value(slice, dg.block.record_id_len as usize, ch)
+                                .unwrap_or(DecodedValue::Unknown);
+                            vals.push(ch.apply_conversion_value(dv, &mdf.mmap)?);
+                        }
+                        writer.write_record(&cg_id, &vals)?;
+                    }
+                    writer.finish_data_block(&cg_id)?;
+                    continue;
+                }
+            };
+
+            writer.start_data_block_for_cg(&cg_id, dg.block.record_id_len)?;
+
+            loop {
+                let mut rec = Vec::with_capacity(iters.len());
+                for it in iters.iter_mut() {
+                    match it.next() {
+                        Some(Ok(r)) => rec.push(r),
+                        Some(Err(e)) => return Err(e),
+                        None => { rec.clear(); break; }
+                    }
+                }
+                if rec.is_empty() { break; }
+
+                // Decode time value
+                let time_val = {
+                    let ch = &channel_blocks[time_idx];
+                    let dv = decode_channel_value(rec[time_idx], dg.block.record_id_len as usize, ch)
+                        .unwrap_or(DecodedValue::Unknown);
+                    match ch.apply_conversion_value(dv, &mdf.mmap)? {
+                        DecodedValue::Float(f) => f,
+                        DecodedValue::UnsignedInteger(u) => u as f64,
+                        DecodedValue::SignedInteger(i) => i as f64,
+                        _ => continue,
+                    }
+                };
+
+                if time_val < start_time { continue; }
+                if time_val - end_time > f64::EPSILON { break; }
+
+                let mut vals = Vec::new();
+                for (slice, ch) in rec.into_iter().zip(channel_blocks.iter()) {
+                    let dv = decode_channel_value(slice, dg.block.record_id_len as usize, ch)
+                        .unwrap_or(DecodedValue::Unknown);
+                    vals.push(ch.apply_conversion_value(dv, &mdf.mmap)?);
+                }
+                writer.write_record(&cg_id, &vals)?;
+            }
+            writer.finish_data_block(&cg_id)?;
+        }
+    }
+
+    writer.finalize()
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod blocks;
 pub mod error;
 pub mod writer;
+pub mod cut;
 
 pub mod parsing {
     pub mod decoder;


### PR DESCRIPTION
## Summary
- provide README overview and example instructions
- document `cut_mdf_by_time` usage in a new example
- tweak time comparison logic in `cut_mdf_by_time`

## Testing
- `cargo test --quiet`
- `cargo run --quiet --example cut_file`
- `python3 - <<'EOF'
from asammdf import MDF
print(MDF('cut_example_output.mf4').info())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684587fff030832b8e496715ca46c152