### PR TITLE
Implement Default for MDF blocks

### DIFF
--- a/src/blocks/channel_block.rs
+++ b/src/blocks/channel_block.rs
@@ -93,51 +93,6 @@ impl BlockParse<'_> for ChannelBlock {
 }
 
 impl ChannelBlock {
-    /// Returns a ChannelBlock with default values and automatically creates the header.
-    /// 
-    /// # Returns
-    /// A new ChannelBlock instance with a properly initialized header (id="##CN", block_len=160)
-    /// and all other fields set to default values.
-    pub fn default() -> Self {
-        // Create a header with the correct ID and block length
-        let header = BlockHeader {
-            id: String::from("##CN"),
-            reserved0: 0,
-            block_len: 160,
-            links_nr: 8,
-        };
-        
-        ChannelBlock {
-            header,
-            next_ch_addr: 0,
-            component_addr: 0,
-            name_addr: 0,
-            source_addr: 0,
-            conversion_addr: 0,
-            data: 0,
-            unit_addr: 0,
-            comment_addr: 0,
-            channel_type: 0,
-            sync_type: 0,
-            data_type: DataType::UnsignedIntegerLE, // Default data type
-            bit_offset: 0,
-            byte_offset: 0,
-            bit_count: 0,
-            flags: 0,
-            pos_invalidation_bit: 0,
-            precision: 0,
-            reserved1: 0,
-            attachment_nr: 0,
-            min_raw_value: 0.0,
-            max_raw_value: 0.0,
-            lower_limit: 0.0,
-            upper_limit: 0.0,
-            lower_ext_limit: 0.0,
-            upper_ext_limit: 0.0,
-            name: None,
-            conversion: None,
-        }
-    }
     
     /// Serializes the ChannelBlock to bytes according to MDF 4.1 specification.
     /// 
@@ -318,5 +273,47 @@ impl ChannelBlock {
             raw
         };
         Ok(decoded)
+    }
+}
+
+impl Default for ChannelBlock {
+    fn default() -> Self {
+        let header = BlockHeader {
+            id: String::from("##CN"),
+            reserved0: 0,
+            block_len: 160,
+            links_nr: 8,
+        };
+
+        ChannelBlock {
+            header,
+            next_ch_addr: 0,
+            component_addr: 0,
+            name_addr: 0,
+            source_addr: 0,
+            conversion_addr: 0,
+            data: 0,
+            unit_addr: 0,
+            comment_addr: 0,
+            channel_type: 0,
+            sync_type: 0,
+            data_type: DataType::UnsignedIntegerLE,
+            bit_offset: 0,
+            byte_offset: 0,
+            bit_count: 0,
+            flags: 0,
+            pos_invalidation_bit: 0,
+            precision: 0,
+            reserved1: 0,
+            attachment_nr: 0,
+            min_raw_value: 0.0,
+            max_raw_value: 0.0,
+            lower_limit: 0.0,
+            upper_limit: 0.0,
+            lower_ext_limit: 0.0,
+            upper_ext_limit: 0.0,
+            name: None,
+            conversion: None,
+        }
     }
 }

