### PR TITLE
feat: build MdfIndex over HTTP range requests (cloud indexing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -71,10 +83,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "either"
@@ -89,6 +118,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +144,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -125,6 +185,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +228,18 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "iana-time-zone"
@@ -161,13 +266,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -216,10 +431,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -299,7 +532,10 @@ dependencies = [
  "pyo3-stub-gen",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
+ "tiny_http",
+ "ureq",
 ]
 
 [[package]]
@@ -402,6 +638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +654,25 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -478,7 +739,7 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -526,6 +787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,10 +808,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -563,6 +892,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -635,6 +970,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,10 +993,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -669,6 +1040,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -719,10 +1112,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -767,6 +1229,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -829,10 +1343,275 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,4 @@ tempfile = "3"
 [features]
 default = []
 http = ["dep:ureq"]
-pyo3 = ["dep:pyo3", "dep:numpy", "dep:pyo3-stub-gen"]
+pyo3 = ["dep:pyo3", "dep:numpy", "dep:pyo3-stub-gen", "http"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,19 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+# HTTP range-reader (optional)
+ureq = { version = "2", default-features = false, features = ["tls"], optional = true }
+
 # Python bindings
 pyo3 = { version = "0.21", features = ["extension-module", "abi3-py38"], optional = true }
 numpy = { version = "0.21", optional = true }
 pyo3-stub-gen = { version = "0.7", optional = true }
 
+[dev-dependencies]
+tiny_http = "0.12"
+tempfile = "3"
+
 [features]
 default = []
+http = ["dep:ureq"]
 pyo3 = ["dep:pyo3", "dep:numpy", "dep:pyo3-stub-gen"]

--- a/python/mf4_rs/_mf4_rs.pyi
+++ b/python/mf4_rs/_mf4_rs.pyi
@@ -442,6 +442,39 @@ class PyMdfIndex:
         """
         ...
 
+    @staticmethod
+    def from_url(url:builtins.str, chunk_size:typing.Optional[builtins.int]) -> PyMdfIndex:
+        r"""
+        Build an index from an MDF file served over HTTP / S3 using range
+        requests, without downloading the whole file.
+        
+        Issues range reads only for metadata blocks (``##ID``, ``##HD``,
+        ``##DG``, ``##CG``, ``##CN``, name / unit / comment ``##TX``,
+        conversion ``##CC`` plus its ``cc_ref`` chain, and ``##DT``/``##DV``/
+        ``##DZ``/``##DL`` headers). Sample data is never fetched. With the
+        default 1 MiB read-ahead chunk, a typical file collapses to a handful
+        of underlying HTTP requests regardless of file size.
+        
+        Parameters
+        ----------
+        url : str
+            ``http://`` or ``https://`` URL of the ``.mf4`` resource. The
+            server must honour single-range ``Range: bytes=A-B`` requests.
+        chunk_size : int, optional
+            Read-ahead chunk size in bytes for the metadata phase
+            (default 1 MiB). Smaller values reduce wasted bytes when
+            metadata is densely packed near the file head; larger values
+            reduce the number of HTTP round-trips when metadata is
+            scattered across the file.
+        
+        Raises
+        ------
+        MdfException
+            If the URL cannot be reached, the server does not honour
+            range requests, or the response is not a valid MDF file.
+        """
+        ...
+
     def save_to_file(self, path:builtins.str) -> None:
         r"""
         Serialize the index to JSON at ``path``.
@@ -516,6 +549,37 @@ class PyMdfIndex:
         See :py:meth:`read_channel_values` for the return / error contract.
         If multiple groups contain the same channel name, prefer
         :py:meth:`read_channel_values_by_group_and_name`.
+        """
+        ...
+
+    def read_channel_values_from_url(self, group_index:builtins.int, channel_index:builtins.int, url:builtins.str) -> builtins.list[typing.Optional[typing.Any]]:
+        r"""
+        Read every sample of a channel via HTTP range requests.
+        
+        Issues one HTTP request per data block holding this channel. Cache
+        is bypassed because data-block payloads are typically far larger
+        than any sensible chunk size; one ranged ``GET`` per block is the
+        cheapest pattern.
+        
+        Parameters
+        ----------
+        group_index : int
+        channel_index : int
+        url : str
+            URL of the same MDF file the index was built from.
+        
+        Returns
+        -------
+        list[Optional[Union[float, int, str, bytes]]]
+            One entry per record. ``None`` indicates an invalid sample.
+        """
+        ...
+
+    def read_channel_values_by_name_from_url(self, channel_name:builtins.str, url:builtins.str) -> builtins.list[typing.Optional[typing.Any]]:
+        r"""
+        Read every sample of a channel by name via HTTP range requests.
+        
+        See :py:meth:`read_channel_values_from_url` for the I/O contract.
         """
         ...
 
@@ -781,15 +845,24 @@ class PyMdfWriter:
         Parameters
         ----------
         name : Optional[str]
-            Group name. **Currently ignored** — the underlying writer does
-            not yet emit ``acq_name`` / metadata for groups. Pass any value
-            (or ``None``) for forward compatibility.
+            Group acquisition name. Written as a ``##TX`` block referenced
+            from the new ``##CG`` via ``acq_name_addr``. Pass ``None`` to
+            leave it unset.
         
         Returns
         -------
         str
             Opaque group ID (e.g. ``"cg_0"``) — pass to subsequent
             ``add_channel`` / ``write_record`` / ``finish_data_block`` calls.
+        """
+        ...
+
+    def set_channel_group_comment(self, group_id:builtins.str, comment:builtins.str) -> None:
+        r"""
+        Attach a comment / description to a channel group.
+        
+        Writes a ``##TX`` block holding ``comment`` and links it from the
+        group's ``comment_addr`` field.
         """
         ...
 

--- a/src/blocks/common.rs
+++ b/src/blocks/common.rs
@@ -242,3 +242,35 @@ pub fn read_string_block(mmap: &[u8], address: u64) -> Result<Option<String>, Md
         _ => Ok(None),
     }
 }
+
+/// Read a text or metadata block via a [`ByteRangeReader`].
+///
+/// Mirrors [`read_string_block`] but fetches the block bytes through a range
+/// reader instead of a memory-mapped slice. Returns `Ok(None)` for `address ==
+/// 0` or non-text block IDs.
+pub fn read_string_block_via_reader<R>(
+    reader: &mut R,
+    address: u64,
+) -> Result<Option<String>, MdfError>
+where
+    R: crate::index::ByteRangeReader<Error = MdfError>,
+{
+    if address == 0 {
+        return Ok(None);
+    }
+
+    let header_bytes = reader.read_range(address, 24)?;
+    let header = BlockHeader::from_bytes(&header_bytes)?;
+
+    match header.id.as_str() {
+        "##TX" => {
+            let bytes = reader.read_range(address, header.block_len)?;
+            Ok(Some(TextBlock::from_bytes(&bytes)?.text))
+        }
+        "##MD" => {
+            let bytes = reader.read_range(address, header.block_len)?;
+            Ok(Some(MetadataBlock::from_bytes(&bytes)?.xml))
+        }
+        _ => Ok(None),
+    }
+}

--- a/src/blocks/conversion/base.rs
+++ b/src/blocks/conversion/base.rs
@@ -285,6 +285,114 @@ impl ConversionBlock {
         Ok(())
     }
     
+    /// Resolve all dependencies via a [`crate::index::ByteRangeReader`].
+    ///
+    /// Mirrors [`Self::resolve_all_dependencies`] but fetches referenced text
+    /// and conversion blocks through a range reader instead of a memory-mapped
+    /// slice. Used when constructing an [`crate::index::MdfIndex`] from a
+    /// remote source over HTTP range requests.
+    pub fn resolve_all_dependencies_via_reader<R>(
+        &mut self,
+        reader: &mut R,
+        current_address: u64,
+    ) -> Result<(), MdfError>
+    where
+        R: crate::index::ByteRangeReader<Error = MdfError>,
+    {
+        use std::collections::HashSet;
+
+        let mut visited = HashSet::new();
+        self.resolve_recursive_via_reader(reader, 0, &mut visited, current_address)
+    }
+
+    fn resolve_recursive_via_reader<R>(
+        &mut self,
+        reader: &mut R,
+        depth: usize,
+        visited: &mut std::collections::HashSet<u64>,
+        current_address: u64,
+    ) -> Result<(), MdfError>
+    where
+        R: crate::index::ByteRangeReader<Error = MdfError>,
+    {
+        use crate::blocks::common::{read_string_block_via_reader, BlockHeader};
+        use std::collections::HashMap;
+
+        const MAX_DEPTH: usize = 20;
+
+        if depth > MAX_DEPTH {
+            return Err(MdfError::ConversionChainTooDeep { max_depth: MAX_DEPTH });
+        }
+
+        visited.insert(current_address);
+
+        // Algebraic formula resolution
+        self.resolve_formula_via_reader(reader)?;
+
+        let mut resolved_texts = HashMap::new();
+        let mut resolved_conversions = HashMap::new();
+        let mut default_conversion = None;
+
+        let has_default_conversion = matches!(
+            self.cc_type,
+            crate::blocks::conversion::types::ConversionType::RangeToText
+        );
+
+        let default_ref_index = if has_default_conversion && self.cc_ref.len() > 2 {
+            Some(self.cc_ref.len() - 1)
+        } else {
+            None
+        };
+
+        let cc_ref_snapshot: Vec<u64> = self.cc_ref.clone();
+        for (i, &link_addr) in cc_ref_snapshot.iter().enumerate() {
+            if link_addr == 0 {
+                continue;
+            }
+
+            if visited.contains(&link_addr) {
+                return Err(MdfError::ConversionChainCycle { address: link_addr });
+            }
+
+            let header_bytes = reader.read_range(link_addr, 24)?;
+            let header = BlockHeader::from_bytes(&header_bytes)?;
+
+            match header.id.as_str() {
+                "##TX" => {
+                    if let Some(text) = read_string_block_via_reader(reader, link_addr)? {
+                        resolved_texts.insert(i, text);
+                    }
+                }
+                "##CC" => {
+                    let block_bytes = reader.read_range(link_addr, header.block_len)?;
+                    let mut nested = ConversionBlock::from_bytes(&block_bytes)?;
+                    nested.resolve_recursive_via_reader(reader, depth + 1, visited, link_addr)?;
+
+                    if Some(i) == default_ref_index {
+                        default_conversion = Some(Box::new(nested));
+                    } else {
+                        resolved_conversions.insert(i, Box::new(nested));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if !resolved_texts.is_empty() {
+            self.resolved_texts = Some(resolved_texts);
+        }
+        if !resolved_conversions.is_empty() {
+            self.resolved_conversions = Some(resolved_conversions);
+        }
+        if default_conversion.is_some() {
+            self.default_conversion = default_conversion;
+        }
+
+        visited.remove(&current_address);
+
+        Ok(())
+    }
+
     /// Get a resolved text string for a given cc_ref index.
     /// Returns the text if it was resolved during dependency resolution.
     pub fn get_resolved_text(&self, ref_index: usize) -> Option<&String> {

--- a/src/blocks/conversion/formula.rs
+++ b/src/blocks/conversion/formula.rs
@@ -24,4 +24,23 @@ impl ConversionBlock {
 
         Ok(())
     }
+
+    /// Resolve the algebraic formula via a [`crate::index::ByteRangeReader`].
+    pub fn resolve_formula_via_reader<R>(&mut self, reader: &mut R) -> Result<(), MdfError>
+    where
+        R: crate::index::ByteRangeReader<Error = MdfError>,
+    {
+        use crate::blocks::common::read_string_block_via_reader;
+
+        if self.cc_type != ConversionType::Algebraic || self.cc_ref.is_empty() {
+            return Ok(());
+        }
+
+        let addr = self.cc_ref[0];
+        if let Some(formula) = read_string_block_via_reader(reader, addr)? {
+            self.formula = Some(formula);
+        }
+
+        Ok(())
+    }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -509,9 +509,20 @@ impl ByteRangeReader for HttpRangeReader {
             .map_err(|e| MdfError::BlockSerializationError(format!("HTTP GET error: {e}")))?;
         self.request_count += 1;
 
-        let mut buf = Vec::with_capacity(length as usize);
+        // Trust the server's Content-Length over our requested length: when
+        // the requested range extends past EOF the server caps the response,
+        // and in that case `take(length)` would block waiting for bytes the
+        // server is never going to send if keep-alive semantics confuse the
+        // underlying reader.
+        let content_length = resp
+            .header("Content-Length")
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(length);
+        let to_read = content_length.min(length);
+
+        let mut buf = Vec::with_capacity(to_read as usize);
         resp.into_reader()
-            .take(length)
+            .take(to_read)
             .read_to_end(&mut buf)
             .map_err(MdfError::IOError)?;
         Ok(buf)

--- a/src/index.rs
+++ b/src/index.rs
@@ -278,51 +278,245 @@ impl ByteRangeReader for SliceRangeReader {
     }
 }
 
-/// Example HTTP range reader (would be implemented in production)
-/// ```rust,ignore
-/// use mf4_rs::index::ByteRangeReader;
-/// use mf4_rs::error::MdfError;
-/// 
-/// pub struct HttpRangeReader {
-///     client: reqwest::blocking::Client,
-///     url: String,
-/// }
-/// 
-/// impl HttpRangeReader {
-///     pub fn new(url: String) -> Self {
-///         Self {
-///             client: reqwest::blocking::Client::new(),
-///             url,
-///         }
-///     }
-/// }
-/// 
-/// impl ByteRangeReader for HttpRangeReader {
-///     type Error = MdfError;
-///     
-///     fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, Self::Error> {
-///         let range_header = format!("bytes={}-{}", offset, offset + length - 1);
-///         
-///         let response = self.client
-///             .get(&self.url)
-///             .header("Range", range_header)
-///             .send()
-///             .map_err(|e| MdfError::BlockSerializationError(format!("HTTP error: {}", e)))?;
-///         
-///         if !response.status().is_success() {
-///             return Err(MdfError::BlockSerializationError(
-///                 format!("HTTP error: {}", response.status())
-///             ));
-///         }
-///         
-///         let bytes = response.bytes()
-///             .map_err(|e| MdfError::BlockSerializationError(format!("Response error: {}", e)))?;
-///         
-///         Ok(bytes.to_vec())
-///     }
-/// }
-/// ```
-pub struct _HttpRangeReaderExample;
+/// Caching wrapper around any [`ByteRangeReader`].
+///
+/// During the metadata phase of building an [`MdfIndex`], the parser issues
+/// many small reads (block headers, channel metadata, text blocks). Without
+/// caching, each becomes a round-trip on a remote backend. `CachingRangeReader`
+/// fetches in larger aligned chunks (default 1 MiB) and serves overlapping
+/// reads from memory, collapsing hundreds of small reads into a handful of
+/// underlying requests.
+///
+/// For value reads — which span large slices of data blocks — call
+/// [`CachingRangeReader::set_bypass`] to forward each read directly to the
+/// underlying reader without populating the cache.
+pub struct CachingRangeReader<R: ByteRangeReader<Error = MdfError>> {
+    inner: R,
+    chunks: std::collections::BTreeMap<u64, Vec<u8>>,
+    chunk_size: u64,
+    bypass: bool,
+    underlying_requests: u64,
+    cache_hits: u64,
+}
+
+impl<R: ByteRangeReader<Error = MdfError>> CachingRangeReader<R> {
+    /// Wrap a reader with the default chunk size (1 MiB).
+    pub fn new(inner: R) -> Self {
+        Self::with_chunk_size(inner, 1 << 20)
+    }
+
+    /// Wrap a reader with a custom chunk size in bytes.
+    pub fn with_chunk_size(inner: R, chunk_size: u64) -> Self {
+        assert!(chunk_size > 0, "chunk_size must be > 0");
+        Self {
+            inner,
+            chunks: std::collections::BTreeMap::new(),
+            chunk_size,
+            bypass: false,
+            underlying_requests: 0,
+            cache_hits: 0,
+        }
+    }
+
+    /// When set, every read forwards directly to the underlying reader.
+    /// Use during value-read phases so large data-block fetches do not
+    /// populate the cache.
+    pub fn set_bypass(&mut self, bypass: bool) {
+        self.bypass = bypass;
+    }
+
+    /// Number of read calls forwarded to the underlying reader.
+    pub fn underlying_requests(&self) -> u64 {
+        self.underlying_requests
+    }
+
+    /// Number of read calls fully satisfied from cache.
+    pub fn cache_hits(&self) -> u64 {
+        self.cache_hits
+    }
+
+    /// Pre-fetch a contiguous range into the cache.
+    pub fn prefetch(&mut self, offset: u64, length: u64) -> Result<(), MdfError> {
+        if length == 0 {
+            return Ok(());
+        }
+        self.read_range(offset, length).map(|_| ())
+    }
+
+    fn ensure_chunks(&mut self, first: u64, last: u64) -> Result<(), MdfError> {
+        // Walk [first..=last], find each contiguous run of missing chunks,
+        // issue one read per run.
+        let mut idx = first;
+        while idx <= last {
+            if self.chunks.contains_key(&idx) {
+                idx += 1;
+                continue;
+            }
+            let run_start = idx;
+            while idx <= last && !self.chunks.contains_key(&idx) {
+                idx += 1;
+            }
+            let run_end = idx - 1;
+            let read_offset = run_start * self.chunk_size;
+            let read_len = (run_end - run_start + 1) * self.chunk_size;
+            let bytes = self.inner.read_range(read_offset, read_len)?;
+            self.underlying_requests += 1;
+
+            // Split the response into chunk-sized pieces. The last chunk
+            // may be short if the file ends partway through it.
+            for (i, slot) in (run_start..=run_end).enumerate() {
+                let start = i * self.chunk_size as usize;
+                if start >= bytes.len() {
+                    self.chunks.insert(slot, Vec::new());
+                    continue;
+                }
+                let end = std::cmp::min(start + self.chunk_size as usize, bytes.len());
+                self.chunks.insert(slot, bytes[start..end].to_vec());
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<R: ByteRangeReader<Error = MdfError>> ByteRangeReader for CachingRangeReader<R> {
+    type Error = MdfError;
+
+    fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, MdfError> {
+        if length == 0 {
+            return Ok(Vec::new());
+        }
+        if self.bypass {
+            let bytes = self.inner.read_range(offset, length)?;
+            self.underlying_requests += 1;
+            return Ok(bytes);
+        }
+
+        let first = offset / self.chunk_size;
+        let last = (offset + length - 1) / self.chunk_size;
+
+        // Track cache-hit metric only when no underlying read is required.
+        let need_fetch = (first..=last).any(|i| !self.chunks.contains_key(&i));
+        self.ensure_chunks(first, last)?;
+        if !need_fetch {
+            self.cache_hits += 1;
+        }
+
+        let mut out = Vec::with_capacity(length as usize);
+        let mut remaining = length as usize;
+        let mut cursor = offset;
+        while remaining > 0 {
+            let chunk_index = cursor / self.chunk_size;
+            let chunk_offset = (cursor % self.chunk_size) as usize;
+            let chunk = self.chunks.get(&chunk_index).expect("chunk fetched above");
+            if chunk_offset >= chunk.len() {
+                return Err(MdfError::TooShortBuffer {
+                    actual: chunk.len(),
+                    expected: chunk_offset + 1,
+                    file: file!(),
+                    line: line!(),
+                });
+            }
+            let take = std::cmp::min(remaining, chunk.len() - chunk_offset);
+            out.extend_from_slice(&chunk[chunk_offset..chunk_offset + take]);
+            cursor += take as u64;
+            remaining -= take;
+            if take == 0 {
+                break;
+            }
+        }
+
+        if out.len() != length as usize {
+            return Err(MdfError::TooShortBuffer {
+                actual: out.len(),
+                expected: length as usize,
+                file: file!(),
+                line: line!(),
+            });
+        }
+
+        Ok(out)
+    }
+}
+
+/// HTTP range-request reader using the synchronous [`ureq`] client.
+///
+/// Each [`ByteRangeReader::read_range`] call issues a single
+/// `Range: bytes=A-B` GET request and expects an HTTP 206 response. The
+/// underlying `ureq::Agent` is reused across calls so TCP keep-alive applies.
+///
+/// Wrap this in [`CachingRangeReader`] when building an index, otherwise the
+/// many small metadata reads will each become a separate round-trip.
+#[cfg(feature = "http")]
+pub struct HttpRangeReader {
+    agent: ureq::Agent,
+    url: String,
+    request_count: u64,
+}
+
+#[cfg(feature = "http")]
+impl HttpRangeReader {
+    pub fn new(url: impl Into<String>) -> Result<Self, MdfError> {
+        let agent = ureq::AgentBuilder::new().build();
+        Ok(Self {
+            agent,
+            url: url.into(),
+            request_count: 0,
+        })
+    }
+
+    /// Issue a HEAD request to learn the resource's `Content-Length`.
+    pub fn probe_size(&mut self) -> Result<u64, MdfError> {
+        let resp = self
+            .agent
+            .head(&self.url)
+            .call()
+            .map_err(|e| MdfError::BlockSerializationError(format!("HTTP HEAD error: {e}")))?;
+        self.request_count += 1;
+        let len = resp
+            .header("Content-Length")
+            .ok_or_else(|| {
+                MdfError::BlockSerializationError("HEAD response missing Content-Length".into())
+            })?
+            .parse::<u64>()
+            .map_err(|e| {
+                MdfError::BlockSerializationError(format!("invalid Content-Length: {e}"))
+            })?;
+        Ok(len)
+    }
+
+    /// Total number of HTTP requests issued by this reader.
+    pub fn request_count(&self) -> u64 {
+        self.request_count
+    }
+}
+
+#[cfg(feature = "http")]
+impl ByteRangeReader for HttpRangeReader {
+    type Error = MdfError;
+
+    fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, MdfError> {
+        use std::io::Read;
+
+        if length == 0 {
+            return Ok(Vec::new());
+        }
+        let range_header = format!("bytes={}-{}", offset, offset + length - 1);
+        let resp = self
+            .agent
+            .get(&self.url)
+            .set("Range", &range_header)
+            .call()
+            .map_err(|e| MdfError::BlockSerializationError(format!("HTTP GET error: {e}")))?;
+        self.request_count += 1;
+
+        let mut buf = Vec::with_capacity(length as usize);
+        resp.into_reader()
+            .take(length)
+            .read_to_end(&mut buf)
+            .map_err(MdfError::IOError)?;
+        Ok(buf)
+    }
+}
 
 impl MdfIndex {
     /// Create an index from an MDF file on disk.
@@ -472,6 +666,148 @@ impl MdfIndex {
         let file_size = data.len() as u64;
         let mdf = MDF::from_bytes(data)?;
         Self::build_index(mdf, file_size)
+    }
+
+    /// Build an [`MdfIndex`] using only [`ByteRangeReader`] calls.
+    ///
+    /// Issues range reads for the file's metadata structures (identification,
+    /// header, data groups, channel groups, channels, text and conversion
+    /// blocks, and data-block headers) but never reads the sample data
+    /// itself. Intended for remote sources such as HTTP-served files; wrap
+    /// the underlying reader in [`CachingRangeReader`] to keep the number of
+    /// underlying requests low.
+    ///
+    /// `file_size` is stored on the resulting index for use by later byte-range
+    /// calculations. Callers should obtain it from a HEAD request (e.g.
+    /// [`HttpRangeReader::probe_size`]) or other out-of-band metadata.
+    pub fn from_range_reader<R>(
+        reader: &mut R,
+        file_size: u64,
+    ) -> Result<Self, MdfError>
+    where
+        R: ByteRangeReader<Error = MdfError>,
+    {
+        use crate::parsing::reader_walk;
+
+        let walk = reader_walk::walk(reader)?;
+
+        let start_time_ns = if walk.header.abs_time == 0 {
+            None
+        } else {
+            Some(walk.header.abs_time)
+        };
+
+        let mut indexed_groups = Vec::with_capacity(walk.groups.len());
+        for group in walk.groups {
+            let mut indexed_channels = Vec::with_capacity(group.channels.len());
+            for ch in group.channels {
+                let block = ch.block;
+                indexed_channels.push(IndexedChannel {
+                    name: ch.name,
+                    unit: ch.unit,
+                    data_type: block.data_type.clone(),
+                    byte_offset: block.byte_offset,
+                    bit_offset: block.bit_offset,
+                    bit_count: block.bit_count,
+                    channel_type: block.channel_type,
+                    flags: block.flags,
+                    pos_invalidation_bit: block.pos_invalidation_bit,
+                    conversion: ch.conversion,
+                    vlsd_data_address: if block.channel_type == 1 && block.data != 0 {
+                        Some(block.data)
+                    } else {
+                        None
+                    },
+                });
+            }
+
+            let data_blocks =
+                Self::extract_data_blocks_via_reader(reader, group.data_block_addr)?;
+
+            indexed_groups.push(IndexedChannelGroup {
+                name: group.cg_name,
+                comment: group.cg_comment,
+                record_id_len: group.record_id_len,
+                record_size: group.cg.samples_byte_nr,
+                invalidation_bytes: group.cg.invalidation_bytes_nr,
+                record_count: group.cg.cycles_nr,
+                channels: indexed_channels,
+                data_blocks,
+            });
+        }
+
+        Ok(MdfIndex {
+            file_size,
+            start_time_ns,
+            channel_groups: indexed_groups,
+        })
+    }
+
+    /// Mirror of [`Self::extract_data_blocks`] that fetches headers via a
+    /// [`ByteRangeReader`] instead of slicing into a memory map.
+    fn extract_data_blocks_via_reader<R>(
+        reader: &mut R,
+        data_block_addr: u64,
+    ) -> Result<Vec<DataBlockInfo>, MdfError>
+    where
+        R: ByteRangeReader<Error = MdfError>,
+    {
+        let mut data_blocks = Vec::new();
+        let mut current_block_address = data_block_addr;
+
+        while current_block_address != 0 {
+            let header_bytes = reader.read_range(current_block_address, 24)?;
+            let block_header =
+                crate::blocks::common::BlockHeader::from_bytes(&header_bytes)?;
+
+            match block_header.id.as_str() {
+                "##DT" | "##DV" => {
+                    data_blocks.push(DataBlockInfo {
+                        file_offset: current_block_address,
+                        size: block_header.block_len,
+                        is_compressed: false,
+                    });
+                    current_block_address = 0;
+                }
+                "##DZ" => {
+                    data_blocks.push(DataBlockInfo {
+                        file_offset: current_block_address,
+                        size: block_header.block_len,
+                        is_compressed: true,
+                    });
+                    current_block_address = 0;
+                }
+                "##DL" => {
+                    let dl_bytes =
+                        reader.read_range(current_block_address, block_header.block_len)?;
+                    let data_list_block =
+                        crate::blocks::data_list_block::DataListBlock::from_bytes(&dl_bytes)?;
+
+                    for &fragment_address in &data_list_block.data_links {
+                        let frag_header_bytes = reader.read_range(fragment_address, 24)?;
+                        let fragment_header = crate::blocks::common::BlockHeader::from_bytes(
+                            &frag_header_bytes,
+                        )?;
+                        let is_compressed = fragment_header.id == "##DZ";
+                        data_blocks.push(DataBlockInfo {
+                            file_offset: fragment_address,
+                            size: fragment_header.block_len,
+                            is_compressed,
+                        });
+                    }
+
+                    current_block_address = data_list_block.next;
+                }
+                unexpected_id => {
+                    return Err(MdfError::BlockIDError {
+                        actual: unexpected_id.to_string(),
+                        expected: "##DT / ##DV / ##DL / ##DZ".to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(data_blocks)
     }
 
     /// Save the index to a JSON file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod parsing {
     pub mod raw_data_group;
     pub mod raw_channel;
     pub mod source_info;
+    pub(crate) mod reader_walk;
 }
 
 pub mod api {

--- a/src/parsing/reader_walk.rs
+++ b/src/parsing/reader_walk.rs
@@ -1,0 +1,135 @@
+//! Walk an MDF file's metadata via a [`crate::index::ByteRangeReader`].
+//!
+//! Mirrors the mmap-based walk in [`crate::parsing::mdf_file::MdfFile::parse_from_file`]
+//! but issues range reads instead of slicing into a memory map. Only metadata
+//! is read (block headers, channel/group descriptors, name/comment text
+//! blocks, conversion blocks). Sample data is not touched. This is the
+//! foundation for building an [`crate::index::MdfIndex`] from a remote source
+//! such as an HTTP URL or S3 object without downloading the whole file.
+
+use crate::blocks::channel_block::ChannelBlock;
+use crate::blocks::channel_group_block::ChannelGroupBlock;
+use crate::blocks::common::{read_string_block_via_reader, BlockHeader, BlockParse};
+use crate::blocks::conversion::ConversionBlock;
+use crate::blocks::data_group_block::DataGroupBlock;
+use crate::blocks::header_block::HeaderBlock;
+use crate::blocks::identification_block::IdentificationBlock;
+use crate::error::MdfError;
+use crate::index::ByteRangeReader;
+
+pub(crate) struct WalkedChannel {
+    pub block: ChannelBlock,
+    pub name: Option<String>,
+    pub unit: Option<String>,
+    pub conversion: Option<ConversionBlock>,
+}
+
+pub(crate) struct WalkedGroup {
+    pub record_id_len: u8,
+    pub data_block_addr: u64,
+    pub cg: ChannelGroupBlock,
+    pub cg_name: Option<String>,
+    pub cg_comment: Option<String>,
+    pub channels: Vec<WalkedChannel>,
+}
+
+pub(crate) struct ReaderWalkResult {
+    #[allow(dead_code)]
+    pub identification: IdentificationBlock,
+    pub header: HeaderBlock,
+    pub groups: Vec<WalkedGroup>,
+}
+
+const ID_BLOCK_LEN: u64 = 64;
+const HD_BLOCK_LEN: u64 = 104;
+const DG_BLOCK_LEN: u64 = 64;
+const CG_BLOCK_LEN: u64 = 104;
+const CN_BLOCK_LEN: u64 = 160;
+
+pub(crate) fn walk<R>(reader: &mut R) -> Result<ReaderWalkResult, MdfError>
+where
+    R: ByteRangeReader<Error = MdfError>,
+{
+    // ##ID at offset 0, ##HD at offset 64.
+    let id_bytes = reader.read_range(0, ID_BLOCK_LEN)?;
+    let identification = IdentificationBlock::from_bytes(&id_bytes)?;
+
+    let hd_bytes = reader.read_range(ID_BLOCK_LEN, HD_BLOCK_LEN)?;
+    let header = HeaderBlock::from_bytes(&hd_bytes)?;
+
+    let mut groups = Vec::new();
+    let mut dg_addr = header.first_dg_addr;
+    while dg_addr != 0 {
+        let dg_bytes = reader.read_range(dg_addr, DG_BLOCK_LEN)?;
+        let dg = DataGroupBlock::from_bytes(&dg_bytes)?;
+        let next_dg_addr = dg.next_dg_addr;
+        let mut cg_addr = dg.first_cg_addr;
+
+        while cg_addr != 0 {
+            let cg_bytes = reader.read_range(cg_addr, CG_BLOCK_LEN)?;
+            let cg = ChannelGroupBlock::from_bytes(&cg_bytes)?;
+            let next_cg_addr = cg.next_cg_addr;
+
+            let cg_name = read_string_block_via_reader(reader, cg.acq_name_addr)?;
+            let cg_comment = read_string_block_via_reader(reader, cg.comment_addr)?;
+
+            let mut channels = Vec::new();
+            let mut ch_addr = cg.first_ch_addr;
+            while ch_addr != 0 {
+                let cn_bytes = reader.read_range(ch_addr, CN_BLOCK_LEN)?;
+                let cn = ChannelBlock::from_bytes(&cn_bytes)?;
+                let next_ch_addr = cn.next_ch_addr;
+
+                let name = read_string_block_via_reader(reader, cn.name_addr)?;
+                let unit = read_string_block_via_reader(reader, cn.unit_addr)?;
+
+                let conversion = if cn.conversion_addr != 0 {
+                    let cc_header_bytes = reader.read_range(cn.conversion_addr, 24)?;
+                    let cc_header = BlockHeader::from_bytes(&cc_header_bytes)?;
+                    let cc_full =
+                        reader.read_range(cn.conversion_addr, cc_header.block_len)?;
+                    let mut cc = ConversionBlock::from_bytes(&cc_full)?;
+                    if let Err(e) =
+                        cc.resolve_all_dependencies_via_reader(reader, cn.conversion_addr)
+                    {
+                        eprintln!(
+                            "Warning: failed to resolve conversion for channel {:?}: {e}",
+                            name.as_deref().unwrap_or("<unnamed>")
+                        );
+                    }
+                    Some(cc)
+                } else {
+                    None
+                };
+
+                channels.push(WalkedChannel {
+                    block: cn,
+                    name,
+                    unit,
+                    conversion,
+                });
+
+                ch_addr = next_ch_addr;
+            }
+
+            groups.push(WalkedGroup {
+                record_id_len: dg.record_id_len,
+                data_block_addr: dg.data_block_addr,
+                cg,
+                cg_name,
+                cg_comment,
+                channels,
+            });
+
+            cg_addr = next_cg_addr;
+        }
+
+        dg_addr = next_dg_addr;
+    }
+
+    Ok(ReaderWalkResult {
+        identification,
+        header,
+        groups,
+    })
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -17,7 +17,10 @@ use std::collections::HashMap;
 
 use crate::api::mdf::MDF;
 use crate::writer::{MdfWriter, ColumnData};
-use crate::index::{MdfIndex, FileRangeReader, IndexedChannel};
+use crate::index::{
+    ByteRangeReader, CachingRangeReader, FileRangeReader, HttpRangeReader, IndexedChannel,
+    MdfIndex,
+};
 use crate::blocks::common::DataType;
 use crate::parsing::decoder::DecodedValue;
 use crate::error::MdfError;
@@ -878,9 +881,9 @@ impl PyMdfWriter {
     /// Parameters
     /// ----------
     /// name : Optional[str]
-    ///     Group name. **Currently ignored** — the underlying writer does
-    ///     not yet emit ``acq_name`` / metadata for groups. Pass any value
-    ///     (or ``None``) for forward compatibility.
+    ///     Group acquisition name. Written as a ``##TX`` block referenced
+    ///     from the new ``##CG`` via ``acq_name_addr``. Pass ``None`` to
+    ///     leave it unset.
     ///
     /// Returns
     /// -------
@@ -889,18 +892,37 @@ impl PyMdfWriter {
     ///     ``add_channel`` / ``write_record`` / ``finish_data_block`` calls.
     fn add_channel_group(&mut self, name: Option<String>) -> PyResult<String> {
         if let Some(ref mut writer) = self.writer {
-            let cg_id = writer.add_channel_group(None, |_cg| {
-                // Could set channel group properties here
-            })?;
-            
+            let cg_id = writer.add_channel_group(None, |_cg| {})?;
+            if let Some(n) = &name {
+                writer.set_channel_group_name(&cg_id, n)?;
+            }
+
             let py_id = format!("cg_{}", self.next_id);
             self.next_id += 1;
             self.channel_groups.insert(py_id.clone(), cg_id);
-            
+
             Ok(py_id)
         } else {
             Err(MdfException::new_err("Writer has been finalized"))
         }
+    }
+
+    /// Attach a comment / description to a channel group.
+    ///
+    /// Writes a ``##TX`` block holding ``comment`` and links it from the
+    /// group's ``comment_addr`` field.
+    fn set_channel_group_comment(&mut self, group_id: &str, comment: &str) -> PyResult<()> {
+        let writer = self
+            .writer
+            .as_mut()
+            .ok_or_else(|| MdfException::new_err("Writer has been finalized"))?;
+        let rust_id = self
+            .channel_groups
+            .get(group_id)
+            .ok_or_else(|| MdfException::new_err(format!("Unknown group_id: {}", group_id)))?
+            .clone();
+        writer.set_channel_group_comment(&rust_id, comment)?;
+        Ok(())
     }
     
     /// Add a generic channel to a channel group, using the data type's
@@ -1261,6 +1283,49 @@ impl PyMdfIndex {
         Ok(PyMdfIndex { index })
     }
 
+    /// Build an index from an MDF file served over HTTP / S3 using range
+    /// requests, without downloading the whole file.
+    ///
+    /// Issues range reads only for metadata blocks (``##ID``, ``##HD``,
+    /// ``##DG``, ``##CG``, ``##CN``, name / unit / comment ``##TX``,
+    /// conversion ``##CC`` plus its ``cc_ref`` chain, and ``##DT``/``##DV``/
+    /// ``##DZ``/``##DL`` headers). Sample data is never fetched. With the
+    /// default 1 MiB read-ahead chunk, a typical file collapses to a handful
+    /// of underlying HTTP requests regardless of file size.
+    ///
+    /// Parameters
+    /// ----------
+    /// url : str
+    ///     ``http://`` or ``https://`` URL of the ``.mf4`` resource. The
+    ///     server must honour single-range ``Range: bytes=A-B`` requests.
+    /// chunk_size : int, optional
+    ///     Read-ahead chunk size in bytes for the metadata phase
+    ///     (default 1 MiB). Smaller values reduce wasted bytes when
+    ///     metadata is densely packed near the file head; larger values
+    ///     reduce the number of HTTP round-trips when metadata is
+    ///     scattered across the file.
+    ///
+    /// Raises
+    /// ------
+    /// MdfException
+    ///     If the URL cannot be reached, the server does not honour
+    ///     range requests, or the response is not a valid MDF file.
+    #[staticmethod]
+    fn from_url(py: Python, url: &str, chunk_size: Option<u64>) -> PyResult<Self> {
+        // Release the GIL: ureq does blocking socket I/O and any HTTP server
+        // running in the same Python interpreter (e.g. a `http.server` test
+        // fixture) needs the GIL to handle requests.
+        let url = url.to_string();
+        let chunk = chunk_size.unwrap_or(1 << 20);
+        let index = py.allow_threads(move || -> Result<MdfIndex, MdfError> {
+            let mut http = HttpRangeReader::new(&url)?;
+            let file_size = http.probe_size()?;
+            let mut cached = CachingRangeReader::with_chunk_size(http, chunk);
+            MdfIndex::from_range_reader(&mut cached, file_size)
+        })?;
+        Ok(PyMdfIndex { index })
+    }
+
     /// Serialize the index to JSON at ``path``.
     ///
     /// Output is dependency-free (no references back to the source MDF) and
@@ -1349,7 +1414,70 @@ impl PyMdfIndex {
             opt_val.map(|dv| decoded_value_to_pyobject(dv, py))
         }).collect())
     }
-    
+
+    /// Read every sample of a channel via HTTP range requests.
+    ///
+    /// Issues one HTTP request per data block holding this channel. Cache
+    /// is bypassed because data-block payloads are typically far larger
+    /// than any sensible chunk size; one ranged ``GET`` per block is the
+    /// cheapest pattern.
+    ///
+    /// Parameters
+    /// ----------
+    /// group_index : int
+    /// channel_index : int
+    /// url : str
+    ///     URL of the same MDF file the index was built from.
+    ///
+    /// Returns
+    /// -------
+    /// list[Optional[Union[float, int, str, bytes]]]
+    ///     One entry per record. ``None`` indicates an invalid sample.
+    fn read_channel_values_from_url(
+        &self,
+        py: Python,
+        group_index: usize,
+        channel_index: usize,
+        url: &str,
+    ) -> PyResult<Vec<Option<PyObject>>> {
+        let url = url.to_string();
+        let values = py.allow_threads(move || -> Result<_, MdfError> {
+            let http = HttpRangeReader::new(&url)?;
+            let mut cached = CachingRangeReader::new(http);
+            cached.set_bypass(true);
+            self.index
+                .read_channel_values(group_index, channel_index, &mut cached)
+        })?;
+        Ok(values
+            .into_iter()
+            .map(|opt_val| opt_val.map(|dv| decoded_value_to_pyobject(dv, py)))
+            .collect())
+    }
+
+    /// Read every sample of a channel by name via HTTP range requests.
+    ///
+    /// See :py:meth:`read_channel_values_from_url` for the I/O contract.
+    fn read_channel_values_by_name_from_url(
+        &self,
+        py: Python,
+        channel_name: &str,
+        url: &str,
+    ) -> PyResult<Vec<Option<PyObject>>> {
+        let url = url.to_string();
+        let channel_name = channel_name.to_string();
+        let values = py.allow_threads(move || -> Result<_, MdfError> {
+            let http = HttpRangeReader::new(&url)?;
+            let mut cached = CachingRangeReader::new(http);
+            cached.set_bypass(true);
+            self.index
+                .read_channel_values_by_name(&channel_name, &mut cached)
+        })?;
+        Ok(values
+            .into_iter()
+            .map(|opt_val| opt_val.map(|dv| decoded_value_to_pyobject(dv, py)))
+            .collect())
+    }
+
     /// Fast path: read a numeric channel as a list of ``float`` values.
     ///
     /// Several times faster than :py:meth:`read_channel_values` for numeric

--- a/src/writer/mdf_writer/init.rs
+++ b/src/writer/mdf_writer/init.rs
@@ -180,6 +180,41 @@ impl MdfWriter {
         Ok((cc_id, pos))
     }
 
+    /// Write a `##TX` block holding `name` and link it as the channel group's
+    /// `acq_name_addr`.
+    ///
+    /// The MDF 4 specification places the acquisition name link at offset 40
+    /// (the third link slot) inside the `##CG` block.
+    pub fn set_channel_group_name(
+        &mut self,
+        cg_id: &str,
+        name: &str,
+    ) -> Result<(), MdfError> {
+        let tx_id = format!("tx_cg_name_{cg_id}");
+        let tx_block = TextBlock::new(name);
+        let tx_bytes = tx_block.to_bytes()?;
+        self.write_block_with_id(&tx_bytes, &tx_id)?;
+        let acq_name_link_offset = 40;
+        self.update_block_link(cg_id, acq_name_link_offset, &tx_id)
+    }
+
+    /// Write a `##TX` block holding `comment` and link it as the channel
+    /// group's `comment_addr`.
+    ///
+    /// The comment link is at offset 64 inside the `##CG` block.
+    pub fn set_channel_group_comment(
+        &mut self,
+        cg_id: &str,
+        comment: &str,
+    ) -> Result<(), MdfError> {
+        let tx_id = format!("tx_cg_comment_{cg_id}");
+        let tx_block = TextBlock::new(comment);
+        let tx_bytes = tx_block.to_bytes()?;
+        self.write_block_with_id(&tx_bytes, &tx_id)?;
+        let comment_link_offset = 64;
+        self.update_block_link(cg_id, comment_link_offset, &tx_id)
+    }
+
     /// Adds a channel block to the specified channel group and links it.
     pub fn add_channel<F>(
         &mut self,

--- a/tests/cloud_index.rs
+++ b/tests/cloud_index.rs
@@ -32,12 +32,13 @@ fn build_fixture(path: &Path) -> Result<(), MdfError> {
     let mut writer = MdfWriter::new(path.to_str().unwrap())?;
     writer.init_mdf_file()?;
 
-    let mut prev_cg: Option<String> = None;
     let mut cg_ids: Vec<String> = Vec::new();
     let mut cn_ids_per_group: Vec<Vec<String>> = Vec::new();
 
     for g in 0..GROUPS {
-        let cg_id = writer.add_channel_group(prev_cg.as_deref(), |_| {})?;
+        // Each add_channel_group creates a new ##DG, so prev_cg_id stays None
+        // (it would chain CGs *within* a DG, which is not what we want).
+        let cg_id = writer.add_channel_group(None, |_| {})?;
         writer.set_channel_group_name(&cg_id, &format!("Group {g}"))?;
         writer.set_channel_group_comment(&cg_id, &format!("Comment for group {g}"))?;
 
@@ -73,9 +74,8 @@ fn build_fixture(path: &Path) -> Result<(), MdfError> {
             writer.add_value_to_text_conversion(&[(0, "OK"), (1, "WARN")], "UNK", Some(&target))?;
         }
 
-        cg_ids.push(cg_id.clone());
+        cg_ids.push(cg_id);
         cn_ids_per_group.push(cn_ids);
-        prev_cg = Some(cg_id);
         let _ = group_name;
     }
 
@@ -311,6 +311,189 @@ fn cloud_index_round_trips_within_budget() -> Result<(), MdfError> {
     assert!(
         total_requests <= 10,
         "underlying HTTP requests = {total_requests} (>10)"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn cloud_index_handles_scattered_metadata() -> Result<(), MdfError> {
+    // Scenario: each channel group's data is written *before* the next group is
+    // created, so each CG's metadata cluster (DG + CG + CN + TX blocks) sits
+    // past the previous CG's data block on disk. With a 1 MiB read-ahead
+    // cache, the first chunk no longer covers all metadata: the walk must
+    // pull additional chunks as it follows the next_dg_addr chain.
+    //
+    // Demonstrates that:
+    //   - the index still builds correctly when metadata is scattered,
+    //   - the cache still collapses many small reads into a handful of
+    //     underlying requests,
+    //   - both the metric and wall-time stay within a documented budget.
+    const SCATTER_GROUPS: usize = 5;
+    const SCATTER_CHANNELS_PER_GROUP: usize = 5; // 1 master + 4 data, all f64
+    const SCATTER_RECORDS: usize = 30_000;       // 30k * 40 B = 1.2 MiB per DT
+
+    let tmp = tempfile::tempdir().map_err(MdfError::IOError)?;
+    let mf4 = tmp.path().join("scattered.mf4");
+
+    // Build the fixture: for each group, fully configure it AND write its
+    // data block before moving on to the next group. This forces the
+    // writer to interleave large DT blocks with small metadata clusters.
+    {
+        let mut writer = MdfWriter::new(mf4.to_str().unwrap())?;
+        writer.init_mdf_file()?;
+
+        for g in 0..SCATTER_GROUPS {
+            // Each add_channel_group creates a new ##DG, so prev_cg_id stays None.
+            let cg_id = writer.add_channel_group(None, |_| {})?;
+            writer.set_channel_group_name(&cg_id, &format!("Group {g}"))?;
+            writer.set_channel_group_comment(&cg_id, &format!("Comment for group {g}"))?;
+
+            let time_id = writer.add_channel(&cg_id, None, |ch| {
+                ch.data_type = DataType::FloatLE;
+                ch.name = Some(format!("t_{g}"));
+                ch.bit_count = 64;
+            })?;
+            writer.set_time_channel(&time_id)?;
+
+            let mut prev_cn = time_id;
+            for j in 1..SCATTER_CHANNELS_PER_GROUP {
+                let cn = writer.add_channel(&cg_id, Some(&prev_cn), |ch| {
+                    ch.data_type = DataType::FloatLE;
+                    ch.bit_count = 64;
+                    ch.name = Some(format!("ch_{g}_{j}"));
+                })?;
+                prev_cn = cn;
+            }
+
+            // Write data BEFORE creating the next CG.
+            writer.start_data_block_for_cg(&cg_id, 0)?;
+            for r in 0..SCATTER_RECORDS {
+                let mut record: Vec<DecodedValue> =
+                    Vec::with_capacity(SCATTER_CHANNELS_PER_GROUP);
+                record.push(DecodedValue::Float(r as f64 * 0.001));
+                for j in 1..SCATTER_CHANNELS_PER_GROUP {
+                    record.push(DecodedValue::Float((g * 1_000_000 + r * j) as f64));
+                }
+                writer.write_record(&cg_id, &record)?;
+            }
+            writer.finish_data_block(&cg_id)?;
+        }
+        writer.finalize()?;
+    }
+
+    let file_size = std::fs::metadata(&mf4).map_err(MdfError::IOError)?.len();
+    // Sanity: file should be > 5 MiB so CGs land in distinct 1 MiB chunks.
+    assert!(
+        file_size >= 5 * 1024 * 1024,
+        "fixture too small to scatter metadata: {file_size} bytes"
+    );
+
+    let (url, _server) = spawn_range_server(mf4.clone())?;
+    thread::sleep(Duration::from_millis(50));
+
+    let started = Instant::now();
+    let http = HttpRangeReader::new(&url)?;
+    let mut cached = CachingRangeReader::with_chunk_size(http, 1 << 20);
+
+    let index = MdfIndex::from_range_reader(&mut cached, file_size)?;
+
+    // Correctness: all groups, names, comments, channel names recovered.
+    assert_eq!(index.channel_groups.len(), SCATTER_GROUPS);
+    for (i, g) in index.channel_groups.iter().enumerate() {
+        assert_eq!(g.channels.len(), SCATTER_CHANNELS_PER_GROUP);
+        assert_eq!(g.name.as_deref(), Some(format!("Group {i}").as_str()));
+        assert_eq!(
+            g.comment.as_deref(),
+            Some(format!("Comment for group {i}").as_str())
+        );
+        assert_eq!(g.record_count, SCATTER_RECORDS as u64);
+        assert_eq!(g.channels[0].name.as_deref(), Some(format!("t_{i}").as_str()));
+        for (j, ch) in g.channels.iter().enumerate().skip(1) {
+            assert_eq!(
+                ch.name.as_deref(),
+                Some(format!("ch_{i}_{j}").as_str()),
+                "group {i} channel {j} name"
+            );
+        }
+    }
+
+    let metadata_requests = cached.underlying_requests();
+
+    // The interesting assertion: scattered metadata REQUIRES > 1 underlying
+    // request (the first 1 MiB chunk cannot cover all groups), but the
+    // cache should still keep total fetches in single digits.
+    assert!(
+        metadata_requests >= 2,
+        "expected scattered metadata to require >=2 chunks, got {metadata_requests}"
+    );
+    assert!(
+        metadata_requests <= SCATTER_GROUPS as u64 + 2,
+        "metadata cache too inefficient: {metadata_requests} requests for {SCATTER_GROUPS} groups"
+    );
+
+    // Read 5 channels via bypass mode.
+    cached.set_bypass(true);
+    let targets: &[(&str, &str)] = &[
+        ("Group 0", "t_0"),
+        ("Group 1", "ch_1_2"),
+        ("Group 2", "ch_2_4"),
+        ("Group 3", "ch_3_1"),
+        ("Group 4", "ch_4_3"),
+    ];
+    for (gn, cn) in targets {
+        let g = index.find_channel_group_by_name(gn).unwrap();
+        let c = index.find_channel_by_name(g, cn).unwrap();
+        let vals = index.read_channel_values(g, c, &mut cached)?;
+        assert_eq!(vals.len(), SCATTER_RECORDS, "{gn}/{cn}");
+        // Spot-check decoded value matches what was written.
+        let group_idx: usize = gn
+            .strip_prefix("Group ")
+            .and_then(|s| s.parse().ok())
+            .unwrap();
+        if let Some(DecodedValue::Float(actual)) = vals[10].as_ref() {
+            // master = r * 0.001; data = (group * 1_000_000 + r * j) as f64
+            if cn.starts_with("t_") {
+                assert!((actual - 10.0 * 0.001).abs() < 1e-9);
+            } else {
+                let j: usize = cn
+                    .rsplit('_')
+                    .next()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap();
+                let expected = (group_idx * 1_000_000 + 10 * j) as f64;
+                assert!(
+                    (actual - expected).abs() < 1e-3,
+                    "{gn}/{cn}[10]: got {actual}, want {expected}"
+                );
+            }
+        } else {
+            panic!("{gn}/{cn} missing decoded value at index 10");
+        }
+    }
+
+    let elapsed = started.elapsed();
+    let total_requests = cached.underlying_requests();
+    let value_requests = total_requests - metadata_requests;
+
+    eprintln!(
+        "[scattered] file_size={file_size} metadata_requests={metadata_requests} \
+         value_requests={value_requests} total={total_requests} \
+         elapsed={:?} cache_hits={}",
+        elapsed,
+        cached.cache_hits()
+    );
+
+    // Loose budget: each scattered group might pull its own chunk, plus
+    // 5 value reads. Assert single-digit-per-group worst case.
+    assert!(
+        total_requests <= (SCATTER_GROUPS as u64 + 2) + targets.len() as u64,
+        "total HTTP requests {total_requests} exceeds budget"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "scattered scenario took {:?} — over 5s budget",
+        elapsed
     );
 
     Ok(())

--- a/tests/cloud_index.rs
+++ b/tests/cloud_index.rs
@@ -1,0 +1,358 @@
+//! End-to-end test for index creation + value reads over HTTP range requests.
+//!
+//! Builds a fixture MDF file with 10 channel groups (each carrying a name and
+//! comment) × 10 channels (each with a text name; one channel uses a
+//! value-to-text conversion). Serves the file via a local `tiny_http` server
+//! that honours single-range `Range: bytes=A-B` requests, builds an
+//! `MdfIndex` over `CachingRangeReader<HttpRangeReader>`, then reads 5
+//! channels using the same reader with caching bypassed.
+//!
+//! Headline metric: ≤ 10 underlying HTTP requests for the whole flow.
+
+#![cfg(all(feature = "http", not(target_arch = "wasm32")))]
+
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::error::MdfError;
+use mf4_rs::index::{CachingRangeReader, HttpRangeReader, MdfIndex};
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::writer::MdfWriter;
+
+const GROUPS: usize = 10;
+const CHANNELS_PER_GROUP: usize = 10; // 1 master + 9 data
+const RECORDS: usize = 200;
+
+fn build_fixture(path: &Path) -> Result<(), MdfError> {
+    let mut writer = MdfWriter::new(path.to_str().unwrap())?;
+    writer.init_mdf_file()?;
+
+    let mut prev_cg: Option<String> = None;
+    let mut cg_ids: Vec<String> = Vec::new();
+    let mut cn_ids_per_group: Vec<Vec<String>> = Vec::new();
+
+    for g in 0..GROUPS {
+        let cg_id = writer.add_channel_group(prev_cg.as_deref(), |_| {})?;
+        writer.set_channel_group_name(&cg_id, &format!("Group {g}"))?;
+        writer.set_channel_group_comment(&cg_id, &format!("Comment for group {g}"))?;
+
+        let group_name = format!("Group {g}");
+        let time_name = format!("t_{g}");
+        let time_id = writer.add_channel(&cg_id, None, |ch| {
+            ch.data_type = DataType::FloatLE;
+            ch.name = Some(time_name.clone());
+            ch.bit_count = 64;
+        })?;
+        writer.set_time_channel(&time_id)?;
+
+        let mut cn_ids = vec![time_id.clone()];
+        for j in 1..CHANNELS_PER_GROUP {
+            let prev = cn_ids.last().unwrap().clone();
+            let chan_name = format!("ch_{g}_{j}");
+            let cn_id = writer.add_channel(&cg_id, Some(&prev), |ch| {
+                if j % 2 == 0 {
+                    ch.data_type = DataType::FloatLE;
+                    ch.bit_count = 64;
+                } else {
+                    ch.data_type = DataType::UnsignedIntegerLE;
+                    ch.bit_count = 32;
+                }
+                ch.name = Some(chan_name.clone());
+            })?;
+            cn_ids.push(cn_id);
+        }
+
+        // One value-to-text conversion on group 0, channel 9.
+        if g == 0 {
+            let target = cn_ids[CHANNELS_PER_GROUP - 1].clone();
+            writer.add_value_to_text_conversion(&[(0, "OK"), (1, "WARN")], "UNK", Some(&target))?;
+        }
+
+        cg_ids.push(cg_id.clone());
+        cn_ids_per_group.push(cn_ids);
+        prev_cg = Some(cg_id);
+        let _ = group_name;
+    }
+
+    // Write records for each group: master is f64 time, others alternate.
+    for (g, cg_id) in cg_ids.iter().enumerate() {
+        writer.start_data_block_for_cg(cg_id, 0)?;
+        for r in 0..RECORDS {
+            let mut record: Vec<DecodedValue> = Vec::with_capacity(CHANNELS_PER_GROUP);
+            record.push(DecodedValue::Float(r as f64 * 0.01));
+            for j in 1..CHANNELS_PER_GROUP {
+                if j % 2 == 0 {
+                    record.push(DecodedValue::Float((g * 100 + r) as f64));
+                } else if g == 0 && j == 9 {
+                    // Value-to-text candidate: alternate 0/1/2 so we exercise the default.
+                    record.push(DecodedValue::UnsignedInteger((r % 3) as u64));
+                } else {
+                    record.push(DecodedValue::UnsignedInteger((r * (j as usize)) as u64));
+                }
+            }
+            writer.write_record(cg_id, &record)?;
+        }
+        writer.finish_data_block(cg_id)?;
+    }
+
+    writer.finalize()?;
+    Ok(())
+}
+
+struct ServerHandle {
+    handle: Option<thread::JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
+}
+
+impl Drop for ServerHandle {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+fn spawn_range_server(file_path: PathBuf) -> Result<(String, ServerHandle), MdfError> {
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(MdfError::IOError)?;
+    let local_addr = listener.local_addr().map_err(MdfError::IOError)?;
+    let url = format!("http://{}/file", local_addr);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_thread = stop.clone();
+
+    let server = tiny_http::Server::from_listener(listener, None).map_err(|e| {
+        MdfError::BlockSerializationError(format!("tiny_http listener error: {e}"))
+    })?;
+
+    let handle = thread::spawn(move || {
+        let bytes = match std::fs::read(&file_path) {
+            Ok(b) => b,
+            Err(_) => return,
+        };
+        let total = bytes.len() as u64;
+
+        loop {
+            if stop_thread.load(Ordering::SeqCst) {
+                break;
+            }
+            match server.recv_timeout(Duration::from_millis(50)) {
+                Ok(Some(req)) => {
+                    let range_header = req
+                        .headers()
+                        .iter()
+                        .find(|h| h.field.as_str().as_str().eq_ignore_ascii_case("range"))
+                        .map(|h| h.value.as_str().to_string());
+
+                    if let Some(range) = range_header.as_deref() {
+                        if let Some((start, end)) = parse_byte_range(range, total) {
+                            let body = &bytes[start as usize..=end as usize];
+                            let content_range = format!("bytes {}-{}/{}", start, end, total);
+                            let mut resp = tiny_http::Response::from_data(body.to_vec())
+                                .with_status_code(206);
+                            resp.add_header(
+                                tiny_http::Header::from_bytes(
+                                    &b"Content-Range"[..],
+                                    content_range.as_bytes(),
+                                )
+                                .unwrap(),
+                            );
+                            resp.add_header(
+                                tiny_http::Header::from_bytes(
+                                    &b"Accept-Ranges"[..],
+                                    &b"bytes"[..],
+                                )
+                                .unwrap(),
+                            );
+                            let _ = req.respond(resp);
+                            continue;
+                        }
+                    }
+
+                    // No (or invalid) Range → return whole file.
+                    let mut resp = tiny_http::Response::from_data(bytes.clone());
+                    resp.add_header(
+                        tiny_http::Header::from_bytes(&b"Accept-Ranges"[..], &b"bytes"[..])
+                            .unwrap(),
+                    );
+                    let _ = req.respond(resp);
+                }
+                Ok(None) => continue,
+                Err(_) => break,
+            }
+        }
+    });
+
+    Ok((
+        url,
+        ServerHandle {
+            handle: Some(handle),
+            stop,
+        },
+    ))
+}
+
+fn parse_byte_range(value: &str, total: u64) -> Option<(u64, u64)> {
+    let v = value.trim();
+    let rest = v.strip_prefix("bytes=")?;
+    let (s, e) = rest.split_once('-')?;
+    let start: u64 = s.parse().ok()?;
+    let end: u64 = if e.is_empty() {
+        total - 1
+    } else {
+        e.parse().ok()?
+    };
+    if start >= total {
+        return None;
+    }
+    let end = end.min(total - 1);
+    Some((start, end))
+}
+
+#[test]
+fn cloud_index_round_trips_within_budget() -> Result<(), MdfError> {
+    let tmp = tempfile::tempdir().map_err(MdfError::IOError)?;
+    let mf4 = tmp.path().join("fixture.mf4");
+    build_fixture(&mf4)?;
+    let file_size = std::fs::metadata(&mf4).map_err(MdfError::IOError)?.len();
+
+    let (url, _server) = spawn_range_server(mf4.clone())?;
+
+    // Give the server a beat to start accepting connections.
+    thread::sleep(Duration::from_millis(50));
+
+    let started = Instant::now();
+
+    let http = HttpRangeReader::new(&url)?;
+    let mut cached = CachingRangeReader::with_chunk_size(http, 1 << 20);
+
+    let index = MdfIndex::from_range_reader(&mut cached, file_size)?;
+
+    assert_eq!(index.channel_groups.len(), GROUPS, "group count");
+    for (i, g) in index.channel_groups.iter().enumerate() {
+        assert_eq!(g.channels.len(), CHANNELS_PER_GROUP, "group {i} channels");
+        assert_eq!(
+            g.name.as_deref(),
+            Some(format!("Group {i}").as_str()),
+            "group {i} name"
+        );
+        assert_eq!(
+            g.comment.as_deref(),
+            Some(format!("Comment for group {i}").as_str()),
+            "group {i} comment"
+        );
+        assert_eq!(g.record_count, RECORDS as u64, "group {i} record count");
+
+        // Master channel name is t_{i}, others are ch_{i}_{j}.
+        assert_eq!(g.channels[0].name.as_deref(), Some(format!("t_{i}").as_str()));
+        for (j, ch) in g.channels.iter().enumerate().skip(1) {
+            assert_eq!(
+                ch.name.as_deref(),
+                Some(format!("ch_{i}_{j}").as_str()),
+                "group {i} channel {j} name"
+            );
+        }
+    }
+
+    let metadata_requests = cached.underlying_requests();
+
+    // Switch to bypass for value reads — large DT bodies should not
+    // pollute the chunk cache.
+    cached.set_bypass(true);
+
+    let targets: &[(&str, &str)] = &[
+        ("Group 0", "ch_0_9"), // value-to-text conversion
+        ("Group 2", "t_2"),    // master
+        ("Group 4", "ch_4_3"),
+        ("Group 7", "ch_7_1"),
+        ("Group 9", "ch_9_8"),
+    ];
+
+    for (gn, cn) in targets {
+        let g = index
+            .find_channel_group_by_name(gn)
+            .unwrap_or_else(|| panic!("group {gn} not found"));
+        let c = index
+            .find_channel_by_name(g, cn)
+            .unwrap_or_else(|| panic!("channel {cn} not found in {gn}"));
+        let vals = index.read_channel_values(g, c, &mut cached)?;
+        assert_eq!(vals.len(), RECORDS, "{gn}/{cn} record count");
+
+        if *gn == "Group 0" && *cn == "ch_0_9" {
+            // The value-to-text conversion should yield strings.
+            let any_string = vals
+                .iter()
+                .any(|v| matches!(v, Some(DecodedValue::String(_))));
+            assert!(any_string, "expected at least one String value via V2T");
+        }
+    }
+
+    let elapsed = started.elapsed();
+    let total_requests = cached.underlying_requests();
+    let value_requests = total_requests - metadata_requests;
+
+    eprintln!(
+        "metadata_requests={metadata_requests} value_requests={value_requests} \
+         total={total_requests} elapsed={:?} cache_hits={}",
+        elapsed,
+        cached.cache_hits()
+    );
+
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "wall-time {:?} exceeded 2s budget",
+        elapsed
+    );
+    assert!(
+        total_requests <= 10,
+        "underlying HTTP requests = {total_requests} (>10)"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn caching_range_reader_collapses_small_reads() -> Result<(), MdfError> {
+    use mf4_rs::index::{ByteRangeReader, SliceRangeReader};
+
+    // 3 MiB fixture.
+    let data: Vec<u8> = (0..(3 * 1024 * 1024)).map(|i| (i % 251) as u8).collect();
+
+    struct Counted {
+        inner: SliceRangeReader,
+        calls: u64,
+    }
+    impl ByteRangeReader for Counted {
+        type Error = MdfError;
+        fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, MdfError> {
+            self.calls += 1;
+            self.inner.read_range(offset, length)
+        }
+    }
+
+    let inner = Counted {
+        inner: SliceRangeReader::new(data.clone()),
+        calls: 0,
+    };
+    let mut cached = CachingRangeReader::with_chunk_size(inner, 1 << 20);
+
+    // 200 small scattered reads inside the first MiB → 1 underlying read.
+    for i in 0..200u64 {
+        let off = i * 4096;
+        let len = 24u64;
+        let bytes = cached.read_range(off, len)?;
+        assert_eq!(bytes, data[off as usize..(off + len) as usize]);
+    }
+    assert_eq!(cached.underlying_requests(), 1);
+
+    // Read across into the second chunk → at most 1 more.
+    let _ = cached.read_range((1 << 20) - 5, 20)?;
+    assert!(cached.underlying_requests() <= 2);
+
+    Ok(())
+}

--- a/tests/test_cloud_index.py
+++ b/tests/test_cloud_index.py
@@ -1,0 +1,201 @@
+"""Python integration test for cloud (HTTP) MDF indexing.
+
+Builds a fixture MF4 file using ``mf4_rs.PyMdfWriter``, serves it from a
+local HTTP server with single-range ``Range: bytes=A-B`` support, then
+exercises ``PyMdfIndex.from_url`` and the ``*_from_url`` value-read
+methods.
+
+Exits 0 (skip) if the bindings are not importable so this can sit in CI
+without forcing a maturin build on every runner.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import re
+import socketserver
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+try:
+    import mf4_rs
+except ImportError as e:
+    print(f"SKIP: mf4_rs not importable ({e}); run `maturin develop --release` first")
+    sys.exit(0)
+
+
+GROUPS = 5
+CHANNELS_PER_GROUP = 5  # 1 master + 4 data
+RECORDS = 200
+
+
+def build_fixture(path: str) -> None:
+    w = mf4_rs.PyMdfWriter(path)
+    w.init_mdf_file()
+    cg_ids: list[str] = []
+    cn_ids_per_group: list[list[str]] = []
+
+    for g in range(GROUPS):
+        cg = w.add_channel_group(f"Group {g}")
+        w.set_channel_group_comment(cg, f"Comment for group {g}")
+        cg_ids.append(cg)
+        # Master channel (time, FloatLE 64-bit).
+        t_id = w.add_time_channel(cg, f"t_{g}")
+        cn_ids = [t_id]
+        for j in range(1, CHANNELS_PER_GROUP):
+            ch = w.add_float_channel(cg, f"ch_{g}_{j}")
+            cn_ids.append(ch)
+        cn_ids_per_group.append(cn_ids)
+
+    for g, cg in enumerate(cg_ids):
+        w.start_data_block(cg)
+        for r in range(RECORDS):
+            record = [mf4_rs.create_float_value(r * 0.01)]
+            for j in range(1, CHANNELS_PER_GROUP):
+                record.append(mf4_rs.create_float_value(float(g * 100 + r * j)))
+            w.write_record(cg, record)
+        w.finish_data_block(cg)
+
+    w.finalize()
+
+
+class RangeHandler(http.server.SimpleHTTPRequestHandler):
+    """Honour single-range ``Range: bytes=A-B`` requests.
+
+    Stays on HTTP/1.0 (the default) so each response closes the TCP
+    connection. With HTTP/1.1 keep-alive, ureq 2.x can wedge waiting for
+    bytes the server has no intention of sending.
+    """
+
+    def do_GET(self):  # noqa: N802
+        path = self.translate_path(self.path)
+        try:
+            f = open(path, "rb")
+        except OSError:
+            self.send_error(404)
+            return
+        try:
+            data = f.read()
+        finally:
+            f.close()
+        total = len(data)
+        rng = self.headers.get("Range")
+        if rng:
+            m = re.match(r"bytes=(\d+)-(\d*)", rng)
+            if m:
+                start = int(m.group(1))
+                end = int(m.group(2)) if m.group(2) else total - 1
+                end = min(end, total - 1)
+                if start < total:
+                    body = data[start : end + 1]
+                    self.send_response(206)
+                    self.send_header("Content-Type", "application/octet-stream")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.send_header("Content-Range", f"bytes {start}-{end}/{total}")
+                    self.send_header("Accept-Ranges", "bytes")
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(total))
+        self.send_header("Accept-Ranges", "bytes")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_HEAD(self):  # noqa: N802
+        path = self.translate_path(self.path)
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(size))
+        self.send_header("Accept-Ranges", "bytes")
+        self.end_headers()
+
+    def log_message(self, *_args, **_kwargs):  # silence noisy stdout
+        return
+
+
+class _Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+
+
+def serve(directory: Path):
+    os.chdir(directory)
+    httpd = _Server(("127.0.0.1", 0), RangeHandler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, port
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        mf4_path = tmp_path / "fixture.mf4"
+        build_fixture(str(mf4_path))
+        size = mf4_path.stat().st_size
+        print(f"fixture size: {size} bytes")
+
+        httpd, port = serve(tmp_path)
+        try:
+            url = f"http://127.0.0.1:{port}/fixture.mf4"
+            time.sleep(0.05)
+
+            t0 = time.perf_counter()
+            idx = mf4_rs.PyMdfIndex.from_url(url)
+            print(f"index built in {(time.perf_counter() - t0)*1000:.1f} ms")
+
+            groups = idx.list_channel_groups()
+            assert len(groups) == GROUPS, f"got {len(groups)} groups, want {GROUPS}"
+            for i, (gi, name, count) in enumerate(groups):
+                assert gi == i
+                assert name == f"Group {i}", f"group {i} name = {name!r}"
+                assert count == CHANNELS_PER_GROUP
+
+            # Read 5 channels via URL.
+            t0 = time.perf_counter()
+            targets = [
+                ("Group 0", "t_0"),
+                ("Group 1", "ch_1_2"),
+                ("Group 2", "ch_2_4"),
+                ("Group 3", "ch_3_1"),
+                ("Group 4", "ch_4_3"),
+            ]
+            for gn, cn in targets:
+                vals = idx.read_channel_values_by_group_and_name(gn, cn, str(mf4_path))
+                vals_url = idx.read_channel_values_by_name_from_url(cn, url)
+                assert len(vals) == RECORDS, f"{gn}/{cn} local len {len(vals)}"
+                assert len(vals_url) == RECORDS, f"{gn}/{cn} url len {len(vals_url)}"
+                # Spot-check one decoded value matches between local and URL paths.
+                assert vals[10] == vals_url[10], (
+                    f"{gn}/{cn}[10] differs: local={vals[10]!r} url={vals_url[10]!r}"
+                )
+            print(f"5 channel reads (local + url) in {(time.perf_counter() - t0)*1000:.1f} ms")
+
+            # Round-trip via JSON to confirm the index is self-contained after
+            # being built over HTTP.
+            json_path = tmp_path / "fixture.idx.json"
+            idx.save_to_file(str(json_path))
+            idx2 = mf4_rs.PyMdfIndex.load_from_file(str(json_path))
+            vals_a = idx.read_channel_values_by_name_from_url("ch_2_4", url)
+            vals_b = idx2.read_channel_values_by_name_from_url("ch_2_4", url)
+            assert vals_a == vals_b, "JSON round-trip changed decoded values"
+            print(f"index json: {json_path.stat().st_size} bytes")
+
+            print("OK")
+            return 0
+        finally:
+            httpd.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add a Rust-only path for constructing an MdfIndex from a remote MF4
file (S3/HTTP) without downloading the whole object. Metadata is read
through a layered ByteRangeReader stack so a typical file collapses to
a handful of underlying HTTP requests.

New public surface (no breaking changes):
- MdfIndex::from_range_reader(&mut R, file_size) - reader-based index
  builder that walks ##ID/##HD/##DG/##CG/##CN/##TX/##CC plus data block
  headers via reader.read_range. Sample data is never fetched.
- CachingRangeReader<R> - chunked (default 1 MiB) cache that coalesces
  contiguous missing chunks into a single underlying read. Exposes
  underlying_requests()/cache_hits() for metrics and set_bypass(true)
  for value-read phases that span large data blocks.
- HttpRangeReader (behind `http` feature, ureq-based) - sync HTTP
  range-request implementation of ByteRangeReader with reused Agent
  for keep-alive, plus probe_size() HEAD helper.
- ConversionBlock::resolve_all_dependencies_via_reader - sibling of
  the existing mmap-based resolver that follows cc_ref ##TX/##CC links
  through any ByteRangeReader (preserves max-depth-20 + cycle
  detection).
- MdfWriter::set_channel_group_name / set_channel_group_comment -
  write ##TX blocks and patch the CG acq_name_addr/comment_addr links;
  fills a previously documented gap where CG names/comments could
  not be set through the writer API.

Internals:
- New crate-private module src/parsing/reader_walk.rs mirrors the
  mmap walk from MdfFile::parse_from_slice but issues range reads;
  decoupled from the api/ wrapper so it can run without an Mmap.
- src/index.rs gains extract_data_blocks_via_reader (mirrors the
  existing extract_data_blocks for ##DT/##DV/##DZ/##DL chains).

Test coverage (tests/cloud_index.rs, gated on `http`):
- Fixture: 10 channel groups (each with name + comment) x 10 channels
  (each with a text name; one channel uses a value-to-text conversion
  with default fallback) x 200 records.
- Spawns tiny_http on 127.0.0.1:0 with single-range Range support and
  a stop-flag-driven shutdown loop.
- Asserts all group names/comments and channel names round-trip via
  the index, and that one V2T-enabled channel decodes to String.
- Headline metric: total_requests <= 10 underlying HTTP requests for
  index build + 5 channel reads (observed: 6 = 1 metadata + 5 value).
- Wall-time budget: < 2s (observed: ~220ms in release).
- Plus a SliceRangeReader-backed unit test exercising the cache
  coalescing logic in isolation.