### PR TITLE
fix(ci): install perl-FindBin and perl-IPC-Cmd for vendored OpenSSL build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,12 @@ jobs:
           args: --release --out dist
           manylinux: auto
           sccache: "true"
+          # openssl-src (vendored OpenSSL) drives the build via perl's
+          # Configure script, which needs FindBin and IPC::Cmd. The
+          # CentOS 7-based manylinux2014 image's minimal perl install
+          # lacks them; install before maturin invokes cargo.
+          before-script-linux: |
+            yum install -y perl-FindBin perl-IPC-Cmd
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-linux-${{ matrix.target }}


### PR DESCRIPTION
## Summary

After the vendored-OpenSSL switch in #75 (1.7.4), the Linux wheel builds now fail in openssl-src's perl `Configure` step:

```
Compilation failed in require at ./Configure line 23.
BEGIN failed--compilation aborted at ./Configure line 23.
Error configuring OpenSSL build:
    'perl' reported failure with exit status: 2
```

OpenSSL 3.x's build system requires the `FindBin` and `IPC::Cmd` perl modules. The CentOS-7-based manylinux2014 image only ships a minimal perl, so the `require` fails before any compilation happens.

Fix: install both modules via `yum` in `before-script-linux`, which `maturin-action` runs inside the build container before invoking cargo. Applies to both x86_64 and aarch64 matrix entries.

## Test plan

- [ ] Release workflow runs on merge → patch bump to 1.7.5
- [ ] `build-wheels-linux (x86_64)` succeeds — perl Configure passes, OpenSSL builds, wheel produced
- [ ] `build-wheels-linux (aarch64)` succeeds (same fix benefits both)
- [ ] `publish-pypi` runs and uploads `mf4-rs 1.7.5`
- [ ] `pip install 'mf4-rs>=1.7.5'` works

---
_Generated by [Claude Code](https://claude.ai/code/session_011drHagusHMjNJ6APExDB7Y)_