### PR TITLE
Use dt counter for block IDs

### DIFF
--- a/src/writer/mdf_writer/data.rs
+++ b/src/writer/mdf_writer/data.rs
@@ -29,8 +29,8 @@ impl MdfWriter {
 
         let header = BlockHeader { id: "##DT".to_string(), reserved0: 0, block_len: 24, links_nr: 0 };
         let header_bytes = header.to_bytes()?;
-        let dt_count = self.block_positions.keys().filter(|k| k.starts_with("dt_")).count();
-        let dt_id = format!("dt_{}", dt_count);
+        let dt_id = format!("dt_{}", self.dt_counter);
+        self.dt_counter += 1;
         let dt_pos = self.write_block_with_id(&header_bytes, &dt_id)?;
 
         let dg_data_link_offset = 40;
@@ -90,8 +90,8 @@ impl MdfWriter {
             }
             let header = BlockHeader { id: "##DT".to_string(), reserved0: 0, block_len: 24, links_nr: 0 };
             let header_bytes = header.to_bytes()?;
-            let dt_count = self.block_positions.keys().filter(|k| k.starts_with("dt_")).count();
-            let new_dt_id = format!("dt_{}", dt_count);
+            let new_dt_id = format!("dt_{}", self.dt_counter);
+            self.dt_counter += 1;
             let new_dt_pos = self.write_block_with_id(&header_bytes, &new_dt_id)?;
 
             let dt = self.open_dts.get_mut(cg_id).unwrap();

--- a/src/writer/mdf_writer/io.rs
+++ b/src/writer/mdf_writer/io.rs
@@ -15,6 +15,7 @@ impl MdfWriter {
             offset: 0,
             block_positions: HashMap::new(),
             open_dts: HashMap::new(),
+            dt_counter: 0,
             last_dg: None,
             cg_to_dg: HashMap::new(),
             cg_offsets: HashMap::new(),

--- a/src/writer/mdf_writer/mod.rs
+++ b/src/writer/mdf_writer/mod.rs
@@ -31,6 +31,7 @@ pub struct MdfWriter {
     offset: u64,
     block_positions: HashMap<String, u64>,
     open_dts: HashMap<String, OpenDataBlock>,
+    dt_counter: usize,
     last_dg: Option<String>,
     cg_to_dg: HashMap<String, String>,
     cg_offsets: HashMap<String, usize>,


### PR DESCRIPTION
## Summary
- add a `dt_counter` field to `MdfWriter`
- create DT ids using the counter instead of scanning `block_positions`
- increment counter after assigning ID to keep numbering aligned with old logic

## Testing
- `cargo test`
- `cargo run --example write_records`
- `cargo run --example multi_groups_with_data`
- verified MF4 outputs with `asammdf`

------
https://chatgpt.com/codex/tasks/task_e_6845ae567868832b8e4c4a1ee26df87c