### PR TITLE
fix: probe remote file size with ranged GET instead of HEAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ dependencies = [
  "byteorder",
  "memmap2",
  "meval",
+ "native-tls",
  "nom 8.0.0",
  "numpy",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ serde_json = "1.0"
 # under the manylinux2014 aarch64 toolchain (gcc fails to define __ARM_ARCH).
 ureq = { version = "2", default-features = false, features = ["native-tls"], optional = true }
 
+# ureq's native-tls backend is not auto-configured: the connector must be
+# built explicitly and handed to the AgentBuilder, so we depend on native-tls
+# directly. Vendored so the manylinux aarch64 wheel needs no system libssl.
+native-tls = { version = "0.2", features = ["vendored"], optional = true }
+
 # Force openssl to be built from source rather than linked against the
 # host system. The manylinux2014 aarch64 cross-toolchain image ships
 # /usr/aarch64-unknown-linux-gnu/ but no OpenSSL development headers for
@@ -49,5 +54,5 @@ tempfile = "3"
 
 [features]
 default = []
-http = ["dep:ureq", "dep:openssl"]
+http = ["dep:ureq", "dep:openssl", "dep:native-tls"]
 pyo3 = ["dep:pyo3", "dep:numpy", "dep:pyo3-stub-gen", "http"]

--- a/src/index.rs
+++ b/src/index.rs
@@ -456,7 +456,15 @@ pub struct HttpRangeReader {
 #[cfg(feature = "http")]
 impl HttpRangeReader {
     pub fn new(url: impl Into<String>) -> Result<Self, MdfError> {
-        let agent = ureq::AgentBuilder::new().build();
+        // ureq's native-tls feature is not auto-wired (unlike rustls): the
+        // connector must be constructed and attached explicitly, otherwise
+        // HTTPS requests fail with "no TLS backend is configured".
+        let connector = native_tls::TlsConnector::new().map_err(|e| {
+            MdfError::BlockSerializationError(format!("failed to init TLS backend: {e}"))
+        })?;
+        let agent = ureq::AgentBuilder::new()
+            .tls_connector(std::sync::Arc::new(connector))
+            .build();
         Ok(Self {
             agent,
             url: url.into(),

--- a/src/index.rs
+++ b/src/index.rs
@@ -472,24 +472,54 @@ impl HttpRangeReader {
         })
     }
 
-    /// Issue a HEAD request to learn the resource's `Content-Length`.
+    /// Learn the resource's total size with a single-byte ranged GET.
+    ///
+    /// Uses `GET` with `Range: bytes=0-0` and parses the total length out of
+    /// the `Content-Range: bytes 0-0/<total>` header, rather than issuing a
+    /// `HEAD`. Presigned URLs (e.g. AWS S3) are signed for one specific HTTP
+    /// method, so a `HEAD` against a GET-signed URL is rejected with 403; a
+    /// ranged `GET` matches the method the data reads use.
     pub fn probe_size(&mut self) -> Result<u64, MdfError> {
+        use std::io::Read;
+
         let resp = self
             .agent
-            .head(&self.url)
+            .get(&self.url)
+            .set("Range", "bytes=0-0")
             .call()
-            .map_err(|e| MdfError::BlockSerializationError(format!("HTTP HEAD error: {e}")))?;
+            .map_err(|e| MdfError::BlockSerializationError(format!("HTTP GET error: {e}")))?;
         self.request_count += 1;
-        let len = resp
+
+        // Preferred: total size from the Content-Range header of a 206 response.
+        let total = resp
+            .header("Content-Range")
+            .and_then(|cr| cr.rsplit('/').next().map(|s| s.trim().to_string()))
+            .filter(|s| s != "*")
+            .and_then(|s| s.parse::<u64>().ok());
+
+        // Fallback: a server that ignores the Range header replies 200 with the
+        // full body, in which case Content-Length is the total size. Drain the
+        // body so the connection can be reused for keep-alive.
+        let content_length = resp
             .header("Content-Length")
-            .ok_or_else(|| {
-                MdfError::BlockSerializationError("HEAD response missing Content-Length".into())
-            })?
-            .parse::<u64>()
-            .map_err(|e| {
-                MdfError::BlockSerializationError(format!("invalid Content-Length: {e}"))
-            })?;
-        Ok(len)
+            .and_then(|s| s.parse::<u64>().ok());
+        let status = resp.status();
+        let mut sink = Vec::new();
+        let _ = resp.into_reader().take(1).read_to_end(&mut sink);
+
+        if let Some(len) = total {
+            Ok(len)
+        } else if status == 200 {
+            content_length.ok_or_else(|| {
+                MdfError::BlockSerializationError(
+                    "size probe: server ignored Range and sent no Content-Length".into(),
+                )
+            })
+        } else {
+            Err(MdfError::BlockSerializationError(
+                "size probe: 206 response missing Content-Range total".into(),
+            ))
+        }
     }
 
     /// Total number of HTTP requests issued by this reader.


### PR DESCRIPTION
## Problem

Reading from a presigned S3 URL (works in a browser) failed with `403 Forbidden`.

## Root cause

`HttpRangeReader::probe_size()` learned the file size with an HTTP `HEAD` request, while the data reads use ranged `GET`. Presigned URLs (AWS S3 etc.) are signed for a single HTTP method, so a `HEAD` against a GET-signed URL is rejected with 403 even though the `GET` reads succeed.

## Fix

`probe_size()` now issues `GET` with `Range: bytes=0-0` and parses the total length from the `Content-Range: bytes 0-0/<total>` header, falling back to `Content-Length` for servers that ignore the range. Every request is now a `GET`, matching the method the data reads (and a browser download) use.

## Verification

- Live HTTPS endpoint: probe returns the correct total via `Content-Range`, ranged read returns expected bytes.
- `cargo test --features http --test cloud_index` — 3/3 pass.

https://claude.ai/code/session_01RegTZSMFcz68mK769jkYsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RegTZSMFcz68mK769jkYsR)_