### PR TITLE
Fix time channel type and preserve channel names in cut

### DIFF
--- a/examples/cut_file.rs
+++ b/examples/cut_file.rs
@@ -3,6 +3,7 @@ use mf4_rs::blocks::common::DataType;
 use mf4_rs::parsing::decoder::DecodedValue;
 use mf4_rs::error::MdfError;
 use mf4_rs::cut::cut_mdf_by_time;
+use mf4_rs::api::mdf::MDF;
 
 fn main() -> Result<(), MdfError> {
     let input = "cut_example_input.mf4";
@@ -38,6 +39,17 @@ fn main() -> Result<(), MdfError> {
 
     // cut between 0.3 and 0.6 seconds
     cut_mdf_by_time(input, output, 0.3, 0.6)?;
+
+    // Inspect the cut file and print channel names
+    let mdf = MDF::from_file(output)?;
+    for (g_idx, group) in mdf.channel_groups().iter().enumerate() {
+        let channels = group.channels();
+        for (c_idx, ch) in channels.iter().enumerate() {
+            if let Some(name) = ch.name()? {
+                println!("Group {} Channel {}: {}", g_idx + 1, c_idx + 1, name);
+            }
+        }
+    }
 
     println!("Created {} and {}", input, output);
     Ok(())

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -11,7 +11,7 @@ use crate::writer::MdfWriter;
 /// structure as the input but only records whose timestamp lies within the
 /// `[start_time, end_time]` range.
 ///
-/// The implementation looks for the channel marked as master (channel type 1
+/// The implementation looks for the channel marked as master (channel type 2
 /// and sync type 1) to determine the timestamp of each record.
 pub fn cut_mdf_by_time(
     input_path: &str,
@@ -32,7 +32,8 @@ pub fn cut_mdf_by_time(
             let mut prev_cn: Option<String> = None;
             let mut channel_blocks: Vec<ChannelBlock> = Vec::new();
             for ch in &cg.raw_channels {
-                let block = ch.block.clone();
+                let mut block = ch.block.clone();
+                block.resolve_name(&mdf.mmap)?;
                 let id = writer.add_channel(&cg_id, prev_cn.as_deref(), |c| {
                     *c = block.clone();
                 })?;
@@ -49,7 +50,7 @@ pub fn cut_mdf_by_time(
             // Identify the time (master) channel index
             let mut time_idx: Option<usize> = None;
             for (idx, ch) in cg.raw_channels.iter().enumerate() {
-                if ch.block.channel_type == 1 && ch.block.sync_type == 1 {
+                if ch.block.channel_type == 2 && ch.block.sync_type == 1 {
                     time_idx = Some(idx);
                     break;
                 }

--- a/src/writer/mdf_writer.rs
+++ b/src/writer/mdf_writer.rs
@@ -506,26 +506,26 @@ impl MdfWriter {
         Ok(cn_id)
     }
 
-    /// Mark an existing channel as the time (master) channel.
-    /// This sets the channel's type and sync type to 1 in the file and updates
-    /// the stored channel metadata.
-    pub fn set_time_channel(&mut self, cn_id: &str) -> Result<(), MdfError> {
-        // Offsets of channel_type and sync_type within the CN block
-        const CHANNEL_TYPE_OFFSET: u64 = 88;
-        const SYNC_TYPE_OFFSET: u64 = 89;
-        self.update_block_u8(cn_id, CHANNEL_TYPE_OFFSET, 1)?;
-        self.update_block_u8(cn_id, SYNC_TYPE_OFFSET, 1)?;
+/// Mark an existing channel as the time (master) channel.
+/// This sets the channel's type to 2 and sync type to 1 in the file and updates
+/// the stored channel metadata.
+pub fn set_time_channel(&mut self, cn_id: &str) -> Result<(), MdfError> {
+    // Offsets of channel_type and sync_type within the CN block
+    const CHANNEL_TYPE_OFFSET: u64 = 88;
+    const SYNC_TYPE_OFFSET: u64 = 89;
+    self.update_block_u8(cn_id, CHANNEL_TYPE_OFFSET, 2)?;
+    self.update_block_u8(cn_id, SYNC_TYPE_OFFSET, 1)?;
 
-        if let Some((cg, idx)) = self.channel_map.get(cn_id).cloned() {
-            if let Some(chs) = self.cg_channels.get_mut(&cg) {
-                if let Some(ch) = chs.get_mut(idx) {
-                    ch.channel_type = 1;
-                    ch.sync_type = 1;
-                }
+    if let Some((cg, idx)) = self.channel_map.get(cn_id).cloned() {
+        if let Some(chs) = self.cg_channels.get_mut(&cg) {
+            if let Some(ch) = chs.get_mut(idx) {
+                ch.channel_type = 2;
+                ch.sync_type = 1;
             }
         }
-        Ok(())
     }
+    Ok(())
+}
 
     /// Start writing a DTBLOCK for the given data group.
     /// `channels` describes the fixed layout of one record.


### PR DESCRIPTION
## Summary
- use channel type `2` for the time channel
- propagate channel names when cutting
- show channel names in the cut example

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845961d63ec832bbaad054fe9f8fd88