--- a/src/blocks/channel_group_block.rs
+++ b/src/blocks/channel_group_block.rs
@@ -60,37 +60,6 @@ impl BlockParse<'_> for ChannelGroupBlock {
     }
 }
 impl ChannelGroupBlock {
-    /// Returns a ChannelGroupBlock with default values and automatically creates the header.
-    /// 
-    /// # Returns
-    /// A new ChannelGroupBlock instance with a properly initialized header (id="##CG", block_len=104)
-    /// and all other fields set to default values.
-    pub fn default() -> Self {
-        // Create a header with the correct ID and block length
-        let header = BlockHeader {
-            id: String::from("##CG"),
-            reserved0: 0,
-            block_len: 104,
-            links_nr: 6,  // ChannelGroupBlock has 6 links
-        };
-        
-        ChannelGroupBlock {
-            header,
-            next_cg_addr: 0,
-            first_ch_addr: 0,
-            acq_name_addr: 0,
-            acq_source_addr: 0,
-            first_sample_reduction_addr: 0,
-            comment_addr: 0,
-            record_id: 0,
-            cycles_nr: 0,
-            flags: 0,
-            path_separator: 0,
-            reserved1: 0,
-            samples_byte_nr: 0,
-            invalidation_bytes_nr: 0,
-        }
-    }
     
     /// Serializes the ChannelGroupBlock to bytes according to MDF 4.1 specification.
     /// 
@@ -186,5 +155,33 @@ impl ChannelGroupBlock {
         }
 
         Ok(channels)
+    }
+}
+
+impl Default for ChannelGroupBlock {
+    fn default() -> Self {
+        let header = BlockHeader {
+            id: String::from("##CG"),
+            reserved0: 0,
+            block_len: 104,
+            links_nr: 6,
+        };
+
+        ChannelGroupBlock {
+            header,
+            next_cg_addr: 0,
+            first_ch_addr: 0,
+            acq_name_addr: 0,
+            acq_source_addr: 0,
+            first_sample_reduction_addr: 0,
+            comment_addr: 0,
+            record_id: 0,
+            cycles_nr: 0,
+            flags: 0,
+            path_separator: 0,
+            reserved1: 0,
+            samples_byte_nr: 0,
+            invalidation_bytes_nr: 0,
+        }
     }
 }

--- a/src/blocks/data_group_block.rs
+++ b/src/blocks/data_group_block.rs
@@ -52,30 +52,6 @@ impl BlockParse<'_> for DataGroupBlock {
 }
 
 impl DataGroupBlock {
-    /// Returns a DataGroupBlock with default values and automatically creates the header.
-    /// 
-    /// # Returns
-    /// A new DataGroupBlock instance with a properly initialized header (id="##DG", block_len=64)
-    /// and all other fields set to default values.
-    pub fn default() -> Self {
-        // Create a header with the correct ID and block length
-        let header = BlockHeader {
-            id: String::from("##DG"),
-            reserved0: 0,
-            block_len: 64,
-            links_nr: 4,  // DataGroupBlock has 4 links
-        };
-        
-        DataGroupBlock {
-            header,
-            next_dg_addr: 0,
-            first_cg_addr: 0,
-            data_block_addr: 0,
-            comment_addr: 0,
-            record_id_len: 0,
-            reserved1: String::new(),
-        }
-    }
     
     /// Serializes the DataGroupBlock to bytes according to MDF 4.1 specification.
     /// 
@@ -136,5 +112,26 @@ impl DataGroupBlock {
         debug_assert_eq!(buffer.len() % 8, 0, "DataGroupBlock size is not 8-byte aligned");
         
         Ok(buffer)
+    }
+}
+
+impl Default for DataGroupBlock {
+    fn default() -> Self {
+        let header = BlockHeader {
+            id: String::from("##DG"),
+            reserved0: 0,
+            block_len: 64,
+            links_nr: 4,
+        };
+
+        DataGroupBlock {
+            header,
+            next_dg_addr: 0,
+            first_cg_addr: 0,
+            data_block_addr: 0,
+            comment_addr: 0,
+            record_id_len: 0,
+            reserved1: String::new(),
+        }
     }
 }

