### PR TITLE
ci: add automated SemVer release pipeline driven by Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,40 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  validate:
+    name: Validate Conventional Commits format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            chore
+            docs
+            refactor
+            test
+            ci
+            build
+            style
+          requireScope: false
+          subjectPattern: ^[A-Za-z0-9].+$
+          subjectPatternError: |
+            The PR title subject (after the colon) must start with an alphanumeric character.
+            Example: `feat: add CAN bus extraction`
+          wip: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,363 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  compute-bump:
+    name: Compute SemVer bump from Conventional Commits
+    runs-on: ubuntu-latest
+    outputs:
+      release_needed: ${{ steps.bump.outputs.release_needed }}
+      new_version: ${{ steps.bump.outputs.new_version }}
+      previous_tag: ${{ steps.bump.outputs.previous_tag }}
+      bump: ${{ steps.bump.outputs.bump }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: bump
+        name: Determine next version
+        shell: python
+        run: |
+          import os, re, subprocess
+
+          tags = subprocess.check_output(
+              ["git", "tag", "--list", "v*", "--sort=-v:refname"], text=True
+          ).split()
+          last_tag = tags[0] if tags else "v0.0.0"
+          range_arg = "HEAD" if last_tag == "v0.0.0" else f"{last_tag}..HEAD"
+
+          hashes = subprocess.check_output(
+              ["git", "log", range_arg, "--format=%H"], text=True
+          ).split()
+
+          TYPE_RE = re.compile(
+              r"^(feat|fix|perf|refactor|chore|docs|test|ci|build|style)"
+              r"(\([^)]+\))?(!)?:"
+          )
+          BREAKING_FOOTER = re.compile(r"^BREAKING[ -]CHANGE:", re.M | re.I)
+
+          rank = {"none": 0, "patch": 1, "minor": 2, "major": 3}
+          bump = "none"
+
+          for h in hashes:
+              body = subprocess.check_output(
+                  ["git", "show", "-s", "--format=%B", h], text=True
+              )
+              subject = body.splitlines()[0] if body else ""
+              m = TYPE_RE.match(subject)
+              if (m and m.group(3) == "!") or BREAKING_FOOTER.search(body):
+                  bump = "major"
+                  break
+              if not m:
+                  continue
+              t = m.group(1)
+              if t == "feat" and rank[bump] < rank["minor"]:
+                  bump = "minor"
+              elif t in ("fix", "perf") and rank[bump] < rank["patch"]:
+                  bump = "patch"
+
+          base = last_tag.lstrip("v")
+          major, minor, patch = (int(x) for x in base.split("."))
+          if bump == "major":
+              major, minor, patch = major + 1, 0, 0
+          elif bump == "minor":
+              minor, patch = minor + 1, 0
+          elif bump == "patch":
+              patch += 1
+
+          new_version = f"{major}.{minor}.{patch}" if bump != "none" else ""
+          release_needed = "true" if bump != "none" else "false"
+
+          print(f"Previous tag: {last_tag}")
+          print(f"Commits analyzed: {len(hashes)}")
+          print(f"Bump: {bump}")
+          print(f"New version: {new_version or '(none — skipping release)'}")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"previous_tag={last_tag}\n")
+              f.write(f"new_version={new_version}\n")
+              f.write(f"release_needed={release_needed}\n")
+              f.write(f"bump={bump}\n")
+
+  bump-and-tag:
+    name: Bump version, update changelog, tag
+    needs: compute-bump
+    if: needs.compute-bump.outputs.release_needed == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ needs.compute-bump.outputs.new_version }}
+      tag: v${{ needs.compute-bump.outputs.new_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git author
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump Cargo.toml
+        run: |
+          sed -i -E 's/^version *= *"[^"]+"/version = "${{ needs.compute-bump.outputs.new_version }}"/' Cargo.toml
+          grep '^version' Cargo.toml
+
+      - name: Bump pyproject.toml
+        run: |
+          python -c "
+          import re, pathlib
+          p = pathlib.Path('pyproject.toml')
+          new = re.sub(r'^version = \".*\"', 'version = \"${{ needs.compute-bump.outputs.new_version }}\"', p.read_text(), count=1, flags=re.M)
+          p.write_text(new)
+          "
+          grep '^version' pyproject.toml
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Refresh Cargo.lock
+        run: cargo update -p mf4-rs
+
+      - name: Generate changelog entry
+        id: changelog
+        env:
+          PREVIOUS_TAG: ${{ needs.compute-bump.outputs.previous_tag }}
+          NEW_VERSION: ${{ needs.compute-bump.outputs.new_version }}
+        shell: python
+        run: |
+          import datetime, os, pathlib, re, subprocess
+
+          prev = os.environ["PREVIOUS_TAG"]
+          new_tag = "v" + os.environ["NEW_VERSION"]
+          range_arg = "HEAD" if prev == "v0.0.0" else f"{prev}..HEAD"
+
+          subjects = subprocess.check_output(
+              ["git", "log", range_arg, "--format=%s"], text=True
+          ).splitlines()
+
+          TYPE = re.compile(r"^([a-z]+)(\([^)]+\))?(!)?:\s*(.+)$")
+          groups = [
+              ("feat",     "Features"),
+              ("fix",      "Fixes"),
+              ("perf",     "Performance"),
+              ("refactor", "Refactors"),
+              ("docs",     "Docs"),
+              ("build",    "Build"),
+              ("ci",       "CI"),
+          ]
+          breaking = []
+          buckets = {t: [] for t, _ in groups}
+          for s in subjects:
+              m = TYPE.match(s)
+              if not m:
+                  continue
+              t, _, bang, desc = m.groups()
+              if bang:
+                  breaking.append(f"- {desc}")
+              if t in buckets:
+                  buckets[t].append(f"- {desc}")
+
+          today = datetime.date.today().isoformat()
+          lines = [f"## {new_tag} — {today}", ""]
+          if breaking:
+              lines += ["### BREAKING CHANGES", *breaking, ""]
+          for t, label in groups:
+              if buckets[t]:
+                  lines += [f"### {label}", *buckets[t], ""]
+
+          new_section = "\n".join(lines).rstrip() + "\n"
+          pathlib.Path("new_section.md").write_text(new_section)
+
+          changelog = pathlib.Path("CHANGELOG.md")
+          if changelog.exists():
+              changelog.write_text(new_section + "\n" + changelog.read_text())
+          else:
+              header = (
+                  "# Changelog\n\n"
+                  "All notable changes to mf4-rs are documented in this file. "
+                  "This project follows Semantic Versioning and Conventional Commits.\n\n"
+              )
+              changelog.write_text(header + new_section)
+
+          print("--- generated changelog section ---")
+          print(new_section)
+
+      - name: Commit, tag, and push
+        run: |
+          set -euo pipefail
+          new='v${{ needs.compute-bump.outputs.new_version }}'
+          git add Cargo.toml Cargo.lock pyproject.toml CHANGELOG.md
+          git commit -m "chore(release): ${new}"
+          git tag -a "${new}" -m "Release ${new}"
+          git push origin HEAD:main
+          git push origin "${new}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.compute-bump.outputs.new_version }}" \
+            --title "v${{ needs.compute-bump.outputs.new_version }}" \
+            --notes-file new_section.md
+
+  build-wheels-linux:
+    name: Build wheels (Linux ${{ matrix.target }})
+    needs: bump-and-tag
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-and-tag.outputs.tag }}
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          manylinux: auto
+          sccache: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
+
+  build-wheels-macos:
+    name: Build wheels (macOS ${{ matrix.target }})
+    needs: bump-and-tag
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-13
+            target: x86_64
+            pythons: |
+              3.8
+              3.9
+              3.10
+              3.11
+              3.12
+          - os: macos-14
+            target: aarch64
+            pythons: |
+              3.10
+              3.11
+              3.12
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-and-tag.outputs.tag }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.pythons }}
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          sccache: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  build-wheels-windows:
+    name: Build wheels (Windows ${{ matrix.target }})
+    needs: bump-and-tag
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-and-tag.outputs.tag }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          sccache: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-${{ matrix.target }}
+          path: dist
+
+  build-sdist:
+    name: Build source distribution
+    needs: bump-and-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-and-tag.outputs.tag }}
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs:
+      - build-wheels-linux
+      - build-wheels-macos
+      - build-wheels-windows
+      - build-sdist
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mf4-rs
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: List collected artifacts
+        run: ls -la dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true
+
+  publish-crates:
+    name: Publish to crates.io
+    needs: bump-and-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-and-tag.outputs.tag }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Dry-run publish
+        run: cargo publish --dry-run --allow-dirty
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --token "$CARGO_REGISTRY_TOKEN"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,52 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Commit & PR Title Format (MUST FOLLOW)
+
+This repository uses **automated releases driven by Conventional Commits**. Every push to `main` runs `.github/workflows/release.yml`, which inspects commit messages since the last `v*` tag, computes a SemVer bump, updates `Cargo.toml` / `pyproject.toml` / `Cargo.lock` / `CHANGELOG.md`, tags `vX.Y.Z`, and publishes to PyPI and crates.io.
+
+The repo squash-merges PRs, so **the PR title becomes the commit message on `main`** — and that is what the release pipeline parses. PR titles are also linted by `.github/workflows/pr-title.yml` (uses `amannn/action-semantic-pull-request`).
+
+### Required PR title grammar
+
+```
+<type>(<optional scope>)<!>: <description>
+```
+
+- `<type>` must be one of: `feat`, `fix`, `perf`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`, `style`.
+- Append `!` (or include a `BREAKING CHANGE:` footer in the PR body) to flag a breaking change.
+- The description must start with an alphanumeric character and use the imperative mood.
+
+### How types map to version bumps
+
+| Title prefix (or footer) | Bump |
+|---|---|
+| `feat!:` / `fix!:` / any `<type>!:` / body `BREAKING CHANGE:` | **major** |
+| `feat:` | **minor** |
+| `fix:` / `perf:` | **patch** |
+| `chore:` / `docs:` / `refactor:` / `test:` / `ci:` / `build:` / `style:` | **no release** |
+
+The pipeline takes the **highest** bump implied by any commit since the last tag. A run with no qualifying commits is a clean no-op (no tag created), which is why the `chore(release): vX.Y.Z` commit pushed back by the workflow does not loop.
+
+### Examples
+
+- `feat: add ##DZ block decompression for index reads` → minor bump
+- `fix: handle empty CHANGELOG.md on first release` → patch bump
+- `feat!: drop Python 3.8 support` → major bump
+- `chore: bump rand to 0.9` → no release
+- `docs: clarify VLSD record format` → no release
+
+### Rules for Claude sessions
+
+1. **Always set the PR title** to a Conventional Commits–conformant string when opening a PR with `mcp__github__create_pull_request`. Default to:
+   - `feat:` for user-visible additions to the Rust or Python API
+   - `fix:` for bug fixes
+   - `perf:` for performance improvements with no behavior change
+   - `chore:` / `docs:` / `refactor:` / `test:` / `ci:` / `build:` / `style:` for non-shipping changes
+2. Use `!` or a `BREAKING CHANGE:` footer **only** when the public Rust crate API or the Python bindings change incompatibly.
+3. **Never hand-edit the `version` fields** in `Cargo.toml` or `pyproject.toml`, and never manually edit `CHANGELOG.md` to add release sections — the release workflow owns those. Editing them by hand will cause merge conflicts the next time the workflow runs.
+4. When committing within a PR branch, individual commit subjects don't need to be conventional (the squash uses the PR title), but matching the convention still helps reviewers.
+
 ## Project Overview
 
 `mf4-rs` is a Rust library for working with ASAM MDF 4 (Measurement Data Format) files. It implements a subset of the MDF 4.1 specification sufficient for data logging and inspection tasks. The library supports reading existing MDF files, writing new ones, creating lightweight JSON indexes for fast random access, time-based file cutting, and file merging. Optional Python bindings are available via PyO3.

