### PR TITLE
Improve crate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,45 @@
 # mf4-rs
 
-This crate provides basic read and write support for the ASAM MDF 4 format.
+`mf4-rs` is a minimal library for working with ASAM MDF 4 measurement files.
+It supports parsing existing files as well as writing new ones through a safe
+API.  Only a subset of the standard is implemented but it is sufficient for
+simple data logging and inspection tasks.
 
 ## Examples
 
-Run `cargo run --example cut_file` to create a small MF4 file and cut it
-between two timestamps. The resulting file can be verified with tools such as
+Run `cargo run --example cut_file` to create a small MF4 file and cut it between
+two timestamps. The resulting file can be verified with tools such as
 `asammdf`.
 
 Run `cargo run --example write_records` to generate a file using
 `MdfWriter::write_records` for appending multiple records at once.
+
+## Usage
+
+Parsing a file is straightforward:
+
+```rust
+use mf4_rs::api::mdf::MDF;
+
+let mdf = MDF::from_file("capture.mf4")?;
+for group in mdf.channel_groups() {
+    println!("channels: {}", group.channels().len());
+}
+```
+
+Writing a file is done via `MdfWriter`:
+
+```rust
+use mf4_rs::writer::MdfWriter;
+
+let mut writer = MdfWriter::new("out.mf4")?;
+writer.init_mdf_file()?;
+let cg = writer.add_channel_group(None, |_| {})?;
+writer.add_channel(&cg, None, |_| {})?;
+writer.start_data_block_for_cg(&cg, 0)?;
+writer.finish_data_block(&cg)?;
+writer.finalize()?;
+```
 
 ## API Highlights
 

--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -7,6 +7,10 @@ use crate::parsing::raw_channel::RawChannel;
 use crate::parsing::source_info::SourceInfo;
 use crate::blocks::common::read_string_block;
 
+/// High level handle for a single channel within a group.
+///
+/// It holds references to the raw blocks and allows convenient access to
+/// metadata and decoded values.
 pub struct Channel<'a> {
     block:          &'a ChannelBlock,
     raw_data_group:   &'a RawDataGroup,
