### PR TITLE
Add master time channel support

### DIFF
--- a/examples/cut_file.rs
+++ b/examples/cut_file.rs
@@ -17,6 +17,7 @@ fn main() -> Result<(), MdfError> {
         ch.name = Some("Time".into());
         ch.bit_count = 64;
     })?;
+    writer.set_time_channel(&time_id)?;
     writer.add_channel(&cg_id, Some(&time_id), |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
         ch.name = Some("Val".into());

--- a/src/parsing/decoder.rs
+++ b/src/parsing/decoder.rs
@@ -41,7 +41,7 @@ pub fn decode_channel_value(
     let bit_offset = channel.bit_offset as usize;
     let bit_count = channel.bit_count as usize;
 
-    let slice: &[u8] = if channel.channel_type == 1 {
+    let slice: &[u8] = if channel.channel_type == 1 && channel.data != 0 {
         // VLSD: the entire record *is* the payload
         record
     } else {

--- a/src/parsing/raw_channel.rs
+++ b/src/parsing/raw_channel.rs
@@ -25,7 +25,7 @@ impl<'a> RawChannel {
         mmap: &'a [u8],
     ) -> Result<Box<dyn Iterator<Item = Result<&'a [u8], MdfError>> + 'a>, MdfError> {
         // 1) VLSD path: channel has its own data pointer => SD/DL chain
-        if self.block.channel_type == 1 {
+        if self.block.channel_type == 1 && self.block.data != 0 {
             // Capture the file bytes and channel pointer
             let bytes = mmap;
             let mut next_addr = self.block.data;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -122,6 +122,7 @@ fn cut_mdf_file_by_time() -> Result<(), MdfError> {
         ch.name = Some("Time".into());
         ch.bit_count = 64;
     })?;
+    writer.set_time_channel(&time_id)?;
     writer.add_channel(&cg_id, Some(&time_id), |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
         ch.bit_count = 32;


### PR DESCRIPTION
## Summary
- allow tracking channel IDs in `MdfWriter`
- add `set_time_channel` helper to mark master time channels
- update cutting logic to detect master channels
- adjust variable length logic for channels without data pointers
- refresh example and tests for new API

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6845906389e0832babdcb41cc1bc6d92