### PR TITLE
feat: enable automated releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,28 @@ Releases are fully automated. Every merge to `main` runs `.github/workflows/rele
 5. Publishes the Rust crate to [crates.io](https://crates.io/crates/mf4-rs).
 
 PR titles are linted against the convention by `.github/workflows/pr-title.yml`. Because PRs are squash-merged, **the PR title is the source of truth** for both the changelog and the version bump. See [`CHANGELOG.md`](CHANGELOG.md) for release history.
+
+### How PR titles map to version bumps
+
+| PR title prefix (or footer)                                       | Bump        | Example                                              |
+|-------------------------------------------------------------------|-------------|------------------------------------------------------|
+| `feat!:` / `<type>!:` / body contains `BREAKING CHANGE:`          | **major**   | `feat!: drop Python 3.8 support`                     |
+| `feat:`                                                           | **minor**   | `feat: add ##DZ block decompression for index reads` |
+| `fix:` / `perf:`                                                  | **patch**   | `fix: handle empty CHANGELOG.md on first release`    |
+| `chore:` / `docs:` / `refactor:` / `test:` / `ci:` / `build:` / `style:` | _no release_ | `docs: clarify VLSD record format`                   |
+
+If multiple commits land between releases, the **highest** bump wins. Runs with no qualifying commits are a clean no-op — no tag is created and no artifacts are published, which is why the `chore(release): vX.Y.Z` commit pushed back by the workflow does not trigger another release.
+
+### What gets published
+
+Each successful release run publishes, in parallel, after the tag is pushed:
+
+- **PyPI**: `mf4-rs` wheels for Linux (x86_64, aarch64), macOS (x86_64 on 13, aarch64 on 14), and Windows (x64), plus an sdist. Authentication uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no long-lived API token is stored. The `pypi` GitHub Actions environment gates this job.
+- **crates.io**: the `mf4-rs` Rust crate, gated by a `cargo publish --dry-run` step. Authentication uses the `CARGO_REGISTRY_TOKEN` repository secret.
+- **GitHub Releases**: a release named `vX.Y.Z` whose body is the same changelog section appended to `CHANGELOG.md`.
+
+### Manual triggers and recovery
+
+- **Re-run a release**: the `Release` workflow accepts `workflow_dispatch`, so a maintainer can re-run it from the Actions tab. If the tag already exists, `bump-and-tag` will fail; in that case re-run only the `publish-pypi` / `publish-crates` jobs from the original run.
+- **Skip a release intentionally**: use a non-releasing prefix (`chore:`, `docs:`, `refactor:`, `test:`, `ci:`, `build:`, `style:`) for the PR title. The workflow will run, compute `bump=none`, and exit cleanly without creating a tag.
+- **First-time setup** (already complete for this repo): a PyPI Trusted Publisher entry for `mf4-rs` pointing at `dmagyar-0/mf4-rs` workflow `release.yml`, environment `pypi`; a `CARGO_REGISTRY_TOKEN` secret; and — if branch protection blocks `GITHUB_TOKEN` pushes to `main` — a `RELEASE_PAT` secret with `contents:write`.


### PR DESCRIPTION
## Summary

First end-to-end test of the Conventional-Commits-driven release pipeline added in #56.

The substantive change in this PR is a README expansion under **Releases** with three new subsections:

- **How PR titles map to version bumps** — table with examples (`feat:` → minor, `fix:`/`perf:` → patch, `feat!:` / `BREAKING CHANGE:` → major, others → no release).
- **What gets published** — PyPI wheels (Linux x86_64 / aarch64, macOS x86_64 / aarch64, Windows x64) + sdist via OIDC trusted publishing, the Rust crate via `CARGO_REGISTRY_TOKEN`, and a GitHub Release.
- **Manual triggers and recovery** — `workflow_dispatch` re-runs, how to intentionally skip a release, and the one-time setup recap.

The PR title uses the `feat:` prefix so this merge exercises the full pipeline: the **Release** workflow should compute a **minor** bump, tag **v1.1.0**, push wheels + sdist to PyPI, and publish the crate to crates.io.

## Test plan

- [ ] PR title lint (`pr-title.yml`) passes.
- [ ] After squash-merge, the **Release** workflow runs on `main`.
- [ ] `compute-bump` outputs `bump=minor`, `new_version=1.1.0`.
- [ ] `bump-and-tag` updates `Cargo.toml` / `pyproject.toml` / `Cargo.lock` / `CHANGELOG.md`, tags `v1.1.0`, and pushes a `chore(release): v1.1.0` commit + tag back to `main`.
- [ ] `build-wheels-linux`, `build-wheels-macos`, `build-wheels-windows`, `build-sdist` all succeed.
- [ ] `publish-pypi` lands `mf4-rs==1.1.0` on https://pypi.org/project/mf4-rs/.
- [ ] `publish-crates` lands `mf4-rs = "1.1.0"` on https://crates.io/crates/mf4-rs.
- [ ] The follow-up `chore(release): v1.1.0` push to `main` triggers a no-op release run (`bump=none`, no new tag).

https://claude.ai/code/session_017g8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYii5G3KL7HsQ8hC96139K)_