### PR TITLE
feat: preserve source HD start time when cutting MDF files

### DIFF
--- a/src/cut.rs
+++ b/src/cut.rs
@@ -212,6 +212,17 @@ pub fn cut_mdf_by_time(
     let mut writer = MdfWriter::new(output_path)?;
     writer.init_mdf_file()?;
 
+    // Anchor the cut output to the same wall-clock as the source. Without this
+    // the writer's default HD timestamp (a fixed non-epoch value) would be
+    // emitted, breaking absolute-time interpretation of the kept records.
+    writer.set_start_time(
+        mdf.header.abs_time,
+        mdf.header.tz_offset,
+        mdf.header.daylight_save_time,
+        mdf.header.time_flags,
+        mdf.header.time_quality,
+    )?;
+
     // Cache mapping source-file block addresses to their freshly written
     // counterparts in the output. Shared across all channels/groups so a
     // text/source/conversion block referenced from multiple places is only

--- a/src/writer/mdf_writer/init.rs
+++ b/src/writer/mdf_writer/init.rs
@@ -22,6 +22,37 @@ impl MdfWriter {
         Ok((id_pos, hd_pos))
     }
 
+    /// Overwrite the start-time fields of the file's `##HD` block.
+    ///
+    /// `init_mdf_file` writes default time metadata, which loses the
+    /// wall-clock anchor when authoring a file derived from another (for
+    /// example, [`crate::cut::cut_mdf_by_time`] copying a window out of a
+    /// source MF4). Call this after `init_mdf_file` to anchor the output
+    /// to a specific timestamp.
+    ///
+    /// HD field offsets touched: 72 (`abs_time` u64), 80 (`tz_offset` i16),
+    /// 82 (`daylight_save_time` i16), 84 (`time_flags` u8),
+    /// 85 (`time_quality` u8).
+    pub fn set_start_time(
+        &mut self,
+        abs_time_ns: u64,
+        tz_offset_min: i16,
+        dst_offset_min: i16,
+        time_flags: u8,
+        time_quality: u8,
+    ) -> Result<(), MdfError> {
+        self.update_block_u64("hd_block", 72, abs_time_ns)?;
+        let tz = tz_offset_min.to_le_bytes();
+        let dst = dst_offset_min.to_le_bytes();
+        self.update_block_u8("hd_block", 80, tz[0])?;
+        self.update_block_u8("hd_block", 81, tz[1])?;
+        self.update_block_u8("hd_block", 82, dst[0])?;
+        self.update_block_u8("hd_block", 83, dst[1])?;
+        self.update_block_u8("hd_block", 84, time_flags)?;
+        self.update_block_u8("hd_block", 85, time_quality)?;
+        Ok(())
+    }
+
     /// Adds a data group block to the file and links it from the header block.
     pub fn add_data_group(&mut self, prev_dg_id: Option<&str>) -> Result<String, MdfError> {
         let dg_count = self.block_positions.keys().filter(|k| k.starts_with("dg_")).count();

--- a/tests/cut_utc.rs
+++ b/tests/cut_utc.rs
@@ -164,3 +164,115 @@ fn cut_by_utc_ns_errors_without_abs_time() -> Result<(), MdfError> {
     let _ = std::fs::remove_file(&out);
     Ok(())
 }
+
+/// `cut_mdf_by_time` must copy the source file's `HD.abs_time` (and the
+/// related tz / DST / time-flag metadata) into the cut output, so that
+/// kept records retain their wall-clock anchor.
+#[test]
+fn cut_preserves_source_start_time() -> Result<(), MdfError> {
+    use mf4_rs::blocks::common::BlockParse;
+    use mf4_rs::blocks::header_block::HeaderBlock;
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    let input = std::env::temp_dir().join("cut_preserves_start_input.mf4");
+    let output = std::env::temp_dir().join("cut_preserves_start_output.mf4");
+    for p in [&input, &output] {
+        if p.exists() {
+            std::fs::remove_file(p)?;
+        }
+    }
+
+    // Build a small file with a master + value channel.
+    let mut writer = MdfWriter::new(input.to_str().unwrap())?;
+    writer.init_mdf_file()?;
+    let cg_id = writer.add_channel_group(None, |_| {})?;
+    let time_id = writer.add_channel(&cg_id, None, |ch| {
+        ch.data_type = DataType::FloatLE;
+        ch.bit_count = 64;
+        ch.name = Some("Time".into());
+    })?;
+    writer.set_time_channel(&time_id)?;
+    writer.add_channel(&cg_id, Some(&time_id), |ch| {
+        ch.data_type = DataType::UnsignedIntegerLE;
+        ch.bit_count = 32;
+        ch.name = Some("Val".into());
+    })?;
+    writer.start_data_block_for_cg(&cg_id, 0)?;
+    for i in 0..5u64 {
+        writer.write_record(
+            &cg_id,
+            &[
+                DecodedValue::Float(i as f64 * 0.1),
+                DecodedValue::UnsignedInteger(i),
+            ],
+        )?;
+    }
+    writer.finish_data_block(&cg_id)?;
+    writer.finalize()?;
+
+    // Stamp distinctive timestamp metadata on the HD block so that defaults
+    // can't mask a regression. abs_time u64 at HD+72; tz/dst i16 at HD+80/82;
+    // time_flags u8 at HD+84; time_quality u8 at HD+85. HD lives at file
+    // offset 64 (right after the identification block).
+    let abs_time_ns: u64 = 1_700_000_000_000_000_000; // 2023-11-14T22:13:20Z
+    let tz_offset_min: i16 = 60; // CET
+    let dst_offset_min: i16 = 60;
+    let time_flags: u8 = 0x02;
+    let time_quality: u8 = 0x10;
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&input)?;
+        f.seek(SeekFrom::Start(64 + 72))?;
+        f.write_all(&abs_time_ns.to_le_bytes())?;
+        f.write_all(&tz_offset_min.to_le_bytes())?;
+        f.write_all(&dst_offset_min.to_le_bytes())?;
+        f.write_all(&[time_flags, time_quality])?;
+    }
+
+    mf4_rs::cut::cut_mdf_by_time(
+        input.to_str().unwrap(),
+        output.to_str().unwrap(),
+        0.1,
+        0.3,
+    )?;
+
+    // Sanity: the cut actually retained records (so we know the new HD wasn't
+    // skipped because of a degenerate code path).
+    let cut_mdf = MDF::from_file(output.to_str().unwrap())?;
+    let chs = cut_mdf.channel_groups()[0].channels();
+    let vals: Vec<u64> = chs[1]
+        .values()?
+        .iter()
+        .map(|v| match v {
+            Some(DecodedValue::UnsignedInteger(u)) => *u,
+            other => panic!("unexpected value: {:?}", other),
+        })
+        .collect();
+    assert_eq!(vals, vec![1, 2, 3]);
+    drop(cut_mdf);
+
+    // Re-read the cut output's HD block raw to confirm every preserved field.
+    let mut f = std::fs::File::open(&output)?;
+    let mut buf = [0u8; 104];
+    f.seek(SeekFrom::Start(64))?;
+    f.read_exact(&mut buf)?;
+    let hd = HeaderBlock::from_bytes(&buf)?;
+    assert_eq!(hd.abs_time, abs_time_ns, "abs_time must be carried over");
+    assert_eq!(hd.tz_offset, tz_offset_min, "tz_offset must be carried over");
+    assert_eq!(
+        hd.daylight_save_time, dst_offset_min,
+        "daylight_save_time must be carried over"
+    );
+    assert_eq!(hd.time_flags, time_flags, "time_flags must be carried over");
+    assert_eq!(
+        hd.time_quality, time_quality,
+        "time_quality must be carried over"
+    );
+
+    for p in [&input, &output] {
+        std::fs::remove_file(p)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
`cut_mdf_by_time` previously initialised the output's `##HD` block with
the writer's default timestamp, dropping the source file's wall-clock
anchor. Records kept by the cut therefore lost their absolute-time
context (and `cut_mdf_by_utc_ns` round-trips relied on a different
abs_time in the cut output than in the source).

Add a public `MdfWriter::set_start_time` helper that patches the HD
abs_time / tz_offset / daylight_save_time / time_flags / time_quality
fields, and call it from `cut_mdf_by_time` with the values parsed from
the source file. A new test in `tests/cut_utc.rs` stamps distinctive
metadata on the input HD block and asserts every field is carried over
to the cut output.

https://claude.ai/code/session_014JR3tuFGFzp85FbnkmQMFn