### PR TITLE
Improve writer example performance

### DIFF
--- a/examples/python_equivalent.rs
+++ b/examples/python_equivalent.rs
@@ -45,7 +45,7 @@ fn read_test_signal(fname: &str, signame: &str) -> Result<(), MdfError> {
 
 fn write_test() -> Result<(), MdfError> {
     println!("Writing test mdf4...");
-    let mut writer = MdfWriter::new("asammdf_test.mf4")?;
+    let mut writer = MdfWriter::new_with_capacity("asammdf_test.mf4", 4 * 1024 * 1024)?;
     writer.init_mdf_file()?;
     let cg = writer.add_channel_group(None, |_| {})?;
     let t_id = writer.add_channel(&cg, None, |ch| {
@@ -77,7 +77,8 @@ fn write_test() -> Result<(), MdfError> {
 
 
 fn write_test_signals() -> Result<(), MdfError> {
-    let mut writer = MdfWriter::new("asammdf_write_test_signals.tmp.mf4")?;
+    let mut writer =
+        MdfWriter::new_with_capacity("asammdf_write_test_signals.tmp.mf4", 4 * 1024 * 1024)?;
     writer.init_mdf_file()?;
     let cg = writer.add_channel_group(None, |_| {})?;
     let t_id = writer.add_channel(&cg, None, |ch| {
@@ -98,9 +99,10 @@ fn write_test_signals() -> Result<(), MdfError> {
     }
 
     writer.start_data_block_for_cg(&cg, 0)?;
+    let mut rec = Vec::with_capacity(SIG_LIST.len() + 1);
     for i in 0..NUM_SAMPLES {
         let ts = 100_000_000.0 + i as f64 * 1000.0;
-        let mut rec = Vec::with_capacity(SIG_LIST.len() + 1);
+        rec.clear();
         rec.push(DecodedValue::Float(ts));
         for s in SIG_LIST {
             match s.data_type {
@@ -121,7 +123,8 @@ fn write_test_signals() -> Result<(), MdfError> {
 }
 
 fn write_test_bytes() -> Result<(), MdfError> {
-    let mut writer = MdfWriter::new("asammdf_write_test_frame.tmp.mf4")?;
+    let mut writer =
+        MdfWriter::new_with_capacity("asammdf_write_test_frame.tmp.mf4", 4 * 1024 * 1024)?;
     writer.init_mdf_file()?;
     let cg = writer.add_channel_group(None, |_| {})?;
     let t_id = writer.add_channel(&cg, None, |ch| {

--- a/src/writer/mdf_writer/io.rs
+++ b/src/writer/mdf_writer/io.rs
@@ -6,11 +6,16 @@ use std::io::{Seek, SeekFrom, Write, BufWriter};
 use byteorder::{LittleEndian, WriteBytesExt};
 
 impl MdfWriter {
-    /// Creates a new MdfWriter for the given file path (overwrites existing).
+    /// Creates a new `MdfWriter` for the given file path (overwrites existing).
     /// Initializes with an empty block position tracker.
     pub fn new(path: &str) -> Result<Self, MdfError> {
+        Self::new_with_capacity(path, 8192)
+    }
+
+    /// Creates a new `MdfWriter` with a custom internal buffer size.
+    pub fn new_with_capacity(path: &str, capacity: usize) -> Result<Self, MdfError> {
         let file = File::create(path)?;
-        let file = BufWriter::new(file);
+        let file = BufWriter::with_capacity(capacity, file);
         Ok(MdfWriter {
             file,
             offset: 0,


### PR DESCRIPTION
## Summary
- add new_with_capacity() to MdfWriter for adjustable buffer sizes
- reuse record buffer in `write_test_signals`
- increase output buffer to 4 MiB in the python_equivalent example

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d1d0d15c4832ba7b48b811e9c33bc