### PR TITLE
fix: configure native-tls backend for HTTPS range reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ dependencies = [
  "byteorder",
  "memmap2",
  "meval",
+ "native-tls",
  "nom 8.0.0",
  "numpy",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ serde_json = "1.0"
 # under the manylinux2014 aarch64 toolchain (gcc fails to define __ARM_ARCH).
 ureq = { version = "2", default-features = false, features = ["native-tls"], optional = true }
 
+# ureq's native-tls backend is not auto-configured: the connector must be
+# built explicitly and handed to the AgentBuilder, so we depend on native-tls
+# directly. Vendored so the manylinux aarch64 wheel needs no system libssl.
+native-tls = { version = "0.2", features = ["vendored"], optional = true }
+
 # Force openssl to be built from source rather than linked against the
 # host system. The manylinux2014 aarch64 cross-toolchain image ships
 # /usr/aarch64-unknown-linux-gnu/ but no OpenSSL development headers for
@@ -49,5 +54,5 @@ tempfile = "3"
 
 [features]
 default = []
-http = ["dep:ureq", "dep:openssl"]
+http = ["dep:ureq", "dep:openssl", "dep:native-tls"]
 pyo3 = ["dep:pyo3", "dep:numpy", "dep:pyo3-stub-gen", "http"]

--- a/src/index.rs
+++ b/src/index.rs
@@ -456,7 +456,15 @@ pub struct HttpRangeReader {
 #[cfg(feature = "http")]
 impl HttpRangeReader {
     pub fn new(url: impl Into<String>) -> Result<Self, MdfError> {
-        let agent = ureq::AgentBuilder::new().build();
+        // ureq's native-tls feature is not auto-wired (unlike rustls): the
+        // connector must be constructed and attached explicitly, otherwise
+        // HTTPS requests fail with "no TLS backend is configured".
+        let connector = native_tls::TlsConnector::new().map_err(|e| {
+            MdfError::BlockSerializationError(format!("failed to init TLS backend: {e}"))
+        })?;
+        let agent = ureq::AgentBuilder::new()
+            .tls_connector(std::sync::Arc::new(connector))
+            .build();
         Ok(Self {
             agent,
             url: url.into(),


### PR DESCRIPTION
## Problem

`PyMdfIndex.from_url(...)` and the `*_from_url` readers failed against any `https://` URL (e.g. presigned S3 links) with:

> cannot make HTTPS request because no TLS backend is configured

## Root cause

`HttpRangeReader` built its `ureq` agent with `AgentBuilder::new().build()`. In ureq 2.x the `native-tls` backend is **not** auto-wired (unlike rustls) — the TLS connector must be constructed and attached to the `AgentBuilder` explicitly. As a result the agent had no TLS backend, so every HTTPS request failed. Plain `http://` worked, which is why this went unnoticed.

## Fix

- Add `native-tls` (vendored) as a direct optional dependency under the `http` feature.
- `HttpRangeReader::new` now builds `native_tls::TlsConnector::new()` and attaches it via `AgentBuilder::tls_connector(...)`.

Kept native-tls rather than switching to rustls, per the existing Cargo.toml note about ring's ARMv8 assembly not cross-compiling for manylinux aarch64.

## Verification

- `cargo build --features http` succeeds.
- A HEAD probe + ranged GET against an `https://` URL both succeed (content-length read and 16 bytes fetched); before the fix this errored with the TLS backend message.

https://claude.ai/code/session_01RegTZSMFcz68mK769jkYsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RegTZSMFcz68mK769jkYsR)_