### PR TITLE
feat(release): use max of latest tag and Cargo.toml version as bump base

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,29 @@ jobs:
         name: Determine next version
         shell: python
         run: |
-          import os, re, subprocess
+          import os, pathlib, re, subprocess
+
+          def parse(v):
+              return tuple(int(x) for x in v.lstrip("v").split("."))
 
           tags = subprocess.check_output(
               ["git", "tag", "--list", "v*", "--sort=-v:refname"], text=True
           ).split()
           last_tag = tags[0] if tags else "v0.0.0"
           range_arg = "HEAD" if last_tag == "v0.0.0" else f"{last_tag}..HEAD"
+
+          # The bump base is the maximum of the latest v* tag and the
+          # version currently declared in Cargo.toml. This way, a manually
+          # bumped Cargo.toml version (or a version published to a registry
+          # before the workflow was wired up) is honored, and we never
+          # downgrade.
+          cargo_version = re.search(
+              r'^version\s*=\s*"([^"]+)"',
+              pathlib.Path("Cargo.toml").read_text(),
+              re.M,
+          ).group(1)
+          base_v = max(parse(last_tag), parse(cargo_version))
+          base_label = f"v{'.'.join(str(x) for x in base_v)}"
 
           hashes = subprocess.check_output(
               ["git", "log", range_arg, "--format=%H"], text=True
@@ -68,8 +84,7 @@ jobs:
               elif t in ("fix", "perf") and rank[bump] < rank["patch"]:
                   bump = "patch"
 
-          base = last_tag.lstrip("v")
-          major, minor, patch = (int(x) for x in base.split("."))
+          major, minor, patch = base_v
           if bump == "major":
               major, minor, patch = major + 1, 0, 0
           elif bump == "minor":
@@ -80,13 +95,19 @@ jobs:
           new_version = f"{major}.{minor}.{patch}" if bump != "none" else ""
           release_needed = "true" if bump != "none" else "false"
 
-          print(f"Previous tag: {last_tag}")
+          print(f"Latest tag: {last_tag}")
+          print(f"Cargo.toml version: {cargo_version}")
+          print(f"Bump base: {base_label}")
           print(f"Commits analyzed: {len(hashes)}")
           print(f"Bump: {bump}")
           print(f"New version: {new_version or '(none — skipping release)'}")
 
+          # previous_tag stays as the actual latest git tag so the
+          # changelog step can use it as a `git log <prev>..HEAD` range.
+          # bump_base is the synthetic baseline used for SemVer arithmetic.
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"previous_tag={last_tag}\n")
+              f.write(f"bump_base={base_label}\n")
               f.write(f"new_version={new_version}\n")
               f.write(f"release_needed={release_needed}\n")
               f.write(f"bump={bump}\n")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "mf4-rs"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "byteorder",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mf4-rs"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 description = "mf4-rs is a Rust library for working with ASAM MDF 4 (Measurement Data Format) files."
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mf4-rs"
-version = "0.1.0"
+version = "1.0.0"
 description = "Python bindings for mf4-rs - A minimal library for working with ASAM MDF 4 measurement files"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Fixes the version-downgrade bug exposed by the first run of the release pipeline (PR #57 → tag `v0.1.0`):

- **Root cause:** `compute-bump` only looked at the latest `v*` git tag and fell back to `v0.0.0` when none existed. With `Cargo.toml` at `version = "1.0.0"` and no `v1.0.0` tag in the repo, `feat:` (minor) computed `v0.0.0 → v0.1.0` — a downgrade — and the workflow `sed`'d `Cargo.toml` / `pyproject.toml` from `1.0.0` to `0.1.0`, then published `mf4-rs 0.1.0` to crates.io alongside the previously published `1.0.0`.
- **Fix:** take the **max of the latest `v*` tag and the version declared in `Cargo.toml`** as the bump base. A hand-set Cargo.toml version (or one inherited from a registry publish before the workflow was wired up) is now honored, and the pipeline never downgrades.
- The actual previous git tag is still emitted as `previous_tag` so the changelog step's `git log <prev>..HEAD` range keeps working.
- `Cargo.toml`, `pyproject.toml`, and `Cargo.lock` are restored to `1.0.0`.

## Expected pipeline behavior after merge

With this PR's `feat:` title:

| compute-bump output | value |
|---|---|
| `last_tag` | `v0.1.0` |
| `cargo_version` | `1.0.0` |
| `bump_base` | `v1.0.0` |
| `bump` | `minor` |
| `new_version` | `1.1.0` |
| `previous_tag` (output) | `v0.1.0` |

Then `bump-and-tag` should write `1.1.0` into `Cargo.toml` / `pyproject.toml` / `Cargo.lock`, prepend a `## v1.1.0 — <date>` section to `CHANGELOG.md`, push `chore(release): v1.1.0` and the `v1.1.0` tag, and the publish jobs should land `mf4-rs 1.1.0` on PyPI and crates.io.

## Test plan

- [ ] PR title lint passes.
- [ ] After squash-merge, `compute-bump` logs show `Bump base: v1.0.0`, `Bump: minor`, `New version: 1.1.0`.
- [ ] `bump-and-tag` produces `chore(release): v1.1.0` and tag `v1.1.0`.
- [ ] Wheel + sdist builds succeed for all targets.
- [ ] `publish-pypi` lands `mf4-rs==1.1.0` on https://pypi.org/project/mf4-rs/.
- [ ] `publish-crates` lands `mf4-rs = "1.1.0"` on https://crates.io/crates/mf4-rs.
- [ ] The follow-up `chore(release): v1.1.0` commit produces a no-op release run (`bump=none`).

## Notes / follow-ups for the maintainer

- `mf4-rs 0.1.0` on crates.io is a stale slot pointing at code that's actually post-1.0.0. Consider [yanking it](https://doc.rust-lang.org/cargo/commands/cargo-yank.html): `cargo yank --version 0.1.0 mf4-rs`. Yank is reversible; deletion is not allowed.
- Same applies to `mf4-rs 0.1.0` on PyPI if that publish completes.

https://claude.ai/code/session_017g8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYii5G3KL7HsQ8hC96139K)_