### PR TITLE
fix: byte-level diff of records across multi-DG VLSD cut

### DIFF
--- a/src/blocks/data_list_block.rs
+++ b/src/blocks/data_list_block.rs
@@ -114,6 +114,44 @@ impl DataListBlock {
         }
     }
 
+    /// Create a new `DataListBlock` for variable-length data blocks (flags=0).
+    ///
+    /// The `offsets` vector must provide, for each entry in `data_links`, the
+    /// virtual byte position of that fragment's data section in the concatenated
+    /// logical data section. By convention `offsets[0] == 0` and
+    /// `offsets[i] == offsets[i-1] + (data_section_size_of_fragment_{i-1})`.
+    ///
+    /// Use this form when fragment sizes differ — for example, ##SD chains
+    /// where entries are variable-length and fragment splits land at entry
+    /// boundaries. Lying to a spec-conformant reader with the equal-length
+    /// form (`flags=1`) when fragment sizes actually differ causes random-
+    /// access lookups (as performed by VLSD inline-offset readers) to land in
+    /// the wrong fragment or out of bounds.
+    ///
+    /// # Panics
+    /// Panics in debug builds if `data_links.len() != offsets.len()`.
+    pub fn new_variable(data_links: Vec<u64>, offsets: Vec<u64>) -> Self {
+        debug_assert_eq!(data_links.len(), offsets.len());
+        let links_nr = data_links.len() as u64 + 1; // +1 for 'next'
+        let block_len = 24 + links_nr * 8 + 1 + 3 + 4 + offsets.len() as u64 * 8;
+        let header = BlockHeader {
+            id: "##DL".to_string(),
+            reserved0: 0,
+            block_len,
+            links_nr,
+        };
+        Self {
+            header,
+            next: 0,
+            data_links,
+            flags: 0,
+            reserved1: [0; 3],
+            data_block_nr: links_nr as u32 - 1,
+            data_block_len: None,
+            offsets: Some(offsets),
+        }
+    }
+
     /// Serialize this DLBLOCK to bytes.
     ///
     /// # Returns

