### PR TITLE
fix(ci): set -march=armv8-a for aarch64 Linux wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,9 +243,6 @@ jobs:
         include:
           - target: x86_64
             sccache: "true"
-          # sccache's preprocessor-cache path strips target-predefined
-          # macros when forwarding ring's .S files through the aarch64
-          # cross-gcc, breaking the ARMv8 asm build (__ARM_ARCH undefined).
           - target: aarch64
             sccache: "false"
     steps:
@@ -253,6 +250,13 @@ jobs:
         with:
           ref: ${{ needs.bump-and-tag.outputs.tag }}
       - uses: PyO3/maturin-action@v1
+        # The manylinux2014 aarch64 cross-gcc doesn't auto-define __ARM_ARCH,
+        # which ring 0.17's pre-generated ARMv8 .S files require. Forcing
+        # -march=armv8-a makes gcc emit __ARM_ARCH=8. maturin-action forwards
+        # CFLAGS_* env vars into the build container. Harmless on x86_64
+        # (CFLAGS_aarch64_* is ignored there).
+        env:
+          CFLAGS_aarch64_unknown_linux_gnu: "-march=armv8-a"
         with:
           target: ${{ matrix.target }}
           args: --release --out dist


### PR DESCRIPTION
## Summary

My previous fix (#72) disabled sccache on the aarch64 Linux wheel build, but the real cause was different: the manylinux2014 aarch64 cross-gcc doesn't auto-define `__ARM_ARCH` without an explicit `-march` flag, so ring 0.17's pre-generated ARMv8 `.S` files still trip the `#error "ARM assembler must define __ARM_ARCH"` guard in `asm_base.h`.

Force `-march=armv8-a` via `CFLAGS_aarch64_unknown_linux_gnu` on the maturin-action step — gcc then emits `__ARM_ARCH=8` automatically and ring's asm builds cleanly. maturin-action forwards `CFLAGS_*` env vars into its docker build container.

This should patch-bump to 1.7.2 and finally complete the PyPI publish.

## Test plan

- [ ] Release workflow runs on merge to `main`
- [ ] `build-wheels-linux (aarch64)` succeeds
- [ ] `publish-pypi` runs and uploads `mf4-rs 1.7.2`
- [ ] `pip install 'mf4-rs>=1.7.2'` works (and `MdfIndex.from_url(...)` is importable)

---
_Generated by [Claude Code](https://claude.ai/code/session_011drHagusHMjNJ6APExDB7Y)_