### PR TITLE
feat: preserve source/text/conversion blocks when cutting MDF files

### DIFF
--- a/src/cut.rs
+++ b/src/cut.rs
@@ -1,7 +1,137 @@
+use std::collections::HashMap;
+
+use crate::blocks::common::{BlockHeader, BlockParse};
+use crate::blocks::conversion::ConversionBlock;
+use crate::blocks::source_block::SourceBlock;
 use crate::error::MdfError;
-use crate::parsing::mdf_file::MdfFile;
 use crate::parsing::decoder::{decode_channel_value, DecodedValue};
+use crate::parsing::mdf_file::MdfFile;
 use crate::writer::MdfWriter;
+
+/// Recursively copy a referenced block (`##TX`, `##MD`, `##SI`, or `##CC`)
+/// from the source MDF mmap into the writer, rewriting any link fields so
+/// the new block points at freshly written copies of its dependencies.
+///
+/// Returns the file offset of the new block, or `Ok(0)` when `src_addr` is
+/// `0`, the offset is out of range, or the block type is not one of the
+/// handled kinds. Already-cloned source addresses are deduplicated through
+/// `cache`.
+fn clone_block_to_writer(
+    writer: &mut MdfWriter,
+    mmap: &[u8],
+    src_addr: u64,
+    cache: &mut HashMap<u64, u64>,
+) -> Result<u64, MdfError> {
+    if src_addr == 0 {
+        return Ok(0);
+    }
+    if let Some(&dst) = cache.get(&src_addr) {
+        return Ok(dst);
+    }
+    let offset = src_addr as usize;
+    if offset + 24 > mmap.len() {
+        return Ok(0);
+    }
+    let header = BlockHeader::from_bytes(&mmap[offset..offset + 24])?;
+    let total_len = header.block_len as usize;
+    if total_len < 24 || offset + total_len > mmap.len() {
+        return Ok(0);
+    }
+
+    let dst = match header.id.as_str() {
+        "##TX" | "##MD" => {
+            // Leaf blocks with no outgoing links: copy raw bytes verbatim.
+            writer.write_block(&mmap[offset..offset + total_len])?
+        }
+        "##SI" => {
+            let src_block = SourceBlock::from_bytes(&mmap[offset..offset + total_len])?;
+            // Reserve the cache slot before recursing to break cycles.
+            cache.insert(src_addr, 0);
+            let new_name = clone_block_to_writer(writer, mmap, src_block.name_addr, cache)?;
+            let new_path = clone_block_to_writer(writer, mmap, src_block.path_addr, cache)?;
+            let new_comment =
+                clone_block_to_writer(writer, mmap, src_block.comment_addr, cache)?;
+            // SourceBlock has no `to_bytes`, so patch the original block's
+            // bytes in place. The link layout is fixed: name/path/comment at
+            // offsets 24/32/40 (only the slots actually referenced by
+            // `header.links_nr` are touched).
+            let mut bytes = mmap[offset..offset + total_len].to_vec();
+            let link_count = header.links_nr as usize;
+            if link_count >= 1 {
+                bytes[24..32].copy_from_slice(&new_name.to_le_bytes());
+            }
+            if link_count >= 2 {
+                bytes[32..40].copy_from_slice(&new_path.to_le_bytes());
+            }
+            if link_count >= 3 {
+                bytes[40..48].copy_from_slice(&new_comment.to_le_bytes());
+            }
+            writer.write_block(&bytes)?
+        }
+        "##CC" => {
+            let src_block = ConversionBlock::from_bytes(&mmap[offset..offset + total_len])?;
+            cache.insert(src_addr, 0);
+            let new_tx_name = clone_block_to_writer(
+                writer,
+                mmap,
+                src_block.cc_tx_name.unwrap_or(0),
+                cache,
+            )?;
+            let new_md_unit = clone_block_to_writer(
+                writer,
+                mmap,
+                src_block.cc_md_unit.unwrap_or(0),
+                cache,
+            )?;
+            let new_md_comment = clone_block_to_writer(
+                writer,
+                mmap,
+                src_block.cc_md_comment.unwrap_or(0),
+                cache,
+            )?;
+            let new_cc_inverse = clone_block_to_writer(
+                writer,
+                mmap,
+                src_block.cc_cc_inverse.unwrap_or(0),
+                cache,
+            )?;
+            let mut new_refs = Vec::with_capacity(src_block.cc_ref.len());
+            for &r in &src_block.cc_ref {
+                new_refs.push(clone_block_to_writer(writer, mmap, r, cache)?);
+            }
+            let new_cc = ConversionBlock {
+                header: src_block.header.clone(),
+                cc_tx_name: (new_tx_name != 0).then_some(new_tx_name),
+                cc_md_unit: (new_md_unit != 0).then_some(new_md_unit),
+                cc_md_comment: (new_md_comment != 0).then_some(new_md_comment),
+                cc_cc_inverse: (new_cc_inverse != 0).then_some(new_cc_inverse),
+                cc_ref: new_refs,
+                cc_type: src_block.cc_type.clone(),
+                cc_precision: src_block.cc_precision,
+                cc_flags: src_block.cc_flags,
+                cc_ref_count: src_block.cc_ref_count,
+                cc_val_count: src_block.cc_val_count,
+                cc_phy_range_min: src_block.cc_phy_range_min,
+                cc_phy_range_max: src_block.cc_phy_range_max,
+                cc_val: src_block.cc_val.clone(),
+                formula: None,
+                resolved_texts: None,
+                resolved_conversions: None,
+                default_conversion: None,
+            };
+            writer.write_block(&new_cc.to_bytes()?)?
+        }
+        _ => 0,
+    };
+
+    if dst != 0 {
+        cache.insert(src_addr, dst);
+    } else {
+        // Drop the cycle-breaker placeholder if cloning ultimately failed.
+        cache.remove(&src_addr);
+    }
+    Ok(dst)
+}
 
 /// Cut a segment of an MDF file using **absolute** UNIX-epoch timestamps.
 ///
