### PR TITLE
fix(ci): drop Intel Mac wheel to avoid macos-13 runner queue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,8 +263,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
-            target: x86_64
           - os: macos-14
             target: aarch64
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Drop the `macos-13` / Intel Mac entry from the wheel-build matrix to remove the macOS x86_64 runner queue as a publish-pypi blocker.

### Why

Release run #4 (for v1.1.1) sat at `Waiting for a runner to pick up this job...` on the macOS x86_64 (`macos-13`) job for 30+ minutes, holding up `publish-pypi` (which `needs:` all wheel jobs). macOS-hosted runners are billed at 10x Linux on GitHub-hosted infra and queue depth is unpredictable on free-tier accounts.

### What changes

```diff
   build-wheels-macos:
     strategy:
       matrix:
         include:
-          - os: macos-13
-            target: x86_64
           - os: macos-14
             target: aarch64
```

Apple Silicon (`macos-14` / `aarch64`) covers every Mac sold since late 2020. Combined with **abi3** (single wheel for Python 3.8+), Apple Silicon Macs on Python 3.8 – 3.13+ are still served by a single prebuilt wheel.

### Trade-off

**Intel Mac users (Macs from ~2020 and earlier) lose the prebuilt wheel.** They can still install via:

```
pip install mf4-rs --no-binary mf4-rs   # builds from sdist; needs Rust toolchain
```

If someone files an issue we can re-add `macos-13` later.

### Expected pipeline behavior

`fix(ci):` → patch bump → `v1.1.2`. After merge:

| Wheel job | Expected |
|---|---|
| Linux x86_64 | green |
| Linux aarch64 | green (QEMU; usually 5–10 min) |
| macOS aarch64 (`macos-14`) | green (no x86_64 sibling to wait for) |
| Windows x64 | green |
| sdist | green |

Then `publish-pypi` should land **`mf4-rs 1.1.2`** as the first version on PyPI, and `publish-crates` should land `1.1.2` on crates.io alongside `1.1.1`.

## Test plan

- [ ] PR title lint passes.
- [ ] After merge, `compute-bump` logs `Bump: patch`, `New version: 1.1.2`.
- [ ] All four wheel jobs go green; sdist green.
- [ ] `publish-pypi` lands `mf4-rs==1.1.2` on https://pypi.org/project/mf4-rs/.
- [ ] `pip install mf4-rs` succeeds on Linux (any arch), Apple Silicon Mac, Windows x64 across Python 3.8–3.13.
- [ ] `publish-crates` lands `mf4-rs = "1.1.2"` on https://crates.io/crates/mf4-rs.

### Note on Release #4

The currently-stuck v1.1.1 Release run is still queued. If macOS x86_64 ever picks up and succeeds before this PR merges, v1.1.1 will land on PyPI and this PR's run will produce v1.1.2 with the same binaries (just no Intel Mac wheel). If it doesn't, **cancelling Release #4 lets this PR's run start immediately**.

https://claude.ai/code/session_017g8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYii5G3KL7HsQ8hC96139K)_