### PR TITLE
fix: attach docstring to MdfException so help() works

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -2139,7 +2139,24 @@ fn merge_files(output: &str, first: &str, second: &str) -> PyResult<()> {
 
 /// The main Python module initialization function
 pub fn init_mf4_rs_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("MdfException", m.py().get_type_bound::<MdfException>())?;
+    let mdf_exception = m.py().get_type_bound::<MdfException>();
+    mdf_exception.setattr(
+        "__doc__",
+        "Exception raised by mf4_rs for any error originating from the \
+         underlying Rust library: malformed or unsupported MDF files, \
+         out-of-range indices, missing channels, I/O failures, conversion \
+         dependency cycles, attempts to use a finalized writer, missing \
+         optional dependencies (e.g. pandas), and so on.\n\n\
+         All public methods on PyMDF, PyMdfWriter, PyMdfIndex, and the \
+         module-level free functions raise this (or a subclass of \
+         Exception) on failure. Catch it as a single category to handle \
+         every mf4_rs failure path:\n\n\
+         >>> try:\n\
+         ...     mdf = mf4_rs.PyMDF(\"missing.mf4\")\n\
+         ... except mf4_rs.MdfException as e:\n\
+         ...     print(\"could not open:\", e)",
+    )?;
+    m.add("MdfException", mdf_exception)?;
     
     // Classes
     m.add_class::<PyMDF>()?;


### PR DESCRIPTION
## Summary

Follow-up to #63. The custom `MdfException` Python type is created with the `create_exception!` macro, which has no slot for `///` doc-comments — so `help(mf4_rs.MdfException)` returned an empty docstring while every other public name in the package now has one. Worse, the cross-references to `:class:`MdfException`` from the class/method docstrings added in #63 dead-ended at an undocumented type.

This PR sets `__doc__` on the exception class explicitly during module initialisation in `init_mf4_rs_module`, documenting:

- Which conditions raise it (malformed/unsupported MDF files, out-of-range indices, missing channels, I/O failures, conversion cycles, finalized writer, missing pandas, etc.).
- That all public reader/writer/index methods and free functions raise this on failure.
- A small catch example.

Why `fix:` and not `docs:` — `help()` not finding a docstring for a public exception class is a real defect users will hit; the previous documentation PR is incomplete without it.

No behavioural change; `cargo check --features pyo3` is clean.

## Test plan

- [x] `cargo check --features pyo3 --lib` succeeds
- [ ] `maturin develop --release && python -c "import mf4_rs; help(mf4_rs.MdfException)"` shows the new docstring
- [ ] Release pipeline cuts a patch bump (v1.3.0 → v1.3.1) and publishes to PyPI / crates.io

https://claude.ai/code/session_012azxzQEG23kjKVudKEdhmp

---
_Generated by [Claude Code](https://claude.ai/code/session_012azxzQEG23kjKVudKEdhmp)_