@@ -58,11 +188,11 @@ pub fn cut_mdf_by_utc_ns(
 /// * per-record invalidation bytes,
 /// * VLSD ("signal-based") channels — fresh `##SD` blocks are written in the
 ///   output, one entry per kept record, and the channel's `data` link is
-///   patched to point at them.
-///
-/// Per-channel conversion / source / metadata blocks are not re-emitted; the
-/// output channels are written without conversions attached. The master
-/// channel's conversion is still applied internally when filtering by time.
+///   patched to point at them,
+/// * per-channel `##CC` conversion, `##SI` source, and `##TX`/`##MD`
+///   unit / comment blocks (recursively, including nested conversion
+///   chains and source name/path/comment text), as well as the
+///   channel-group acquisition name, source, and comment blocks.
 ///
 /// # Arguments
 /// * `input_path` - Path to the source MF4 file
@@ -82,6 +212,12 @@ pub fn cut_mdf_by_time(
     let mut writer = MdfWriter::new(output_path)?;
     writer.init_mdf_file()?;
 
+    // Cache mapping source-file block addresses to their freshly written
+    // counterparts in the output. Shared across all channels/groups so a
+    // text/source/conversion block referenced from multiple places is only
+    // emitted once.
+    let mut block_cache: HashMap<u64, u64> = HashMap::new();
+
     for dg in &mdf.data_groups {
         let record_id_len = dg.block.record_id_len;
 
@@ -96,10 +232,39 @@ pub fn cut_mdf_by_time(
             let cg_id = writer.add_channel_group(prev_cg.as_deref(), |_| {})?;
             prev_cg = Some(cg_id.clone());
 
+            // Carry over the channel-group acq_name / acq_source / comment
+            // blocks from the source. Link offsets in the ##CG block:
+            //   40 = acq_name_addr, 48 = acq_source_addr, 64 = comment_addr.
+            let cg_pos = writer
+                .get_block_position(&cg_id)
+                .ok_or_else(|| MdfError::BlockLinkError(format!("cg '{}' not found", cg_id)))?;
+            let new_acq_name =
+                clone_block_to_writer(&mut writer, &mdf.mmap, cg.block.acq_name_addr, &mut block_cache)?;
+            if new_acq_name != 0 {
+                writer.update_link(cg_pos + 40, new_acq_name)?;
+            }
+            let new_acq_source = clone_block_to_writer(
+                &mut writer,
+                &mdf.mmap,
+                cg.block.acq_source_addr,
+                &mut block_cache,
+            )?;
+            if new_acq_source != 0 {
+                writer.update_link(cg_pos + 48, new_acq_source)?;
+            }
+            let new_cg_comment =
+                clone_block_to_writer(&mut writer, &mdf.mmap, cg.block.comment_addr, &mut block_cache)?;
+            if new_cg_comment != 0 {
+                writer.update_link(cg_pos + 64, new_cg_comment)?;
+            }
+
             // Re-create channel blocks in the output. Stale link addresses
             // pointing into the source file are zeroed out so the resulting
-            // channel block is self-contained. The VLSD `data` link is
-            // patched later by `finish_signal_data_block`.
+            // channel block is self-contained. After the channel block is
+            // written, source/conversion/unit/comment blocks are cloned from
+            // the source file and the channel's links are patched to point
+            // at the freshly written copies. The VLSD `data` link is patched
+            // later by `finish_signal_data_block`.
             let mut prev_cn: Option<String> = None;
             // (out_cn_id, source_channel_index, is_vlsd)
             let mut out_channels: Vec<(String, usize, bool)> = Vec::new();
@@ -108,6 +273,13 @@ pub fn cut_mdf_by_time(
                 block.resolve_name(&mdf.mmap)?;
 
                 let is_vlsd = block.channel_type == 1 && block.data != 0;
+
+                // Capture the source-file link addresses before zeroing them
+                // on the block we hand to `add_channel`.
+                let src_source_addr = block.source_addr;
+                let src_conversion_addr = block.conversion_addr;
+                let src_unit_addr = block.unit_addr;
+                let src_comment_addr = block.comment_addr;
 
                 // Drop links to source-file blocks we do not re-emit. Without
                 // this, the new file would carry pointers into garbage.
@@ -122,6 +294,39 @@ pub fn cut_mdf_by_time(
                 let cn_id = writer.add_channel(&cg_id, prev_cn.as_deref(), |c| {
                     *c = block.clone();
                 })?;
+
+                // Clone source/conversion/unit/comment blocks (recursively
+                // following nested links) and patch the channel's links.
+                // Channel block link offsets: source 48, conversion 56,
+                // unit 72, comment 80.
+                let cn_pos = writer.get_block_position(&cn_id).ok_or_else(|| {
+                    MdfError::BlockLinkError(format!("cn '{}' not found", cn_id))
+                })?;
+                let new_source =
+                    clone_block_to_writer(&mut writer, &mdf.mmap, src_source_addr, &mut block_cache)?;
+                if new_source != 0 {
+                    writer.update_link(cn_pos + 48, new_source)?;
+                }
+                let new_conv = clone_block_to_writer(
+                    &mut writer,
+                    &mdf.mmap,
+                    src_conversion_addr,
+                    &mut block_cache,
+                )?;
+                if new_conv != 0 {
+                    writer.update_link(cn_pos + 56, new_conv)?;
+                }
+                let new_unit =
+                    clone_block_to_writer(&mut writer, &mdf.mmap, src_unit_addr, &mut block_cache)?;
+                if new_unit != 0 {
+                    writer.update_link(cn_pos + 72, new_unit)?;
+                }
+                let new_comment =
+                    clone_block_to_writer(&mut writer, &mdf.mmap, src_comment_addr, &mut block_cache)?;
+                if new_comment != 0 {
+                    writer.update_link(cn_pos + 80, new_comment)?;
+                }
+
                 prev_cn = Some(cn_id.clone());
                 out_channels.push((cn_id, idx, is_vlsd));
             }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -300,22 +300,29 @@ fn cut_does_not_double_apply_conversions() -> Result<(), MdfError> {
         0.5,
     )?;
 
-    // The cut output drops conversion blocks (out of scope per plan), so the
-    // value channel reads as raw u32. The raw values must still equal the
-    // source raw values [3, 4, 5] — i.e. cut must NOT have stored the
-    // physical values [16, 18, 20] in the raw slots.
+    // The cut output preserves the linear conversion block, so the value
+    // channel reads back as the same physical values produced by the source
+    // file: phys = 10 + 2*raw → raws [3, 4, 5] map to [16.0, 18.0, 20.0].
+    // The double-apply regression would manifest as cut having stored the
+    // already-converted values in the raw slots; applying the preserved
+    // conversion on top would then produce [42.0, 46.0, 50.0].
     let mdf = MDF::from_file(output.to_str().unwrap())?;
     let chs = mdf.channel_groups()[0].channels();
     let vals = chs[1].values()?;
     assert_eq!(vals.len(), 3);
-    let raws: Vec<u64> = vals
+    let phys: Vec<f64> = vals
         .iter()
         .map(|v| match v {
-            Some(DecodedValue::UnsignedInteger(u)) => *u,
+            Some(DecodedValue::Float(f)) => *f,
             other => panic!("unexpected cut vals: {:?}", other),
         })
         .collect();
-    assert_eq!(raws, vec![3, 4, 5], "cut stored converted values: {:?}", raws);
+    assert_eq!(
+        phys,
+        vec![16.0, 18.0, 20.0],
+        "cut produced unexpected phys values: {:?}",
+        phys,
+    );
 
     std::fs::remove_file(input)?;
     std::fs::remove_file(output)?;

--- a/tests/cut_preserves_metadata.rs
+++ b/tests/cut_preserves_metadata.rs
@@ -1,0 +1,283 @@
+//! End-to-end checks that `cut_mdf_by_time` preserves the per-channel
+//! source/text/conversion blocks from the input file.
+
+use mf4_rs::api::mdf::MDF;
+use mf4_rs::blocks::common::{BlockHeader, DataType};
+use mf4_rs::blocks::conversion::{ConversionBlock, ConversionType};
+use mf4_rs::blocks::text_block::TextBlock;
+use mf4_rs::error::MdfError;
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::writer::MdfWriter;
+
+fn cleanup(path: &std::path::Path) {
+    if path.exists() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Write a simple SI block with name/path/comment, return its block id.
+fn write_source_block(
+    writer: &mut MdfWriter,
+    id: &str,
+    name: &str,
+    path: &str,
+    comment: &str,
+) -> Result<(), MdfError> {
+    // Emit referenced TX blocks first.
+    let name_id = format!("{}_name", id);
+    let path_id = format!("{}_path", id);
+    let comment_id = format!("{}_comment", id);
+    writer.write_block_with_id(&TextBlock::new(name).to_bytes()?, &name_id)?;
+    writer.write_block_with_id(&TextBlock::new(path).to_bytes()?, &path_id)?;
+    writer.write_block_with_id(&TextBlock::new(comment).to_bytes()?, &comment_id)?;
+
+    // Hand-build the SI block: 24-byte header + 3*8-byte links + 8 bytes of
+    // data/padding = 56 bytes total.
+    let header = BlockHeader {
+        id: "##SI".into(),
+        reserved0: 0,
+        block_len: 56,
+        links_nr: 3,
+    };
+    let mut bytes = Vec::with_capacity(56);
+    bytes.extend_from_slice(&header.to_bytes()?);
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // name_addr — patched below
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // path_addr — patched below
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // comment_addr — patched below
+    bytes.push(4); // source_type = TOOL
+    bytes.push(0); // bus_type = NONE
+    bytes.push(0); // flags
+    bytes.extend_from_slice(&[0u8; 5]); // reserved/padding
+    writer.write_block_with_id(&bytes, id)?;
+
+    // Patch links: name at offset 24, path 32, comment 40.
+    writer.update_block_link(id, 24, &name_id)?;
+    writer.update_block_link(id, 32, &path_id)?;
+    writer.update_block_link(id, 40, &comment_id)?;
+
+    Ok(())
+}
+
+#[test]
+fn cut_preserves_conversion_unit_comment_and_source() -> Result<(), MdfError> {
+    let input = std::env::temp_dir().join("cut_meta_input.mf4");
+    let output = std::env::temp_dir().join("cut_meta_output.mf4");
+    cleanup(&input);
+    cleanup(&output);
+
+    // 1. Build a source file with a time channel and a value channel that
+    //    has a linear conversion, a unit, a comment, and an SI source block.
+    {
+        let mut writer = MdfWriter::new(input.to_str().unwrap())?;
+        writer.init_mdf_file()?;
+        let cg_id = writer.add_channel_group(None, |_| {})?;
+
+        let time_id = writer.add_channel(&cg_id, None, |ch| {
+            ch.data_type = DataType::FloatLE;
+            ch.bit_count = 64;
+            ch.name = Some("Time".into());
+        })?;
+        writer.set_time_channel(&time_id)?;
+
+        let val_id = writer.add_channel(&cg_id, Some(&time_id), |ch| {
+            ch.data_type = DataType::UnsignedIntegerLE;
+            ch.bit_count = 32;
+            ch.name = Some("Val".into());
+        })?;
+
+        // Conversion: phys = 1 + 3 * raw → raw=2 → phys=7, raw=3 → phys=10, etc.
+        let conv = ConversionBlock {
+            header: BlockHeader { id: "##CC".into(), reserved0: 0, block_len: 0, links_nr: 0 },
+            cc_tx_name: None,
+            cc_md_unit: None,
+            cc_md_comment: None,
+            cc_cc_inverse: None,
+            cc_ref: Vec::new(),
+            cc_type: ConversionType::Linear,
+            cc_precision: 0,
+            cc_flags: 0,
+            cc_ref_count: 0,
+            cc_val_count: 2,
+            cc_phy_range_min: None,
+            cc_phy_range_max: None,
+            cc_val: vec![1.0, 3.0],
+            formula: None,
+            resolved_texts: None,
+            resolved_conversions: None,
+            default_conversion: None,
+        };
+        let cc_id = "cc_lin".to_string();
+        writer.write_block_with_id(&conv.to_bytes()?, &cc_id)?;
+        // Patch val channel's conversion link (offset 56 in ##CN block).
+        writer.update_block_link(&val_id, 56, &cc_id)?;
+
+        // Unit text block (link offset 72 in ##CN).
+        let unit_id = "tx_unit".to_string();
+        writer.write_block_with_id(&TextBlock::new("kPa").to_bytes()?, &unit_id)?;
+        writer.update_block_link(&val_id, 72, &unit_id)?;
+
+        // Comment text block (link offset 80 in ##CN).
+        let comment_id = "tx_comment".to_string();
+        writer.write_block_with_id(
+            &TextBlock::new("pressure sensor").to_bytes()?,
+            &comment_id,
+        )?;
+        writer.update_block_link(&val_id, 80, &comment_id)?;
+
+        // Source info block (link offset 48 in ##CN).
+        write_source_block(&mut writer, "si_val", "ECU-A", "/path/to/ecu", "ecu comment")?;
+        writer.update_block_link(&val_id, 48, "si_val")?;
+
+        writer.start_data_block_for_cg(&cg_id, 0)?;
+        for i in 0..10u64 {
+            writer.write_record(
+                &cg_id,
+                &[
+                    DecodedValue::Float(i as f64 * 0.1),
+                    DecodedValue::UnsignedInteger(i),
+                ],
+            )?;
+        }
+        writer.finish_data_block(&cg_id)?;
+        writer.finalize()?;
+    }
+
+    // 2. Sanity check: the source file reads back the metadata as expected.
+    {
+        let mdf = MDF::from_file(input.to_str().unwrap())?;
+        let chs = mdf.channel_groups()[0].channels();
+        let val = &chs[1];
+        assert_eq!(val.unit()?.as_deref(), Some("kPa"));
+        assert_eq!(val.comment()?.as_deref(), Some("pressure sensor"));
+        let src = val.source()?.expect("source info");
+        assert_eq!(src.name.as_deref(), Some("ECU-A"));
+        assert_eq!(src.path.as_deref(), Some("/path/to/ecu"));
+        assert_eq!(src.comment.as_deref(), Some("ecu comment"));
+
+        // Conversion applied: raw=3 → phys=10.
+        let vals = val.values()?;
+        if let Some(DecodedValue::Float(v)) = vals[3] {
+            assert!((v - 10.0).abs() < 1e-9, "source phys[3] = {}", v);
+        } else {
+            panic!("unexpected source vals[3]: {:?}", vals[3]);
+        }
+    }
+
+    // 3. Cut a slice and verify all of the per-channel metadata survives.
+    mf4_rs::cut::cut_mdf_by_time(
+        input.to_str().unwrap(),
+        output.to_str().unwrap(),
+        0.2,
+        0.5,
+    )?;
+
+    let mdf = MDF::from_file(output.to_str().unwrap())?;
+    let groups = mdf.channel_groups();
+    assert_eq!(groups.len(), 1);
+    let chs = groups[0].channels();
+    assert_eq!(chs.len(), 2);
+    let val = &chs[1];
+
+    // Unit, comment, and source info round-tripped.
+    assert_eq!(val.unit()?.as_deref(), Some("kPa"), "unit was lost");
+    assert_eq!(
+        val.comment()?.as_deref(),
+        Some("pressure sensor"),
+        "comment was lost"
+    );
+    let src = val.source()?.expect("source info missing after cut");
+    assert_eq!(src.name.as_deref(), Some("ECU-A"));
+    assert_eq!(src.path.as_deref(), Some("/path/to/ecu"));
+    assert_eq!(src.comment.as_deref(), Some("ecu comment"));
+
+    // Conversion still applied: raws [2,3,4,5] → phys [7,10,13,16].
+    let vals = val.values()?;
+    let phys: Vec<f64> = vals
+        .iter()
+        .map(|v| match v {
+            Some(DecodedValue::Float(f)) => *f,
+            other => panic!("unexpected cut val: {:?}", other),
+        })
+        .collect();
+    assert_eq!(
+        phys,
+        vec![7.0, 10.0, 13.0, 16.0],
+        "conversion was not preserved or was double-applied"
+    );
+
+    cleanup(&input);
+    cleanup(&output);
+    Ok(())
+}
+
+#[test]
+fn cut_preserves_chained_value_to_text_conversion() -> Result<(), MdfError> {
+    let input = std::env::temp_dir().join("cut_v2t_input.mf4");
+    let output = std::env::temp_dir().join("cut_v2t_output.mf4");
+    cleanup(&input);
+    cleanup(&output);
+
+    // Source file with a value-to-text conversion (which references multiple
+    // ##TX blocks via cc_ref). cut should clone all of those.
+    {
+        let mut writer = MdfWriter::new(input.to_str().unwrap())?;
+        writer.init_mdf_file()?;
+        let cg_id = writer.add_channel_group(None, |_| {})?;
+        let time_id = writer.add_channel(&cg_id, None, |ch| {
+            ch.data_type = DataType::FloatLE;
+            ch.bit_count = 64;
+            ch.name = Some("Time".into());
+        })?;
+        writer.set_time_channel(&time_id)?;
+        let val_id = writer.add_channel(&cg_id, Some(&time_id), |ch| {
+            ch.data_type = DataType::UnsignedIntegerLE;
+            ch.bit_count = 32;
+            ch.name = Some("State".into());
+        })?;
+        writer.add_value_to_text_conversion(
+            &[(0, "OFF"), (1, "ON"), (2, "FAULT")],
+            "UNKNOWN",
+            Some(&val_id),
+        )?;
+
+        writer.start_data_block_for_cg(&cg_id, 0)?;
+        for (i, code) in (0u64..6).zip([0u64, 1, 2, 1, 0, 99]) {
+            writer.write_record(
+                &cg_id,
+                &[
+                    DecodedValue::Float(i as f64 * 0.1),
+                    DecodedValue::UnsignedInteger(code),
+                ],
+            )?;
+        }
+        writer.finish_data_block(&cg_id)?;
+        writer.finalize()?;
+    }
+
+    mf4_rs::cut::cut_mdf_by_time(
+        input.to_str().unwrap(),
+        output.to_str().unwrap(),
+        0.0,
+        1.0,
+    )?;
+
+    let mdf = MDF::from_file(output.to_str().unwrap())?;
+    let chs = mdf.channel_groups()[0].channels();
+    let vals = chs[1].values()?;
+    let texts: Vec<String> = vals
+        .iter()
+        .map(|v| match v {
+            Some(DecodedValue::String(s)) => s.clone(),
+            other => panic!("expected string, got {:?}", other),
+        })
+        .collect();
+    assert_eq!(
+        texts,
+        vec!["OFF", "ON", "FAULT", "ON", "OFF", "UNKNOWN"],
+        "value-to-text conversion was not preserved across cut"
+    );
+
+    cleanup(&input);
+    cleanup(&output);
+    Ok(())
+}


### PR DESCRIPTION
`cut_mdf_by_time` previously zeroed out per-channel `source_addr`,
`conversion_addr`, `unit_addr`, and `comment_addr` links, dropping all
referenced ##SI, ##CC, ##TX, and ##MD blocks from the trimmed output.
Channel-group `acq_name`/`acq_source`/`comment` were similarly lost.

The cut routine now recursively clones those blocks from the source
mmap into the output writer, rewriting nested links (SI name/path/
comment, CC fixed links and `cc_ref` chains) so each new block is
self-contained, and patches the channel and channel-group links to
point at the freshly written copies. Cloning is deduplicated through
an address cache so blocks shared across multiple channels are only
written once.

The existing `cut_does_not_double_apply_conversions` regression test
is updated to assert physical values now round-trip via the preserved
conversion (rather than the previous behavior of dropping it). A new
`cut_preserves_metadata` test file covers conversion + unit + comment
+ source preservation and value-to-text conversion chains.