--- a/src/blocks/header_block.rs
+++ b/src/blocks/header_block.rs
@@ -26,42 +26,6 @@ pub struct HeaderBlock {
 }
 
 impl HeaderBlock {
-    /// Returns a HeaderBlock with default values and automatically creates the header.
-    /// 
-    /// # Returns
-    /// A new HeaderBlock instance with a properly initialized header (id="##HD", block_len=104)
-    /// and all other fields set to default values.
-    pub fn default() -> Self {
-        // Create a header with the correct ID and block length
-        let header = BlockHeader {
-            id: String::from("##HD"),
-            reserved0: 0,
-            block_len: 104,
-            links_nr: 6,  // HeaderBlock has 6 links
-        };
-        
-        HeaderBlock {
-            header,
-            first_dg_addr: 0,
-            file_history_addr: 0,
-            channel_tree_addr: 0,
-            first_attachment_addr: 0,
-            first_event_addr: 0,
-            comment_addr: 0,
-            abs_time: 2 * 3600 * 1000000000,  // Preserving the default time value
-            tz_offset: 0,
-            daylight_save_time: 0,
-            time_flags: 0,
-            time_quality: 0,
-            flags: 0,
-            reserved1: 0,
-            start_angle: 0,
-            start_distance: 0,
-        }
-    }
-}
-
-impl HeaderBlock {
     /// Serializes the HeaderBlock to bytes according to MDF 4.1 specification.
     ///
     /// # Structure (104 bytes total):
@@ -174,5 +138,35 @@ impl BlockParse<'_> for HeaderBlock {
             start_angle: LittleEndian::read_u64(&bytes[88..96]),
             start_distance: LittleEndian::read_u64(&bytes[96..104]),
         })
+    }
+}
+
+impl Default for HeaderBlock {
+    fn default() -> Self {
+        let header = BlockHeader {
+            id: String::from("##HD"),
+            reserved0: 0,
+            block_len: 104,
+            links_nr: 6,
+        };
+
+        HeaderBlock {
+            header,
+            first_dg_addr: 0,
+            file_history_addr: 0,
+            channel_tree_addr: 0,
+            first_attachment_addr: 0,
+            first_event_addr: 0,
+            comment_addr: 0,
+            abs_time: 2 * 3600 * 1000000000,
+            tz_offset: 0,
+            daylight_save_time: 0,
+            time_flags: 0,
+            time_quality: 0,
+            flags: 0,
+            reserved1: 0,
+            start_angle: 0,
+            start_distance: 0,
+        }
     }
 }

--- a/src/blocks/text_block.rs
+++ b/src/blocks/text_block.rs
@@ -68,11 +68,11 @@ impl TextBlock {
     }
     
     /// Creates an empty TextBlock with a minimal valid size.
-    /// 
+    ///
     /// # Returns
     /// A new TextBlock with an empty text string
-    pub fn default() -> Self {
-        Self::new("") // Create an empty text block
+    pub fn new_empty() -> Self {
+        Self::new("")
     }
     
     /// Serializes the TextBlock to bytes according to MDF 4.1 specification.
@@ -143,5 +143,11 @@ impl TextBlock {
         debug_assert_eq!(buffer.len() % 8, 0, "TextBlock size is not 8-byte aligned");
         
         Ok(buffer)
+    }
+}
+
+impl Default for TextBlock {
+    fn default() -> Self {
+        Self::new("")
     }
 }


### PR DESCRIPTION
## Summary
- implement `Default` for `ChannelBlock`
- implement `Default` for `ChannelGroupBlock`
- implement `Default` for `DataGroupBlock`
- implement `Default` for `HeaderBlock`
- implement `Default` for `TextBlock`
- remove old inherent `default` methods and adjust code
- fix indentation after replacing default methods
- verify example output using `asammdf`

## Testing
- `cargo test --locked`
- `cargo run --example write_records`
- `cargo run --example multi_groups_with_data`
- `python - <<'PY'
from asammdf import MDF
mdf = MDF('write_records_example.mf4')
print('channel names', list(mdf.channels_db.keys()))
print('first channel values', mdf.get(list(mdf.channels_db.keys())[0]).samples[:5])
PY`
- `python - <<'PY'
from asammdf import MDF
mdf = MDF('multi_group_data.mf4')
print('channels:', mdf.channels_db.keys())
print('Speed first 5', mdf.get('Speed').samples[:5])
print('RPM first 5', mdf.get('RPM').samples[:5])
print('Temperature first 5', mdf.get('Temperature').samples[:5])
print('Pressure first 5', mdf.get('Pressure').samples[:5])
print('Status first 5', mdf.get('Status').samples[:5])
PY`


------
https://chatgpt.com/codex/tasks/task_e_6845ae536814832bbe6178b93438e277