### PR TITLE
fix: rewrite VLSD inline offsets when cutting

### DIFF
--- a/src/cut.rs
+++ b/src/cut.rs
@@ -363,13 +363,40 @@ pub fn cut_mdf_by_time(
                 writer.start_signal_data_block(cn_id)?;
             }
 
-            // Build VLSD source iterators (lockstep with parent records).
-            let mut vlsd_iters: Vec<(String, Box<dyn Iterator<Item = Result<&[u8], MdfError>>>)> =
-                Vec::new();
+            // Build VLSD source iterators (lockstep with parent records). For
+            // each VLSD channel we also record the inline-slot location and
+            // size in the parent record, plus a running offset into the new
+            // ##SD block. The inline slot in MDF4 is the byte offset within
+            // the SD data section where this entry lives — readers (e.g.
+            // asammdf) use it to look up the entry. Since we are writing a
+            // freshly numbered SD block, we must overwrite the source-file
+            // offsets with offsets valid in the output.
+            //
+            // Per spec, the slot starts at `record_id_len + byte_offset` and
+            // is `bit_count / 8` bytes wide. mf4-rs writes VLSD entries
+            // sequentially as `[u32 length][bytes]`, so each entry advances
+            // the running offset by `4 + payload.len()`.
+            struct VlsdState<'a> {
+                cn_id: String,
+                slot_off: usize,
+                slot_size: usize,
+                next_offset: u64,
+                iter: Box<dyn Iterator<Item = Result<&'a [u8], MdfError>> + 'a>,
+            }
+            let mut vlsd_states: Vec<VlsdState> = Vec::new();
             for (cn_id, src_idx, is_vlsd) in &out_channels {
                 if *is_vlsd {
+                    let ch_block = &cg.raw_channels[*src_idx].block;
+                    let slot_size = (ch_block.bit_count / 8) as usize;
+                    let slot_off = record_id_len as usize + ch_block.byte_offset as usize;
                     let it = cg.raw_channels[*src_idx].records(dg, cg, &mdf.mmap)?;
-                    vlsd_iters.push((cn_id.clone(), it));
+                    vlsd_states.push(VlsdState {
+                        cn_id: cn_id.clone(),
+                        slot_off,
+                        slot_size,
+                        next_offset: 0,
+                        iter: it,
+                    });
                 }
             }
 
