### PR TITLE
Add bulk record writing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ Run `cargo run --example cut_file` to create a small MF4 file and cut it
 between two timestamps. The resulting file can be verified with tools such as
 `asammdf`.
 
+Run `cargo run --example write_records` to generate a file using
+`MdfWriter::write_records` for appending multiple records at once.
+
+## API Highlights
+
+- `MdfWriter::write_record` – append a single record to a data block.
+- `MdfWriter::write_records` – append a series of records in one call.
+

--- a/examples/write_records.rs
+++ b/examples/write_records.rs
@@ -1,0 +1,31 @@
+use mf4_rs::writer::MdfWriter;
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::api::mdf::MDF;
+use mf4_rs::error::MdfError;
+
+fn main() -> Result<(), MdfError> {
+    let path = "write_records_example.mf4";
+
+    let mut writer = MdfWriter::new(path)?;
+    writer.init_mdf_file()?;
+    let cg_id = writer.add_channel_group(None, |_| {})?;
+    writer.add_channel(&cg_id, None, |ch| {
+        ch.data_type = DataType::UnsignedIntegerLE;
+        ch.name = Some("Value".into());
+    })?;
+
+    writer.start_data_block_for_cg(&cg_id, 0)?;
+    let records: Vec<Vec<DecodedValue>> = (0u64..5)
+        .map(|i| vec![DecodedValue::UnsignedInteger(i)])
+        .collect();
+    let slices: Vec<&[DecodedValue]> = records.iter().map(|r| r.as_slice()).collect();
+    writer.write_records(&cg_id, slices)?;
+    writer.finish_data_block(&cg_id)?;
+    writer.finalize()?;
+
+    let mdf = MDF::from_file(path)?;
+    let values = mdf.channel_groups()[0].channels()[0].values()?;
+    println!("{} records written", values.len());
+    Ok(())
+}

--- a/src/writer/mdf_writer.rs
+++ b/src/writer/mdf_writer.rs
@@ -691,6 +691,20 @@ pub fn set_time_channel(&mut self, cn_id: &str) -> Result<(), MdfError> {
         Ok(())
     }
 
+    /// Append multiple records sequentially for the specified channel group.
+    ///
+    /// This is a convenience wrapper around [`write_record`] that iterates over
+    /// the provided records and writes each one.
+    pub fn write_records<'a, I>(&mut self, cg_id: &str, records: I) -> Result<(), MdfError>
+    where
+        I: IntoIterator<Item = &'a [DecodedValue]>,
+    {
+        for record in records {
+            self.write_record(cg_id, record)?;
+        }
+        Ok(())
+    }
+
     /// Finalize the currently open DTBLOCK for a given channel group and patch its size field.
     pub fn finish_data_block(&mut self, cg_id: &str) -> Result<(), MdfError> {
         let mut dt = self.open_dts.remove(cg_id).ok_or_else(|| {


### PR DESCRIPTION
## Summary
- document `write_records` example in README
- add `examples/write_records.rs` showing how to append multiple records

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68459ad11578832bb91b4716e9d0d6f4