@@ -16,7 +20,17 @@ pub struct Channel<'a> {
 }
 
 impl<'a> Channel<'a> {
-    /// Build the bare minimum: pointers to raw blocks + sizes.
+    /// Construct a new [`Channel`] from raw block references.
+    ///
+    /// # Arguments
+    /// * `block` - Channel block containing metadata
+    /// * `raw_data_group` - Parent data group
+    /// * `raw_channel_group` - Parent channel group
+    /// * `raw_channel` - Raw channel helper used to iterate samples
+    /// * `mmap` - Memory mapped file backing all data
+    ///
+    /// # Returns
+    /// A [`Channel`] handle with no samples decoded yet.
     pub fn new(
         block: &'a ChannelBlock,
         raw_data_group: &'a RawDataGroup,
@@ -26,28 +40,31 @@ impl<'a> Channel<'a> {
     ) -> Self {
         Channel { block, raw_data_group, raw_channel_group, raw_channel, mmap }
     }
-    /// Human‐readable name
+    /// Retrieve the channel name if present.
     pub fn name(&self) -> Result<Option<String>, MdfError> {
         read_string_block(self.mmap, self.block.name_addr)
     }
 
-    /// Unit, if any
+    /// Retrieve the physical unit description.
     pub fn unit(&self) -> Result<Option<String>, MdfError> {
         read_string_block(self.mmap, self.block.unit_addr)
     }
 
-    /// Comment, if any
+    /// Retrieve the channel comment if present.
     pub fn comment(&self) -> Result<Option<String>, MdfError> {
         read_string_block(self.mmap, self.block.comment_addr)
     }
 
-    /// The signal source for this channel, if present.
+    /// Get the acquisition source for this channel if available.
     pub fn source(&self) -> Result<Option<SourceInfo>, MdfError> {
         let addr = self.block.source_addr;
         SourceInfo::from_mmap(self.mmap, addr)
     }
 
-    /// Decode *and* convert every sample now—returns one element per record.
+    /// Decode and convert all samples of this channel.
+    ///
+    /// # Returns
+    /// A vector with one [`DecodedValue`] per record.
     pub fn values(&self) -> Result<Vec<DecodedValue>, MdfError> {
         let record_id_len = self.raw_data_group.block.record_id_len as usize;
         let mut out = Vec::new();

--- a/src/api/mdf.rs
+++ b/src/api/mdf.rs
@@ -3,18 +3,30 @@ use crate::parsing::mdf_file::MdfFile;
 use crate::api::channel_group::ChannelGroup;
 
 #[derive(Debug)]
+/// High level representation of an MDF file.
+///
+/// The struct stores the memory mapped file internally and lazily exposes
+/// [`ChannelGroup`] wrappers for easy inspection.
 pub struct MDF {
     raw: MdfFile,
 }
 
 impl MDF {
-    /// Parse and hold the raw MDF4 file (with mmap, DataGroup & ChannelGroup blocks).
+    /// Parse an MDF4 file from disk.
+    ///
+    /// # Arguments
+    /// * `path` - Path to the `.mf4` file.
+    ///
+    /// # Returns
+    /// A new [`MDF`] on success or [`MdfError`] on failure.
     pub fn from_file(path: &str) -> Result<Self, MdfError> {
         let raw = MdfFile::parse_from_file(path)?;
         Ok(MDF { raw })
     }
 
-    /// One `ChannelGroup<'_>` per RawChannelGroup, all lazy.
+    /// Retrieve channel groups contained in the file.
+    ///
+    /// Each [`ChannelGroup`] is created lazily and does not decode any samples.
     pub fn channel_groups(&self) -> Vec<ChannelGroup<'_>> {
         let mut groups = Vec::new();
 

--- a/src/blocks/channel_block.rs
+++ b/src/blocks/channel_block.rs
@@ -244,8 +244,14 @@ impl ChannelBlock {
         Ok(buffer)
     }
     
-    /// Resolves the channel name from the file data (typically the entire mmap slice)
-    /// using the `name_addr` field. This function must be explicitly called.
+    /// Load the channel name from the file using the stored `name_addr`.
+    ///
+    /// # Arguments
+    /// * `file_data` - Memory mapped bytes of the entire MDF file.
+    ///
+    /// # Returns
+    /// `Ok(())` on success or an [`MdfError`] if the referenced block is
+    /// incomplete.
     pub fn resolve_name(&mut self, file_data: &[u8]) -> Result<(), MdfError> {
         if self.name.is_none() && self.name_addr != 0 {
             let offset = self.name_addr as usize;
@@ -258,9 +264,14 @@ impl ChannelBlock {
         Ok(())
     }
 
-    /// Resolves the conversion block from the file data (typically the entire file's memory map)
-    /// using the `conversion_addr` field. If the conversion block is present and can be parsed,
-    /// it is stored in the channel's `conversion` field.
+    /// Resolve and store the conversion block pointed to by `conversion_addr`.
+    ///
+    /// # Arguments
+    /// * `bytes` - Memory mapped MDF file bytes.
+    ///
+    /// # Returns
+    /// `Ok(())` on success or an [`MdfError`] if the conversion block cannot be
+    /// read or parsed.
     pub fn resolve_conversion(&mut self, bytes: &[u8]) -> Result<(), MdfError> {
         if self.conversion.is_none() && self.conversion_addr != 0 {
             let offset = self.conversion_addr as usize;
@@ -285,8 +296,17 @@ impl ChannelBlock {
         Ok(())
     }
 
-    /// Applies the conversion directly to a DecodedValue using the associated conversion block.
-    /// If no conversion block is attached, returns the DecodedValue unchanged.
+    /// Apply the stored conversion to a decoded value.
+    ///
+    /// If no conversion block is attached the input value is returned
+    /// unchanged.
+    ///
+    /// # Arguments
+    /// * `raw` - The raw decoded value as returned by [`decode_channel_value`].
+    /// * `file_data` - Memory mapped MDF data used to resolve formulas.
+    ///
+    /// # Returns
+    /// The converted value or the original value on failure.
     pub fn apply_conversion_value(
         &self,
         raw: DecodedValue,

--- a/src/blocks/channel_group_block.rs
+++ b/src/blocks/channel_group_block.rs
@@ -165,7 +165,14 @@ impl ChannelGroupBlock {
         Ok(buffer)
     }
     
-    /// Reads all channels linked to this channel group from the memory-mapped file.
+    /// Read all channels linked to this channel group.
+    ///
+    /// # Arguments
+    /// * `mmap` - Memory mapped MDF data used to follow the channel chain.
+    ///
+    /// # Returns
+    /// A vector of fully parsed [`ChannelBlock`]s or an [`MdfError`] if any
+    /// channel cannot be decoded.
     pub fn read_channels(&mut self, mmap: &[u8]) -> Result<Vec<ChannelBlock>, MdfError> {
         let mut channels = Vec::new();
         let mut current_ch_addr = self.first_ch_addr;

--- a/src/blocks/common.rs
+++ b/src/blocks/common.rs
@@ -72,7 +72,14 @@ impl BlockHeader {
         Ok(buffer)
     }
 
-    /// Parses the first 24 bytes according to "<4sI2Q"
+    /// Parse a block header from the first 24 bytes of `bytes`.
+    ///
+    /// # Arguments
+    /// * `bytes` - Slice containing at least 24 bytes from the MDF file.
+    ///
+    /// # Returns
+    /// A [`BlockHeader`] on success or [`MdfError::TooShortBuffer`] when the
+    /// slice is smaller than 24 bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, MdfError> {
         let expected_bytes = 24;
         if bytes.len() < expected_bytes {
@@ -212,8 +219,15 @@ impl DataType {
     }
 }
 
-/// Read a text or metadata block pointed to by `address` and return its string
-/// content. A zero address yields `Ok(None)`.
+/// Read a text or metadata block at `address` and return its contents.
+///
+/// # Arguments
+/// * `mmap` - The full memory mapped MDF file.
+/// * `address` - Offset of the target block; use `0` for no block.
+///
+/// # Returns
+/// The block's string contents if present or `Ok(None)` if `address` is zero or
+/// the block type is not text or metadata.
 pub fn read_string_block(mmap: &[u8], address: u64) -> Result<Option<String>, MdfError> {
     if address == 0 {
         return Ok(None);

--- a/src/blocks/conversion/base.rs
+++ b/src/blocks/conversion/base.rs
@@ -122,6 +122,10 @@ fn read_u64(bytes: &[u8], offset: &mut usize) -> Result<u64, MdfError> {
 
 impl ConversionBlock {
     /// Serialize this conversion block back to bytes.
+    ///
+    /// # Returns
+    /// A byte vector containing the encoded block or an [`MdfError`] if
+    /// serialization fails.
     pub fn to_bytes(&self) -> Result<Vec<u8>, MdfError> {
         let links = 4 + self.cc_ref.len();
 

--- a/src/blocks/conversion/formula.rs
+++ b/src/blocks/conversion/formula.rs
@@ -4,7 +4,14 @@ use crate::blocks::common::read_string_block;
 use crate::error::MdfError;
 
 impl ConversionBlock {
-    /// Resolves and stores the algebraic formula string (if any) into `self.formula`.
+    /// Resolve and store the algebraic formula referenced by this block.
+    ///
+    /// # Arguments
+    /// * `file_data` - Memory mapped MDF bytes used to read the formula text.
+    ///
+    /// # Returns
+    /// `Ok(())` on success or an [`MdfError`] if the formula block cannot be
+    /// read.
     pub fn resolve_formula(&mut self, file_data: &[u8]) -> Result<(), MdfError> {
         if self.cc_type != ConversionType::Algebraic || self.cc_ref.is_empty() {
             return Ok(());

--- a/src/blocks/data_block.rs
+++ b/src/blocks/data_block.rs
@@ -36,6 +36,12 @@ impl<'a> BlockParse<'a> for DataBlock<'a> {
 impl<'a> DataBlock<'a> {
     /// Iterate over raw records of fixed size.
     /// If the data block contains padding at the end, it’s your caller’s responsibility to trim that.
+    ///
+    /// # Arguments
+    /// * `record_size` - Size in bytes of one record (including record ID)
+    ///
+    /// # Returns
+    /// An iterator yielding each raw record slice.
     pub fn records(&self, record_size: usize) -> impl Iterator<Item = &'a [u8]> {
         self.data.chunks_exact(record_size)
     }

--- a/src/blocks/data_group_block.rs
+++ b/src/blocks/data_group_block.rs
@@ -17,7 +17,14 @@ pub struct DataGroupBlock {
 
 impl BlockParse<'_> for DataGroupBlock {
     const ID: &'static str = "##DG";
-    /// Creates a DataGroupBlock from a 64-byte slice according to the format "<4sI6QB7s".
+    /// Parse a `DataGroupBlock` from a 64 byte slice.
+    ///
+    /// # Arguments
+    /// * `bytes` - Byte slice beginning at the DG block header.
+    ///
+    /// # Returns
+    /// The populated [`DataGroupBlock`] on success or an [`MdfError`] if the
+    /// slice is too small or malformed.
     fn from_bytes(bytes: &[u8]) -> Result<Self, MdfError> {
 
         let header = Self::parse_header(bytes)?;

--- a/src/blocks/data_list_block.rs
+++ b/src/blocks/data_list_block.rs
@@ -85,7 +85,14 @@ impl BlockParse<'_> for DataListBlock {
 }
 
 impl DataListBlock {
-    /// Create a new DataListBlock for equal-length data blocks.
+    /// Create a new `DataListBlock` for equal-length data blocks.
+    ///
+    /// # Arguments
+    /// * `data_links` - Addresses of all data blocks referenced by this list.
+    /// * `data_block_len` - Length in bytes of every referenced data block.
+    ///
+    /// # Returns
+    /// A [`DataListBlock`] ready for serialization.
     pub fn new_equal(data_links: Vec<u64>, data_block_len: u64) -> Self {
         let links_nr = data_links.len() as u64 + 1; // +1 for 'next'
         let block_len = 24 + links_nr * 8 + 1 + 3 + 4 + 8;
@@ -108,6 +115,9 @@ impl DataListBlock {
     }
 
     /// Serialize this DLBLOCK to bytes.
+    ///
+    /// # Returns
+    /// The binary representation of the block or an [`MdfError`] on failure.
     pub fn to_bytes(&self) -> Result<Vec<u8>, MdfError> {
         if self.header.id != "##DL" {
             return Err(MdfError::BlockSerializationError(

--- a/src/blocks/identification_block.rs
+++ b/src/blocks/identification_block.rs
@@ -116,7 +116,14 @@ impl IdentificationBlock {
         Ok(buffer)
     }
 
-    /// Creates an IdentificationBlock from a 64-byte slice.
+    /// Parse an identification block from a 64 byte slice.
+    ///
+    /// # Arguments
+    /// * `bytes` - Slice containing the complete `##ID` block.
+    ///
+    /// # Returns
+    /// The populated [`IdentificationBlock`] or an [`MdfError`] if the slice is
+    /// invalid.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, MdfError> {
         let expected_bytes = 64;
         if bytes.len() < expected_bytes {
@@ -152,9 +159,14 @@ impl IdentificationBlock {
             custom_unfinalized_flags: LittleEndian::read_u16(&bytes[62..64]),
         })
     }
-    /// Helper to parse the version string stored in the identification block.
+    /// Parse the textual version stored in the identification block.
     ///
-    /// Returns the major and minor version numbers as `(major, minor)`.
+    /// # Arguments
+    /// * `bytes` - Eight bytes containing the version string, e.g. `"4.10\0"`.
+    ///
+    /// # Returns
+    /// `(major, minor)` on success or an [`MdfError`] when the format is
+    /// unexpected.
     pub fn parse_block_version(bytes: &[u8]) -> Result<(u16,u16), MdfError> {
         // 1) Decode to &str, ignoring invalid UTF-8 (there shouldn’t be any).
         let raw = from_utf8(&bytes)

--- a/src/blocks/source_block.rs
+++ b/src/blocks/source_block.rs
@@ -83,8 +83,14 @@ impl BlockParse<'_> for SourceBlock {
     }
 }
 
-/// Helper to read a SourceBlock from a memory map at `address`,
-/// returning `None` if `address == 0`.
+/// Read an [`SIBLOCK`](SourceBlock) from the memory mapped file.
+///
+/// # Arguments
+/// * `mmap` - The entire MDF file mapped into memory.
+/// * `address` - File offset of the `##SI` block.
+///
+/// # Returns
+/// The parsed [`SourceBlock`] or an [`MdfError`] if decoding fails.
 pub fn read_source_block(mmap: &[u8], address: u64) -> Result<SourceBlock, MdfError> {
 
     let start = address as usize;

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -4,15 +4,20 @@ use crate::parsing::decoder::{decode_channel_value, DecodedValue};
 use crate::blocks::channel_block::ChannelBlock;
 use crate::writer::MdfWriter;
 
-/// Cut a segment of an MDF file given start and end times (in the unit
-/// of the time channel).
+/// Cut a segment of an MDF file based on time stamps.
 ///
-/// This function creates a new MDF file at `output_path` that contains the same
-/// structure as the input but only records whose timestamp lies within the
-/// `[start_time, end_time]` range.
+/// The input file is scanned for a master time channel (channel type `2` and
+/// sync type `1`). Only records whose time value lies in the inclusive range
+/// `[start_time, end_time]` are copied to the new file.
 ///
-/// The implementation looks for the channel marked as master (channel type 2
-/// and sync type 1) to determine the timestamp of each record.
+/// # Arguments
+/// * `input_path` - Path to the source MF4 file
+/// * `output_path` - Destination path for the trimmed file
+/// * `start_time` - Start time of the segment in seconds
+/// * `end_time` - End time of the segment in seconds
+///
+/// # Returns
+/// `Ok(())` on success or an [`MdfError`] if reading or writing fails.
 pub fn cut_mdf_by_time(
     input_path: &str,
     output_path: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! Minimal utilities for reading and writing ASAM MDF 4 files.
+//!
+//! The crate exposes a high level API under [`api`] to inspect existing
+//! recordings as well as a [`writer::MdfWriter`] to generate new files.  Only a
+//! fraction of the MDF 4 specification is implemented.
+
 pub mod blocks;
 pub mod error;
 pub mod writer;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -77,6 +77,18 @@ fn metas_equal(a: &GroupMeta, b: &GroupMeta) -> bool {
 }
 
 /// Merge two MDF files into a new file.
+///
+/// All channel groups that share the same layout are concatenated. Groups that
+/// do not match are appended as new channel groups. The resulting file is
+/// written to `output`.
+///
+/// # Arguments
+/// * `output` - Path for the merged file
+/// * `first` - Path to the first input file
+/// * `second` - Path to the second input file
+///
+/// # Returns
+/// `Ok(())` on success or an [`MdfError`] otherwise.
 pub fn merge_files(output: &str, first: &str, second: &str) -> Result<(), MdfError> {
     let mdf1 = MdfFile::parse_from_file(first)?;
     let mdf2 = MdfFile::parse_from_file(second)?;

--- a/src/parsing/mdf_file.rs
+++ b/src/parsing/mdf_file.rs
@@ -23,6 +23,13 @@ pub struct MdfFile {
 
 impl MdfFile {
     /// Parse an MDF file from a given file path.
+    ///
+    /// # Arguments
+    /// * `path` - Path to the `.mf4` file on disk.
+    ///
+    /// # Returns
+    /// An [`MdfFile`] containing all parsed blocks or an [`MdfError`] if the
+    /// file could not be read or decoded.
     pub fn parse_from_file(path: &str) -> Result<Self, MdfError> {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file)? };

--- a/src/parsing/raw_channel.rs
+++ b/src/parsing/raw_channel.rs
@@ -18,6 +18,15 @@ impl<'a> RawChannel {
     ///
     /// The iterator yields a `Result` for each record and transparently handles
     /// both fixed-size and VLSD storage schemes.
+    ///
+    /// # Arguments
+    /// * `data_group` - Parent data group owning the records
+    /// * `channel_group` - Channel group this channel belongs to
+    /// * `mmap` - Memory mapped MDF data
+    ///
+    /// # Returns
+    /// An iterator over byte slices containing each raw record, or an
+    /// [`MdfError`] if the underlying blocks could not be parsed.
     pub fn records(
         &self,
         data_group: &'a RawDataGroup,

--- a/src/parsing/raw_data_group.rs
+++ b/src/parsing/raw_data_group.rs
@@ -19,6 +19,12 @@ impl RawDataGroup {
     ///
     /// The returned vector contains the `DT` or `DV` blocks in the order they
     /// appear on disk, transparently following any `DL` list chains.
+    ///
+    /// # Arguments
+    /// * `mmap` - Memory mapped file containing the MDF data
+    ///
+    /// # Returns
+    /// A vector of [`DataBlock`] objects or an [`MdfError`] if parsing fails.
     pub fn data_blocks<'a>(
         &self,
         mmap: &'a [u8],

--- a/src/parsing/source_info.rs
+++ b/src/parsing/source_info.rs
@@ -14,7 +14,15 @@ pub struct SourceInfo {
 }
 
 impl SourceInfo {
-    /// Parse a SourceBlock from the mmap at `address` and read its strings.
+    /// Parse a source information block from the memory mapped file.
+    ///
+    /// # Arguments
+    /// * `mmap` - The memory mapped MDF file
+    /// * `address` - File offset of the SIBLOCK (0 if not present)
+    ///
+    /// # Returns
+    /// `Ok(Some(SourceInfo))` if a block was found, `Ok(None)` if the address
+    /// was zero, or an [`MdfError`] when parsing fails.
     pub fn from_mmap(mmap: &[u8], address: u64) -> Result<Option<Self>, MdfError> {
         // 0 means “no SIBLOCK”
         if address == 0 {

--- a/src/writer/mdf_writer.rs
+++ b/src/writer/mdf_writer.rs
@@ -507,8 +507,15 @@ impl MdfWriter {
     }
 
 /// Mark an existing channel as the time (master) channel.
+///
 /// This sets the channel's type to 2 and sync type to 1 in the file and updates
 /// the stored channel metadata.
+///
+/// # Arguments
+/// * `cn_id` - Identifier of the channel previously returned by [`add_channel`]
+///
+/// # Returns
+/// `Ok(())` on success or an [`MdfError`] if the channel could not be updated.
 pub fn set_time_channel(&mut self, cn_id: &str) -> Result<(), MdfError> {
     // Offsets of channel_type and sync_type within the CN block
     const CHANNEL_TYPE_OFFSET: u64 = 88;


### PR DESCRIPTION
## Summary
- expand README with usage section
- document high level APIs and util functions
- improve function docs with argument and return details
- add missing docs for internal blocks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6845a4253dec832bbfc5a66272d59de3