### PR TITLE
fix(ci): build a single abi3 wheel per OS/arch for Python 3.8+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,7 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           manylinux: auto
           sccache: "true"
       - uses: actions/upload-artifact@v4
@@ -265,18 +265,8 @@ jobs:
         include:
           - os: macos-13
             target: x86_64
-            pythons: |
-              3.8
-              3.9
-              3.10
-              3.11
-              3.12
           - os: macos-14
             target: aarch64
-            pythons: |
-              3.10
-              3.11
-              3.12
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -284,11 +274,11 @@ jobs:
           ref: ${{ needs.bump-and-tag.outputs.tag }}
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.pythons }}
+          python-version: "3.12"
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: "true"
       - uses: actions/upload-artifact@v4
         with:
@@ -309,16 +299,11 @@ jobs:
           ref: ${{ needs.bump-and-tag.outputs.tag }}
       - uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.8
-            3.9
-            3.10
-            3.11
-            3.12
+          python-version: "3.12"
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: "true"
       - uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Python bindings
-pyo3 = { version = "0.21", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.21", features = ["extension-module", "abi3-py38"], optional = true }
 numpy = { version = "0.21", optional = true }
 
 [features]


### PR DESCRIPTION
## Summary

Fixes the wheel-build matrix that's been failing on every release run, blocking `publish-pypi` (we have `mf4-rs 1.0.0` and `1.1.0` on crates.io but **nothing on PyPI**).

### Root cause

`release.yml` calls maturin with `--find-interpreter`, which discovers every Python on the runner. Modern manylinux containers and GitHub-hosted Linux runners now ship Python 3.13 by default. **PyO3 0.21 supports Python 3.7–3.12 only**, and its build script aborts on 3.13:

```
error: the configured Python interpreter version (3.13) is newer than
       PyO3's maximum supported version (3.12)
```

Reproduced locally with `maturin build --release --find-interpreter`.

### Fix

Switch to PyO3's **stable ABI** (`abi3-py38`):

- `Cargo.toml`: add `abi3-py38` to the `pyo3` features so the C extension is built against the stable Python ABI.
- `release.yml`: drop `--find-interpreter` from all three OS jobs and drop the multi-version Python matrix from macOS / Windows. Each job now produces **one** `cp38-abi3` wheel per OS/arch — total 5 wheels (was up to ~25), which also cuts CI time considerably.

### Local verification

```
$ maturin build --release --out dist
📦 Built wheel for abi3 Python ≥ 3.8 to dist/mf4_rs-1.1.0-cp38-abi3-manylinux_2_35_x86_64.whl

$ for py in python3.10 python3.11 python3.12 python3.13; do
    $py -m venv /tmp/v && /tmp/v/bin/pip install dist/*.whl
    /tmp/v/bin/python -c "import mf4_rs"
  done
# All four Pythons import cleanly, including 3.13 (the version that broke the previous build).
```

### Expected pipeline behavior after merge

This PR is a `fix(ci):` (patch bump). After squash-merge:

| compute-bump output | value |
|---|---|
| `last_tag` | `v1.1.0` |
| `cargo_version` | `1.1.0` |
| `bump_base` | `v1.1.0` |
| `bump` | `patch` |
| `new_version` | `1.1.1` |

Then `bump-and-tag` writes `1.1.1` everywhere, tags `v1.1.1`, and the build/publish jobs run. With abi3 in place, all five wheel jobs (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x64) plus sdist should succeed, and `publish-pypi` will land **`mf4-rs 1.1.1` as the first version on PyPI**. `publish-crates` will land `1.1.1` on crates.io alongside `1.1.0`.

### Notes / follow-ups

- `mf4-rs 1.1.0` will not appear on PyPI — the v1.1.0 tag's wheel jobs will keep failing for the same reason. The `Release #3` run from yesterday is the queued/failing one; you may want to **cancel it** so the v1.1.1 run isn't blocked behind it (or, with `cancel-in-progress: false`, the v1.1.1 run will simply queue behind the failing v1.1.0 run; cancelling Release #3 unblocks it immediately).
- A separate, optional follow-up: switch `concurrency: cancel-in-progress: true` so a stuck run can never block a later one.

## Test plan

- [ ] PR title lint passes.
- [ ] After merge + you cancelling the stuck Release #3 if needed, `compute-bump` for the new run logs `Bump: patch`, `New version: 1.1.1`.
- [ ] All five wheel jobs go green.
- [ ] `publish-pypi` lands `mf4-rs==1.1.1` on https://pypi.org/project/mf4-rs/.
- [ ] `pip install mf4-rs` succeeds in a fresh venv on Python 3.10–3.13.
- [ ] `publish-crates` lands `mf4-rs = "1.1.1"` on https://crates.io/crates/mf4-rs.

https://claude.ai/code/session_017g8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYii5G3KL7HsQ8hC96139K)_