@@ -391,9 +418,9 @@ pub fn cut_mdf_by_time(
                     // Pull one VLSD entry per VLSD channel in lockstep with
                     // the parent record, regardless of whether we keep the
                     // record. This keeps the iterators aligned.
-                    let mut vlsd_payloads: Vec<Vec<u8>> = Vec::with_capacity(vlsd_iters.len());
-                    for (_, iter) in vlsd_iters.iter_mut() {
-                        match iter.next() {
+                    let mut vlsd_payloads: Vec<Vec<u8>> = Vec::with_capacity(vlsd_states.len());
+                    for state in vlsd_states.iter_mut() {
+                        match state.iter.next() {
                             Some(Ok(slice)) => vlsd_payloads.push(slice.to_vec()),
                             Some(Err(e)) => return Err(e),
                             None => {
@@ -440,11 +467,45 @@ pub fn cut_mdf_by_time(
                     };
 
                     if keep {
-                        writer.write_raw_record(&cg_id, record_chunk)?;
-                        for ((cn_id, _), payload) in
-                            vlsd_iters.iter().zip(vlsd_payloads.iter())
-                        {
-                            writer.write_signal_data(cn_id, payload)?;
+                        // Patch each VLSD inline slot in the parent record so
+                        // the offset points at the entry's location in the
+                        // freshly written ##SD block. Without this fix-up,
+                        // mf4-rs's own reader still works (it walks SD entries
+                        // sequentially) but spec-conformant readers like
+                        // asammdf — which use the inline offset to locate the
+                        // entry — will produce wrong/short results.
+                        let needs_patch = vlsd_states
+                            .iter()
+                            .any(|s| s.slot_size > 0 && s.slot_off + s.slot_size <= record_chunk.len());
+                        if needs_patch {
+                            let mut patched: Vec<u8> = record_chunk.to_vec();
+                            for (state, payload) in vlsd_states.iter().zip(vlsd_payloads.iter()) {
+                                if state.slot_size == 0 {
+                                    continue;
+                                }
+                                let end = state.slot_off + state.slot_size;
+                                if end > patched.len() {
+                                    continue;
+                                }
+                                let off_bytes = state.next_offset.to_le_bytes();
+                                let copy_len = state.slot_size.min(off_bytes.len());
+                                patched[state.slot_off..state.slot_off + copy_len]
+                                    .copy_from_slice(&off_bytes[..copy_len]);
+                                // Zero any trailing bytes when the slot is
+                                // wider than 8 (extremely unusual for VLSD).
+                                for b in &mut patched[state.slot_off + copy_len..end] {
+                                    *b = 0;
+                                }
+                                let _ = payload; // not used here; advance below
+                            }
+                            writer.write_raw_record(&cg_id, &patched)?;
+                        } else {
+                            writer.write_raw_record(&cg_id, record_chunk)?;
+                        }
+                        for (state, payload) in vlsd_states.iter_mut().zip(vlsd_payloads.iter()) {
+                            writer.write_signal_data(&state.cn_id, payload)?;
+                            state.next_offset =
+                                state.next_offset.saturating_add(4 + payload.len() as u64);
                         }
                     }
                 }

--- a/tests/cut_vlsd.rs
+++ b/tests/cut_vlsd.rs
@@ -123,6 +123,136 @@ fn cut_preserves_vlsd_byte_channel() -> Result<(), MdfError> {
     Ok(())
 }
 
+/// Per the MDF4 spec, the parent record of a VLSD channel carries the byte
+/// offset of the entry within the linked SD block's data section. mf4-rs's own
+/// reader walks SD entries sequentially so it ignores that offset, but
+/// spec-conformant readers (e.g. asammdf) use it for lookup. Cutting must
+/// rewrite each kept record's inline slot to point at the entry's location in
+/// the freshly written ##SD block — otherwise the cut output is unreadable by
+/// asammdf even though it still round-trips through mf4-rs.
+///
+/// This test simulates an asammdf-style file by populating non-zero inline
+/// offsets at write time, cuts a window, and asserts that the inline offsets
+/// in the cut output match the new SD layout (i.e. start at 0 and advance by
+/// `4 + payload.len()` per kept entry).
+#[test]
+fn cut_rewrites_vlsd_inline_offsets() -> Result<(), MdfError> {
+    let input = std::env::temp_dir().join("cut_vlsd_offsets_input.mf4");
+    let output = std::env::temp_dir().join("cut_vlsd_offsets_output.mf4");
+    if input.exists() {
+        std::fs::remove_file(&input)?;
+    }
+    if output.exists() {
+        std::fs::remove_file(&output)?;
+    }
+
+    let mut writer = MdfWriter::new(input.to_str().unwrap())?;
+    writer.init_mdf_file()?;
+    let cg_id = writer.add_channel_group(None, |_| {})?;
+    let time_id = writer.add_channel(&cg_id, None, |ch| {
+        ch.data_type = DataType::FloatLE;
+        ch.bit_count = 64;
+        ch.name = Some("Time".into());
+    })?;
+    writer.set_time_channel(&time_id)?;
+    let vlsd_id = writer.add_channel(&cg_id, Some(&time_id), |ch| {
+        ch.data_type = DataType::StringUtf8;
+        ch.bit_count = 64;
+        ch.channel_type = 1; // VLSD
+        ch.name = Some("Message".into());
+    })?;
+
+    writer.start_data_block_for_cg_raw(&cg_id, 0, 16, 0)?;
+    writer.start_signal_data_block(&vlsd_id)?;
+
+    // Variable-length payloads so SD entry sizes differ — that's what makes
+    // the offset rewrite non-trivial.
+    let payloads: Vec<Vec<u8>> = (0..8u64)
+        .map(|i| format!("msg-{}-{}", i, "x".repeat(i as usize)).into_bytes())
+        .collect();
+
+    let mut running: u64 = 0;
+    for (i, payload) in payloads.iter().enumerate() {
+        let mut record = Vec::with_capacity(16);
+        record.extend_from_slice(&(i as f64 * 0.1).to_le_bytes());
+        // Inline VLSD slot = byte offset within SD data section. This
+        // mimics asammdf's writer.
+        record.extend_from_slice(&running.to_le_bytes());
+        writer.write_raw_record(&cg_id, &record)?;
+        writer.write_signal_data(&vlsd_id, payload)?;
+        running = running.checked_add(4 + payload.len() as u64).unwrap();
+    }
+    writer.finish_signal_data_block(&vlsd_id)?;
+    writer.finish_data_block(&cg_id)?;
+    writer.finalize()?;
+
+    // Cut [0.2, 0.5] -> keep records 2..=5.
+    mf4_rs::cut::cut_mdf_by_time(
+        input.to_str().unwrap(),
+        output.to_str().unwrap(),
+        0.2,
+        0.5,
+    )?;
+
+    // Sanity: mf4-rs still reads the cut file correctly.
+    let mdf = MDF::from_file(output.to_str().unwrap())?;
+    let chs = mdf.channel_groups()[0].channels();
+    let read_payloads = chs[1].values()?;
+    assert_eq!(read_payloads.len(), 4);
+    let expected: Vec<Vec<u8>> = (2u64..=5u64)
+        .map(|i| format!("msg-{}-{}", i, "x".repeat(i as usize)).into_bytes())
+        .collect();
+    for (i, v) in read_payloads.iter().enumerate() {
+        match v {
+            Some(DecodedValue::String(s)) => assert_eq!(s.as_bytes(), &expected[i][..]),
+            Some(DecodedValue::ByteArray(b)) => assert_eq!(b, &expected[i]),
+            other => panic!("cut[{}]: unexpected value {:?}", i, other),
+        }
+    }
+    drop(mdf);
+
+    // Inspect the raw bytes of the output to assert that each kept record's
+    // inline VLSD slot points at the entry's offset in the new SD block.
+    // The slot is at bytes [8..16] of every 16-byte parent record.
+    let bytes = std::fs::read(&output)?;
+    fn find_block(bytes: &[u8], id: &[u8; 4]) -> Option<usize> {
+        let mut off = 64usize;
+        while off + 24 <= bytes.len() {
+            if &bytes[off..off + 4] == id {
+                return Some(off);
+            }
+            off += 8;
+        }
+        None
+    }
+    let dt_off = find_block(&bytes, b"##DT").expect("output should contain a ##DT block");
+    let dt_len = u64::from_le_bytes(bytes[dt_off + 8..dt_off + 16].try_into().unwrap()) as usize;
+    let dt_data = &bytes[dt_off + 24..dt_off + dt_len];
+    assert_eq!(
+        dt_data.len() % 16,
+        0,
+        "cut DT block should contain whole 16-byte records"
+    );
+    assert_eq!(dt_data.len() / 16, 4, "expected 4 kept records");
+
+    let mut expected_offset: u64 = 0;
+    for (i, rec) in dt_data.chunks_exact(16).enumerate() {
+        let slot = u64::from_le_bytes(rec[8..16].try_into().unwrap());
+        assert_eq!(
+            slot, expected_offset,
+            "kept record {}: inline VLSD slot = 0x{:x}, expected 0x{:x}",
+            i, slot, expected_offset
+        );
+        expected_offset = expected_offset
+            .checked_add(4 + expected[i].len() as u64)
+            .unwrap();
+    }
+
+    std::fs::remove_file(input)?;
+    std::fs::remove_file(output)?;
+    Ok(())
+}
+
 /// Cut should also handle VLSD channels carrying empty payloads correctly.
 #[test]
 fn cut_preserves_empty_vlsd_payloads() -> Result<(), MdfError> {

--- a/tests/test_asammdf_interop.py
+++ b/tests/test_asammdf_interop.py
@@ -502,6 +502,73 @@ def test_performance_write():
         cleanup(path)
 
 
+def test_cut_asammdf_vlsd_string():
+    """Cut an asammdf-written file with a VLSD string channel using mf4-rs,
+    then read the cut output back with both libraries.
+
+    Asammdf populates the inline VLSD slot in each parent record with the
+    byte offset of the entry in the linked ##SD block, and uses that offset
+    to locate entries when reading. A naive cut that copies parent records
+    verbatim leaves stale offsets pointing into the source SD layout — mf4-rs
+    can still read it (it walks SD entries sequentially) but asammdf reports
+    a length mismatch. This test exercises the rewrite path.
+    """
+    src = tmp("asammdf_vlsd_src")
+    out = tmp("asammdf_vlsd_cut")
+    try:
+        # Asammdf maps S<n> bytes arrays to channel_type=1 (VLSD), data_type=7
+        # (UTF-8 string). Use a fixed S20 so payload bytes vary in their
+        # null-padded form but the VLSD entry size stays predictable.
+        n = 10
+        t = np.arange(n, dtype=np.float64) * 0.1
+        strings = np.array(
+            [f"event-{i}-payload".encode() for i in range(n)], dtype="S20"
+        )
+        nums = np.arange(n, dtype=np.int32) * 10
+        mdf = AsamMDF(version="4.10")
+        mdf.append(
+            [
+                Signal(samples=strings, timestamps=t, name="Message", encoding="utf-8"),
+                Signal(samples=nums, timestamps=t, name="Counter"),
+            ],
+            common_timebase=True,
+        )
+        mdf.save(src, overwrite=True)
+        mdf.close()
+
+        # Sanity: confirm asammdf actually emitted a VLSD string channel.
+        with AsamMDF(src) as m:
+            ch = next(c for c in m.groups[0].channels if c.name == "Message")
+            assert ch.channel_type == 1, f"expected VLSD channel_type=1, got {ch.channel_type}"
+            assert ch.data_type == 7, f"expected UTF-8 string data_type=7, got {ch.data_type}"
+
+        # Cut a window covering records 2..=6.
+        mf4_rs.cut_mdf_by_time(src, out, 0.2, 0.6)
+
+        # mf4-rs reads numeric channels of the cut output correctly. (The
+        # Python binding's f64 fast path can't return strings — strings round
+        # through native Rust APIs and through asammdf below.)
+        cut_mdf = mf4_rs.PyMDF(out)
+        ctrs = cut_mdf.get_channel_values("Counter")
+        assert ctrs is not None, "Counter not found in cut file"
+        assert [int(c) for c in ctrs] == [20, 30, 40, 50, 60], list(ctrs)
+
+        # asammdf reads the cut output correctly — this is the regression
+        # check. With stale inline offsets it would raise
+        # "samples and timestamps length mismatch".
+        with AsamMDF(out) as m:
+            msg = m.get("Message")
+            ctr = m.get("Counter")
+            assert len(msg.samples) == 5, f"asammdf saw {len(msg.samples)} samples"
+            assert len(msg.timestamps) == 5
+            assert [s.decode().rstrip("\x00") for s in msg.samples.tolist()] == [
+                f"event-{i}-payload" for i in range(2, 7)
+            ]
+            assert ctr.samples.tolist() == [20, 30, 40, 50, 60]
+    finally:
+        cleanup(src, out)
+
+
 def test_performance_read():
     """Performance sanity check for mf4-rs Python read (should complete in < 10s)."""
     import time
@@ -540,6 +607,7 @@ if __name__ == "__main__":
         ("data block splitting cross-read", test_data_block_splitting_cross_read),
         ("value-to-text conversion cross-read", test_value_to_text_conversion_cross_read),
         ("units and comments readable", test_units_and_comments_readable),
+        ("cut preserves asammdf VLSD strings", test_cut_asammdf_vlsd_string),
         ("performance: write", test_performance_write),
         ("performance: read", test_performance_read),
     ]


### PR DESCRIPTION
Per MDF4 spec, the parent record of a VLSD channel carries the byte offset of
the entry within the linked ##SD block's data section. Spec-conformant readers
(e.g. asammdf) use that offset to locate entries. mf4-rs' own reader walks SD
entries sequentially so it ignored the slot, masking a bug in cut_mdf_by_time:
records were copied verbatim, leaving stale offsets that pointed into the
source file's SD layout — even though the writer emitted a freshly numbered SD
block. asammdf reading such a cut file failed with "samples and timestamps
length mismatch" (e.g. 3 vs 5 for a 5-record cut).

Cut now patches each kept record's inline VLSD slot to the running offset of
the entry being written to the new SD block, advancing by 4 + payload.len()
per entry.

Tests:
- cut_rewrites_vlsd_inline_offsets: pure-Rust regression that simulates the
  asammdf-style writer (non-zero inline slots), cuts, and asserts the kept
  records' slots match the new SD layout.
- test_cut_asammdf_vlsd_string: Python interop test that creates a VLSD UTF-8
  string channel with asammdf, cuts via mf4-rs, and verifies asammdf reads the
  result without a length mismatch.

Both new tests fail without the fix and pass with it.

https://claude.ai/code/session_01QYHUkG2nin9B3n2QvoFaqm