--- a/README.md
+++ b/README.md
@@ -237,3 +237,15 @@ for group in mdf.channel_groups():
 - `memmap2` - Memory-mapped file I/O
 - `meval` - Mathematical expression evaluation for formula conversions
 - `thiserror` - Error handling derive macros
+
+## Releases
+
+Releases are fully automated. Every merge to `main` runs `.github/workflows/release.yml`, which:
+
+1. Reads commit messages since the last `v*` tag.
+2. Computes a SemVer bump from [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:` → minor, `fix:`/`perf:` → patch, `feat!:` / `BREAKING CHANGE:` → major; other types do not produce a release).
+3. Updates `Cargo.toml`, `pyproject.toml`, `Cargo.lock`, and `CHANGELOG.md`, then tags `vX.Y.Z`.
+4. Builds wheels for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x64), plus an sdist, and publishes them to [PyPI](https://pypi.org/project/mf4-rs/) via OIDC trusted publishing.
+5. Publishes the Rust crate to [crates.io](https://crates.io/crates/mf4-rs).
+
+PR titles are linted against the convention by `.github/workflows/pr-title.yml`. Because PRs are squash-merged, **the PR title is the source of truth** for both the changelog and the version bump. See [`CHANGELOG.md`](CHANGELOG.md) for release history.


### PR DESCRIPTION
- Add .github/workflows/release.yml: on push to main, computes a SemVer
  bump from Conventional Commits since the last v* tag, updates
  Cargo.toml / pyproject.toml / Cargo.lock / CHANGELOG.md, tags vX.Y.Z,
  builds wheels (Linux x86_64+aarch64, macOS x86_64+aarch64, Windows x64)
  + sdist via maturin, and publishes to PyPI (OIDC trusted publishing)
  and crates.io.
- Add .github/workflows/pr-title.yml: lints PR titles against
  Conventional Commits using amannn/action-semantic-pull-request.
- Document the convention and Claude-session rules in CLAUDE.md so
  future sessions naturally produce conformant PR titles.
- Add a Releases section to README.md.

The chore(release) commit pushed back by the workflow does not match
any release-triggering type, so no [skip ci] guard is needed - the next
push-to-main run is a clean no-op.

One-time setup the maintainer must complete before the first release:
1. Configure a PyPI Trusted Publisher for project mf4-rs, repo
   dmagyar-0/mf4-rs, workflow release.yml, environment pypi.
2. Add CARGO_REGISTRY_TOKEN secret for crates.io.
3. Create a 'pypi' GitHub Actions environment (optional reviewers).
4. If branch protection blocks GITHUB_TOKEN pushes to main, add a
   RELEASE_PAT secret with contents:write.

https://claude.ai/code/session_01Pik7XpoiZJ2wutiFrFLoy9