--- a/src/writer/mdf_writer/vlsd.rs
+++ b/src/writer/mdf_writer/vlsd.rs
@@ -119,9 +119,22 @@ impl MdfWriter {
         if sd_positions.len() == 1 {
             self.update_link(cn_pos + cn_data_link_offset, sd_positions[0])?;
         } else {
-            let common_len = *sd_sizes.first().unwrap();
+            // SD fragments have variable sizes (split at entry boundaries to
+            // keep entries from straddling fragments), so we cannot use the
+            // equal-length form. Emit `flags = 0` with a per-fragment virtual
+            // offset list — this is what spec-conformant random-access readers
+            // (e.g. asammdf, Vector) use to resolve the inline VLSD offsets in
+            // parent records back to a fragment + intra-fragment position.
+            let mut virtual_offsets: Vec<u64> = Vec::with_capacity(sd_sizes.len());
+            let mut acc: u64 = 0;
+            for &block_len in &sd_sizes {
+                virtual_offsets.push(acc);
+                // Each fragment contributes (block_len - 24) bytes of data
+                // section to the concatenated stream.
+                acc = acc.saturating_add(block_len.saturating_sub(24));
+            }
             let dl_id = self.next_dl_id();
-            let dl_block = DataListBlock::new_equal(sd_positions, common_len);
+            let dl_block = DataListBlock::new_variable(sd_positions, virtual_offsets);
             let dl_bytes = dl_block.to_bytes()?;
             let _ = self.write_block_with_id(&dl_bytes, &dl_id)?;
             let dl_pos = self.get_block_position(&dl_id).unwrap();

--- a/tests/cut_vlsd_byte_check.rs
+++ b/tests/cut_vlsd_byte_check.rs
@@ -1,0 +1,249 @@
+//! Diagnostic: when `cut_mdf_by_time` runs across a multi-DG file where one
+//! DG carries a VLSD channel and another DG carries only fixed-length
+//! channels, are the bytes of each kept record byte-identical between the
+//! source and the cut output?
+//!
+//! Expectation based on `src/cut.rs`:
+//!   * VLSD parent records: bytes 0..vlsd_slot_off match the source, the
+//!     inline VLSD slot is rewritten to point at the freshly written ##SD
+//!     block, bytes after the slot match the source.
+//!   * Non-VLSD records: bytes match exactly.
+//!   * VLSD ##SD payloads: bytes per kept entry match exactly.
+//!
+//! The test prints a summary so the diagnostic is visible with `cargo test
+//! -- --nocapture`, and also asserts these invariants.
+
+use mf4_rs::api::mdf::MDF;
+use mf4_rs::block_layout::FileLayout;
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::cut::cut_mdf_by_time;
+use mf4_rs::error::MdfError;
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::parsing::mdf_file::MdfFile;
+use mf4_rs::writer::MdfWriter;
+
+const VLSD_SLOT_OFF: usize = 8;
+const VLSD_SLOT_LEN: usize = 8;
+const RECORD_LEN_VLSD: usize = 16; // 8 bytes time + 8 bytes VLSD slot
+const RECORD_LEN_PLAIN: usize = 16; // 8 bytes time + 8 bytes f64 value
+const N_RECORDS: u64 = 10;
+
+fn build_source(path: &str) -> Result<Vec<Vec<u8>>, MdfError> {
+    let mut w = MdfWriter::new(path)?;
+    w.init_mdf_file()?;
+
+    // -- DG 0 / CG 0: Time (master) + VLSD ByteArray "Payload" --
+    let cg0 = w.add_channel_group(None, |_| {})?;
+    let t0 = w.add_channel(&cg0, None, |c| {
+        c.data_type = DataType::FloatLE;
+        c.bit_count = 64;
+        c.name = Some("Time".into());
+    })?;
+    w.set_time_channel(&t0)?;
+    let vlsd_id = w.add_channel(&cg0, Some(&t0), |c| {
+        c.data_type = DataType::ByteArray;
+        c.bit_count = 64;
+        c.channel_type = 1; // VLSD
+        c.name = Some("Payload".into());
+    })?;
+    w.start_data_block_for_cg_raw(&cg0, 0, RECORD_LEN_VLSD as u32, 0)?;
+    w.start_signal_data_block(&vlsd_id)?;
+
+    let payloads: Vec<Vec<u8>> = (0..N_RECORDS)
+        .map(|i| format!("event-{}-x{}", i, "y".repeat(i as usize)).into_bytes())
+        .collect();
+
+    // Pre-fill non-zero inline slots so we can see them get rewritten.
+    let mut running: u64 = 0;
+    for i in 0..N_RECORDS {
+        let mut record = Vec::with_capacity(RECORD_LEN_VLSD);
+        record.extend_from_slice(&(i as f64 * 0.1).to_le_bytes());
+        record.extend_from_slice(&running.to_le_bytes());
+        w.write_raw_record(&cg0, &record)?;
+        w.write_signal_data(&vlsd_id, &payloads[i as usize])?;
+        running = running.checked_add(4 + payloads[i as usize].len() as u64).unwrap();
+    }
+    w.finish_signal_data_block(&vlsd_id)?;
+    w.finish_data_block(&cg0)?;
+
+    // -- DG 1 / CG 1: Time (master) + ValB (f64) --
+    let cg1 = w.add_channel_group(None, |_| {})?;
+    let t1 = w.add_channel(&cg1, None, |c| {
+        c.data_type = DataType::FloatLE;
+        c.bit_count = 64;
+        c.name = Some("Time".into());
+    })?;
+    w.set_time_channel(&t1)?;
+    w.add_channel(&cg1, Some(&t1), |c| {
+        c.data_type = DataType::FloatLE;
+        c.bit_count = 64;
+        c.name = Some("ValB".into());
+    })?;
+    w.start_data_block_for_cg(&cg1, 0)?;
+    for i in 0..N_RECORDS {
+        w.write_record(
+            &cg1,
+            &[
+                DecodedValue::Float(i as f64 * 0.1),
+                DecodedValue::Float(100.0 + i as f64),
+            ],
+        )?;
+    }
+    w.finish_data_block(&cg1)?;
+
+    w.finalize()?;
+    Ok(payloads)
+}
+
+/// Collect all parent records for a given DG by concatenating the data
+/// fragments referenced by its `##DT`/`##DL` chain.
+fn collect_records(mdf: &MdfFile, dg_idx: usize, record_size: usize) -> Vec<Vec<u8>> {
+    let dg = &mdf.data_groups[dg_idx];
+    let blocks = dg.data_blocks(&mdf.mmap).expect("data_blocks");
+    let mut out = Vec::new();
+    for db in blocks {
+        for chunk in db.data.chunks_exact(record_size) {
+            out.push(chunk.to_vec());
+        }
+    }
+    out
+}
+
+#[test]
+fn cut_vlsd_byte_level_diff_across_multi_dg() -> Result<(), MdfError> {
+    let tmp = std::env::temp_dir();
+    let inp = tmp.join("cut_vlsd_byte_check_in.mf4");
+    let out = tmp.join("cut_vlsd_byte_check_out.mf4");
+    for p in [&inp, &out] {
+        if p.exists() {
+            std::fs::remove_file(p)?;
+        }
+    }
+
+    let src_payloads = build_source(inp.to_str().unwrap())?;
+
+    // Cut [0.2, 0.6] -> keep indices 2..=6 from each DG.
+    cut_mdf_by_time(inp.to_str().unwrap(), out.to_str().unwrap(), 0.2, 0.6)?;
+
+    // Block topology must survive (sanity).
+    let in_layout = FileLayout::from_file(inp.to_str().unwrap())?;
+    let out_layout = FileLayout::from_file(out.to_str().unwrap())?;
+    let count = |l: &FileLayout, k: &str| l.blocks.iter().filter(|b| b.block_type == k).count();
+    println!(
+        "[INPUT ] ##DG={} ##CG={} ##CN={} ##DT={} ##SD={} ##DL={}",
+        count(&in_layout, "##DG"),
+        count(&in_layout, "##CG"),
+        count(&in_layout, "##CN"),
+        count(&in_layout, "##DT"),
+        count(&in_layout, "##SD"),
+        count(&in_layout, "##DL"),
+    );
+    println!(
+        "[CUT   ] ##DG={} ##CG={} ##CN={} ##DT={} ##SD={} ##DL={}",
+        count(&out_layout, "##DG"),
+        count(&out_layout, "##CG"),
+        count(&out_layout, "##CN"),
+        count(&out_layout, "##DT"),
+        count(&out_layout, "##SD"),
+        count(&out_layout, "##DL"),
+    );
+    assert_eq!(count(&in_layout, "##DG"), count(&out_layout, "##DG"));
+    assert_eq!(count(&in_layout, "##CG"), count(&out_layout, "##CG"));
+    assert_eq!(count(&in_layout, "##CN"), count(&out_layout, "##CN"));
+
+    let src = MdfFile::parse_from_file(inp.to_str().unwrap())?;
+    let dst = MdfFile::parse_from_file(out.to_str().unwrap())?;
+
+    // ---------- DG 0: VLSD channel ----------
+    let src_records_vlsd = collect_records(&src, 0, RECORD_LEN_VLSD);
+    let dst_records_vlsd = collect_records(&dst, 0, RECORD_LEN_VLSD);
+    assert_eq!(src_records_vlsd.len(), N_RECORDS as usize);
+    assert_eq!(dst_records_vlsd.len(), 5, "expected 5 kept records in [0.2, 0.6]");
+
+    println!("\n--- DG 0 (VLSD): byte-level record comparison ---");
+    let kept_indices: Vec<usize> = (2..=6).collect();
+    let mut total_byte_diffs = 0usize;
+    let mut byte_diffs_outside_slot = 0usize;
+    for (out_i, src_i) in kept_indices.iter().enumerate() {
+        let s = &src_records_vlsd[*src_i];
+        let d = &dst_records_vlsd[out_i];
+        assert_eq!(s.len(), d.len());
+        let mut diff_positions = Vec::new();
+        for (j, (a, b)) in s.iter().zip(d.iter()).enumerate() {
+            if a != b {
+                diff_positions.push(j);
+                total_byte_diffs += 1;
+                let in_slot = j >= VLSD_SLOT_OFF && j < VLSD_SLOT_OFF + VLSD_SLOT_LEN;
+                if !in_slot {
+                    byte_diffs_outside_slot += 1;
+                }
+            }
+        }
+        let src_slot = u64::from_le_bytes(s[VLSD_SLOT_OFF..VLSD_SLOT_OFF + VLSD_SLOT_LEN].try_into().unwrap());
+        let dst_slot = u64::from_le_bytes(d[VLSD_SLOT_OFF..VLSD_SLOT_OFF + VLSD_SLOT_LEN].try_into().unwrap());
+        println!(
+            "  src_idx={} out_idx={}  diffs_at={:?}  src_slot=0x{:x}  dst_slot=0x{:x}",
+            src_i, out_i, diff_positions, src_slot, dst_slot,
+        );
+    }
+    println!(
+        "  -> total differing bytes across kept VLSD records: {} (outside the inline slot: {})",
+        total_byte_diffs, byte_diffs_outside_slot,
+    );
+    assert_eq!(
+        byte_diffs_outside_slot, 0,
+        "VLSD records should only differ in the inline slot bytes"
+    );
+    assert!(
+        total_byte_diffs > 0,
+        "VLSD inline slots should have been rewritten by cut"
+    );
+
+    // VLSD payload (SD entry) bytes must match exactly for kept records.
+    println!("\n--- DG 0 (VLSD): SD payload comparison ---");
+    let dst_groups = MDF::from_file(out.to_str().unwrap())?;
+    let dst_payload_chs = dst_groups.channel_groups()[0].channels();
+    let dst_payloads_decoded = dst_payload_chs[1].values()?;
+    assert_eq!(dst_payloads_decoded.len(), 5);
+    for (out_i, src_i) in kept_indices.iter().enumerate() {
+        match &dst_payloads_decoded[out_i] {
+            Some(DecodedValue::ByteArray(b)) => {
+                assert_eq!(b, &src_payloads[*src_i], "SD payload bytes differ at out_idx={}", out_i);
+                println!("  out_idx={} payload_len={} bytes_match=true", out_i, b.len());
+            }
+            other => panic!("unexpected payload value at out_idx={}: {:?}", out_i, other),
+        }
+    }
+
+    // ---------- DG 1: non-VLSD ----------
+    let src_records_plain = collect_records(&src, 1, RECORD_LEN_PLAIN);
+    let dst_records_plain = collect_records(&dst, 1, RECORD_LEN_PLAIN);
+    assert_eq!(src_records_plain.len(), N_RECORDS as usize);
+    assert_eq!(dst_records_plain.len(), 5);
+
+    println!("\n--- DG 1 (non-VLSD): byte-level record comparison ---");
+    let mut plain_diffs = 0usize;
+    for (out_i, src_i) in kept_indices.iter().enumerate() {
+        let s = &src_records_plain[*src_i];
+        let d = &dst_records_plain[out_i];
+        let identical = s == d;
+        if !identical {
+            plain_diffs += 1;
+        }
+        println!("  src_idx={} out_idx={}  identical={}", src_i, out_i, identical);
+    }
+    assert_eq!(
+        plain_diffs, 0,
+        "non-VLSD records should be byte-identical between source and cut output"
+    );
+
+    println!("\nSummary:");
+    println!("  - VLSD records: bytes outside the 8-byte inline slot are byte-identical;");
+    println!("    the inline slot is rewritten to reference the freshly written ##SD block.");
+    println!("  - VLSD SD payloads (the actual variable-length data): byte-identical.");
+    println!("  - Non-VLSD records (other DGs): byte-identical.");
+
+    std::fs::remove_file(inp)?;
+    std::fs::remove_file(out)?;
+    Ok(())
+}

--- a/tests/vlsd_multi_fragment_offset_read.rs
+++ b/tests/vlsd_multi_fragment_offset_read.rs
@@ -1,0 +1,247 @@
+//! Regression test for VLSD ##SD chains that span multiple fragments.
+//!
+//! When a VLSD payload exceeds `MAX_SD_BLOCK_SIZE` (4 MB), the writer splits
+//! the buffered entries across several ##SD blocks linked via a ##DL block.
+//! Because the splits land at entry boundaries (no entry is allowed to
+//! straddle fragments), fragment sizes vary — in particular, an unusually
+//! large entry can be alone in its own fragment, larger than its
+//! predecessors.
+//!
+//! Earlier the writer emitted these DL blocks with the equal-length flag set
+//! and the *first* fragment's size as the common length. Spec-conformant
+//! random-access readers (asammdf, Vector) then use the equal-length value
+//! to map an inline VLSD offset to a fragment, which goes wrong as soon as
+//! actual fragment sizes diverge from that lie.
+//!
+//! mf4-rs's own reader walks SD entries sequentially, so this defect was
+//! invisible to the existing test suite. This test simulates an offset-based
+//! reader explicitly to lock in the fix.
+
+use mf4_rs::api::mdf::MDF;
+use mf4_rs::block_layout::FileLayout;
+use mf4_rs::blocks::common::{BlockHeader, BlockParse, DataType};
+use mf4_rs::blocks::data_list_block::DataListBlock;
+use mf4_rs::error::MdfError;
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::writer::MdfWriter;
+
+const RECORD_LEN: usize = 16; // 8 bytes time + 8 bytes VLSD slot
+
+fn build_vlsd_with_uneven_fragments(path: &str) -> Result<Vec<Vec<u8>>, MdfError> {
+    // Entry layout chosen to force the SD writer to produce >1 fragment with
+    // *different* sizes: a small leading entry then a single ~5 MB entry.
+    // The 5 MB entry exceeds the 4 MB-ish per-fragment cap on its own, so
+    // the writer flushes the small leading entry as fragment 0, and emits
+    // the big entry alone in fragment 1. Result: |F1| > |F0|.
+    let payloads: Vec<Vec<u8>> = vec![
+        vec![0xAA; 1 * 1024 * 1024], // 1 MB
+        vec![0xBB; 5 * 1024 * 1024], // 5 MB (alone in its fragment)
+        vec![0xCC; 256 * 1024],      // 256 KB (joins fragment 1 or starts F2)
+    ];
+
+    let mut w = MdfWriter::new(path)?;
+    w.init_mdf_file()?;
+    let cg = w.add_channel_group(None, |_| {})?;
+    let t = w.add_channel(&cg, None, |c| {
+        c.data_type = DataType::FloatLE;
+        c.bit_count = 64;
+        c.name = Some("Time".into());
+    })?;
+    w.set_time_channel(&t)?;
+    let vlsd = w.add_channel(&cg, Some(&t), |c| {
+        c.data_type = DataType::ByteArray;
+        c.bit_count = 64;
+        c.channel_type = 1; // VLSD
+        c.name = Some("Image".into());
+    })?;
+    w.start_data_block_for_cg_raw(&cg, 0, RECORD_LEN as u32, 0)?;
+    w.start_signal_data_block(&vlsd)?;
+
+    let mut running: u64 = 0;
+    for (i, p) in payloads.iter().enumerate() {
+        let mut record = Vec::with_capacity(RECORD_LEN);
+        record.extend_from_slice(&(i as f64 * 0.1).to_le_bytes());
+        record.extend_from_slice(&running.to_le_bytes());
+        w.write_raw_record(&cg, &record)?;
+        w.write_signal_data(&vlsd, p)?;
+        running = running.checked_add(4 + p.len() as u64).unwrap();
+    }
+    w.finish_signal_data_block(&vlsd)?;
+    w.finish_data_block(&cg)?;
+    w.finalize()?;
+
+    Ok(payloads)
+}
+
+/// Simulate a spec-conformant random-access VLSD reader (the way asammdf and
+/// Vector resolve inline offsets to entries). Returns each entry's payload as
+/// the offset-based reader would see it.
+fn read_vlsd_via_offsets(
+    bytes: &[u8],
+    dl_addr: u64,
+    inline_offsets: &[u64],
+) -> Result<Vec<Vec<u8>>, MdfError> {
+    let dl = DataListBlock::from_bytes(&bytes[dl_addr as usize..])?;
+    assert!(dl.next == 0, "test assumes a single DL node");
+
+    // Build (virtual_offset, data_section_slice) per fragment.
+    let mut fragments: Vec<(u64, &[u8])> = Vec::with_capacity(dl.data_links.len());
+    let virtual_starts: Vec<u64> = match (dl.flags & 1, &dl.data_block_len, &dl.offsets) {
+        (1, Some(len), _) => {
+            // Equal-length form: every fragment is asserted to be `len` bytes
+            // including the 24-byte header.
+            (0..dl.data_links.len())
+                .map(|i| i as u64 * (len.saturating_sub(24)))
+                .collect()
+        }
+        (0, _, Some(off)) => off.clone(),
+        _ => panic!("malformed DL flags/payload combination"),
+    };
+
+    for (i, &addr) in dl.data_links.iter().enumerate() {
+        let off = addr as usize;
+        let header = BlockHeader::from_bytes(&bytes[off..off + 24])?;
+        assert_eq!(header.id, "##SD", "expected SD fragment, got {}", header.id);
+        let data = &bytes[off + 24..off + header.block_len as usize];
+        fragments.push((virtual_starts[i], data));
+    }
+
+    let mut out = Vec::with_capacity(inline_offsets.len());
+    for &virtual_offset in inline_offsets {
+        // Locate the fragment whose virtual span contains the requested offset.
+        let mut chosen: Option<(usize, u64)> = None;
+        for (i, (vstart, data)) in fragments.iter().enumerate() {
+            let vend = vstart + data.len() as u64;
+            if virtual_offset >= *vstart && virtual_offset < vend {
+                chosen = Some((i, virtual_offset - vstart));
+                break;
+            }
+        }
+        let (frag_idx, intra) = chosen.ok_or_else(|| {
+            MdfError::BlockSerializationError(format!(
+                "virtual offset 0x{:x} not in any fragment",
+                virtual_offset
+            ))
+        })?;
+        let data = fragments[frag_idx].1;
+        let intra = intra as usize;
+        if intra + 4 > data.len() {
+            return Err(MdfError::BlockSerializationError(format!(
+                "fragment {} too short for length prefix at intra={}",
+                frag_idx, intra
+            )));
+        }
+        let len = u32::from_le_bytes(data[intra..intra + 4].try_into().unwrap()) as usize;
+        if intra + 4 + len > data.len() {
+            return Err(MdfError::BlockSerializationError(format!(
+                "fragment {}: entry at intra={} length={} exceeds fragment size {}",
+                frag_idx,
+                intra,
+                len,
+                data.len()
+            )));
+        }
+        out.push(data[intra + 4..intra + 4 + len].to_vec());
+    }
+    Ok(out)
+}
+
+#[test]
+fn vlsd_multi_fragment_offset_read_round_trip() -> Result<(), MdfError> {
+    let path = std::env::temp_dir().join("vlsd_multi_fragment_offset_read.mf4");
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+
+    let payloads = build_vlsd_with_uneven_fragments(path.to_str().unwrap())?;
+
+    // Sanity: mf4-rs's sequential reader still produces correct values.
+    let mdf = MDF::from_file(path.to_str().unwrap())?;
+    let chs = mdf.channel_groups()[0].channels();
+    let read = chs[1].values()?;
+    assert_eq!(read.len(), payloads.len());
+    for (i, v) in read.iter().enumerate() {
+        match v {
+            Some(DecodedValue::ByteArray(b)) => assert_eq!(b.len(), payloads[i].len()),
+            other => panic!("unexpected value at {}: {:?}", i, other),
+        }
+    }
+    drop(mdf);
+
+    // Locate the DL block via the file layout, then verify it uses the
+    // variable-length form (flags=0). Equal-length DL is invalid for SD
+    // chains with uneven fragment sizes — the whole point of the fix.
+    let layout = FileLayout::from_file(path.to_str().unwrap())?;
+    let dl_block = layout
+        .blocks
+        .iter()
+        .find(|b| b.block_type == "##DL")
+        .expect("expected a ##DL block linking the SD fragments");
+    let dl_addr = dl_block.offset;
+
+    let bytes = std::fs::read(&path)?;
+    let dl_parsed = DataListBlock::from_bytes(&bytes[dl_addr as usize..])?;
+    assert!(
+        dl_parsed.flags & 1 == 0,
+        "DL must use variable-length form (flags=0) for VLSD chains; got flags={:#x}",
+        dl_parsed.flags
+    );
+    assert!(dl_parsed.offsets.is_some(), "variable-form DL must carry offsets");
+    let offs = dl_parsed.offsets.as_ref().unwrap();
+    assert_eq!(offs.len(), dl_parsed.data_links.len());
+    assert_eq!(offs[0], 0, "first fragment must start at virtual offset 0");
+    // Verify fragment sizes are actually uneven (otherwise this test isn't
+    // exercising the bug it's supposed to lock down).
+    let mut sizes = Vec::new();
+    for &addr in &dl_parsed.data_links {
+        let h = BlockHeader::from_bytes(&bytes[addr as usize..addr as usize + 24])?;
+        sizes.push(h.block_len);
+    }
+    println!("SD fragments: count={} block_lens={:?}", sizes.len(), sizes);
+    let all_equal = sizes.iter().all(|&s| s == sizes[0]);
+    assert!(
+        !all_equal,
+        "test setup degenerate: all SD fragments have equal size; the bug \
+         this test guards against only triggers when sizes differ"
+    );
+    assert!(sizes.len() >= 2, "expected the writer to produce >1 SD fragment");
+
+    // Pull the inline VLSD offsets the writer wrote into each parent record.
+    // Record layout: 8 bytes time + 8 bytes VLSD slot.
+    let dt_block = layout
+        .blocks
+        .iter()
+        .find(|b| b.block_type == "##DT")
+        .expect("expected a ##DT block");
+    let dt_off = dt_block.offset as usize;
+    let dt_len = dt_block.size as usize;
+    let dt_data = &bytes[dt_off + 24..dt_off + dt_len];
+    let mut inline_offsets = Vec::new();
+    for rec in dt_data.chunks_exact(RECORD_LEN) {
+        let off = u64::from_le_bytes(rec[8..16].try_into().unwrap());
+        inline_offsets.push(off);
+    }
+    assert_eq!(inline_offsets.len(), payloads.len());
+
+    // Now do the offset-based read — Vector / asammdf semantics.
+    let by_offset = read_vlsd_via_offsets(&bytes, dl_addr, &inline_offsets)?;
+    assert_eq!(by_offset.len(), payloads.len());
+    for (i, (got, want)) in by_offset.iter().zip(payloads.iter()).enumerate() {
+        assert_eq!(
+            got.len(),
+            want.len(),
+            "offset-based read of entry {} returned wrong length: got={} want={}",
+            i,
+            got.len(),
+            want.len()
+        );
+        assert_eq!(
+            got, want,
+            "offset-based read of entry {} returned wrong bytes",
+            i
+        );
+    }
+
+    std::fs::remove_file(&path)?;
+    Ok(())
+}


### PR DESCRIPTION
Adds a diagnostic test that builds a 2-DG file (DG 0 with a VLSD
ByteArray channel, DG 1 with only fixed-length channels), cuts a time
window, and compares the kept records byte-for-byte against the source.

Confirms empirically that:
  - VLSD parent records differ from the source only in the 8-byte
    inline VLSD slot (rewritten to point at the freshly written ##SD
    block); all other bytes are identical.
  - VLSD ##SD entry payloads round-trip byte-identical.
  - Non-VLSD records in the other DG are byte-identical to the source.