### PR TITLE
feat!: redesign reader/index APIs around name-based navigation and signals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,12 +182,15 @@ The codebase is organized into distinct layers. The module structure is defined 
 - `ByteRangeReader` trait - Abstraction for data sources: `read_range(offset, length) -> Vec<u8>`
 - `FileRangeReader` - Built-in local file implementation
 - Public API is **name-based**; positional `(group_index, channel_index)` reads exist only as `pub(crate)` internals.
+- The index remembers its data `Source` (`File(path)` / `Url(url)`), set by `from_file` / `from_url`. The source is **not** serialized (`#[serde(skip)]`) — re-attach after `load_from_file` with `set_file()` / `set_url()` / `set_source()`. Building an index never reads sample data; byte-range reads happen lazily on `read()`.
 - Key capabilities:
-  - `from_file()` / `from_bytes()` / `from_range_reader()` / `save_to_file()` / `load_from_file()` / `to_json()` / `from_json()` - Create, persist, and reload JSON indexes
+  - `from_file()` / `from_bytes()` / `from_range_reader()` / `from_url()` (http) / `save_to_file()` / `load_from_file()` / `to_json()` / `from_json()` - Create, persist, and reload JSON indexes
   - Metadata navigation: `groups()`, `group(name)`, `channel(name)`, `channel_in(group, name)`, `channel_names()`, `find_channels(name)`; `IndexedChannelGroup::channel(name)` / `channel_names()` / `master_channel()`; `IndexedChannel::is_master()` / `is_vlsd()`
-  - Reading: bind a source once with `open(reader)` / `open_file(path)` → returns an `MdfReader`, then `values(name)` / `values_in(group, name)` / `values_f64(name)` / `values_f64_in(group, name)`; `reader_mut()` / `into_inner()` expose the underlying `ByteRangeReader`
+  - Lazy reads via the attached source: `read(name)` / `read_in(group, name)` return a [`Signal`](src/signal.rs) (values paired with the group master/time axis); `source()` / `set_file()` / `set_url()` / `set_source()` manage the source
+  - Explicit/custom readers: bind with `open(reader)` / `open_file(path)` → returns an `MdfReader` with `values(name)` / `values_in()` / `values_f64()` / `signal(name)` / `signal_in()`; `reader_mut()` / `into_inner()` expose the underlying `ByteRangeReader`
   - Byte ranges (power-user / partial reads): `byte_ranges(name)`, `byte_ranges_in(group, name)`, `byte_ranges_for_records(name, start, count)`
   - Conversions are resolved during index creation, enabling reads with empty `file_data` (`&[]`)
+- `Signal` (`src/signal.rs`) is the Rust equivalent of a pandas `Series`: `{ name, unit, timestamps: Vec<f64>, values: Vec<Option<DecodedValue>> }`, with `values_f64()` / `has_timestamps()`. Produced by `MDF::signal()`, `ChannelGroup::signal()`, `MdfReader::signal()`, and `MdfIndex::read()`.
 
 ### 6. File Operations
 - `cut.rs` - `cut_mdf_by_time(input, output, start_time, end_time)`: Copies only records whose master channel value falls within `[start_time, end_time]`. Identifies master channels by `channel_type == 2 && sync_type == 1`.
@@ -206,11 +209,11 @@ The codebase is organized into distinct layers. The module structure is defined 
 - Built only when `pyo3` feature is enabled (configured in `pyproject.toml` via `[tool.maturin] features = ["pyo3"]`)
 - Uses PyO3 0.21 with extension-module feature
 - The Python-visible names drop the `Py` prefix (set via `#[pyclass(name = "…")]`); the Rust struct names keep the `Py` prefix internally. **All navigation is by name — there are no `(group_index, channel_index)` arguments in the Python API.**
+- **`read(name, group=None)` returns a `pandas.Series`** (channel values, conversions applied, indexed by the group master converted to a `DatetimeIndex`). **`values(name, group=None)` returns a plain numpy `float64` array** (no timestamps, pandas-free). `__getitem__` is `read`.
 - Main classes:
-  - `Mdf` (struct `PyMDF`) - Wraps `MDF`; `groups` property (each `GroupInfo` carries its `channels`), `group(name)`, `channel(name)`, `channel_names`; reads: `read(name, group=None)` → numpy f64, `read_raw(name, group=None)` → list with conversions, `series(name, group=None)` → pandas Series, `__getitem__` (= `read`), `file_layout()`
+  - `Mdf` (struct `PyMDF`) - Wraps `MDF`; `groups` property (each `GroupInfo` carries its `channels`), `group(name)`, `channel(name)`, `channel_names`; reads: `read()` → Series, `values()` → numpy, `__getitem__`, `file_layout()`
   - `MdfWriter` (struct `PyMdfWriter`) - Wraps `MdfWriter`; manages ID mapping between Python and Rust IDs; provides `add_time_channel()`, `add_float_channel()`, `add_int_channel()` convenience methods (writer API unchanged in the redesign)
-  - `MdfIndex` (struct `PyMdfIndex`) - Wraps `MdfIndex`; `from_file()` / `load()` / `from_url()` / `save()`; navigation (`groups`, `group`, `channel`, `channel_names`, `groups_with_channel`); `byte_ranges()` / `byte_ranges_for_records()`; `conversion_info(name)`; **`open(path)` / `open_url(url)` return an `MdfData`** (bind the source once)
-  - `MdfData` (struct `PyMdfData`) - A reader bound to an index + one source. `read(name, group=None)` → numpy f64, `read_raw(...)` → list + conversions, `series(...)`, `__getitem__`, `byte_ranges(...)`, plus navigation delegations
+  - `MdfIndex` (struct `PyMdfIndex`) - Wraps `MdfIndex`; `from_file()` / `load()` / `from_url()` / `save()`; navigation (`groups`, `group`, `channel`, `channel_names`, `groups_with_channel`); **carries its data `source`** (settable `source` property, autodetecting `http(s)://` URLs vs file paths, plus `set_source()`); **lazy** `read()` → Series and `values()` → numpy (range request happens on read, GIL released); `byte_ranges()` / `byte_ranges_for_records()`; `conversion_info(name)`. (There is no separate `MdfData` class — the index *is* the bound reader.)
   - `ChannelInfo`, `GroupInfo`, `DecodedValue`, `DataType`, `FileLayout`/`BlockInfo`/`LinkInfo`/`GapInfo` - Data transfer / inspection types
 - Helper functions: `create_float_value()`, `create_uint_value()`, `create_int_value()`, `create_string_value()`, `create_data_type_*()` factory functions
 - Custom `MdfException` Python exception type
@@ -446,9 +449,9 @@ This section documents tested interoperability and differences between `mf4-rs` 
 
 | Class | mf4-rs | asammdf |
 |-------|--------|---------|
-| Reader | `Mdf` - name-based (`groups`, `group`, `channel`, `read`, `read_raw`, `series`, `__getitem__`) | `MDF` - 58+ methods |
+| Reader | `Mdf` - name-based (`groups`, `group`, `channel`, `read`→Series, `values`→numpy, `__getitem__`) | `MDF` - 58+ methods |
 | Writer | `MdfWriter` - 11 methods | `MDF.append()` + `Signal` (numpy-based) |
-| Index | `MdfIndex` + `MdfData` - name-based (bind source once via `open`/`open_url`) | No equivalent |
+| Index | `MdfIndex` - name-based, source-aware (`from_url`/`source`), lazy `read`→Series / `values`→numpy | No equivalent |
 
 ### Performance (100K records, 4 x f64 channels)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,11 +181,12 @@ The codebase is organized into distinct layers. The module structure is defined 
 - `IndexedChannel` - Channel metadata including fully resolved `ConversionBlock` (serializable via serde)
 - `ByteRangeReader` trait - Abstraction for data sources: `read_range(offset, length) -> Vec<u8>`
 - `FileRangeReader` - Built-in local file implementation
+- Public API is **name-based**; positional `(group_index, channel_index)` reads exist only as `pub(crate)` internals.
 - Key capabilities:
-  - `from_file()` / `save_to_file()` / `load_from_file()` - Create, persist, and reload JSON indexes
-  - `read_channel_values()` / `read_channel_values_by_name()` - Read data using index + byte range reader
-  - `get_channel_byte_ranges()` / `get_channel_byte_ranges_for_records()` - Calculate exact byte ranges for partial reads
-  - `find_channel_by_name_global()` / `find_all_channels_by_name()` - Channel name lookups across all groups
+  - `from_file()` / `from_bytes()` / `from_range_reader()` / `save_to_file()` / `load_from_file()` / `to_json()` / `from_json()` - Create, persist, and reload JSON indexes
+  - Metadata navigation: `groups()`, `group(name)`, `channel(name)`, `channel_in(group, name)`, `channel_names()`, `find_channels(name)`; `IndexedChannelGroup::channel(name)` / `channel_names()` / `master_channel()`; `IndexedChannel::is_master()` / `is_vlsd()`
+  - Reading: bind a source once with `open(reader)` / `open_file(path)` → returns an `MdfReader`, then `values(name)` / `values_in(group, name)` / `values_f64(name)` / `values_f64_in(group, name)`; `reader_mut()` / `into_inner()` expose the underlying `ByteRangeReader`
+  - Byte ranges (power-user / partial reads): `byte_ranges(name)`, `byte_ranges_in(group, name)`, `byte_ranges_for_records(name, start, count)`
   - Conversions are resolved during index creation, enabling reads with empty `file_data` (`&[]`)
 
 ### 6. File Operations
@@ -204,11 +205,13 @@ The codebase is organized into distinct layers. The module structure is defined 
 ### 8. Python Bindings (`src/python.rs`)
 - Built only when `pyo3` feature is enabled (configured in `pyproject.toml` via `[tool.maturin] features = ["pyo3"]`)
 - Uses PyO3 0.21 with extension-module feature
+- The Python-visible names drop the `Py` prefix (set via `#[pyclass(name = "…")]`); the Rust struct names keep the `Py` prefix internally. **All navigation is by name — there are no `(group_index, channel_index)` arguments in the Python API.**
 - Main classes:
-  - `PyMDF` - Wraps `MDF`; methods: `channel_groups()`, `get_channel_values()`, `get_channel_values_by_group_and_name()`, `get_channel_as_series()` (pandas DatetimeIndex support)
-  - `PyMdfWriter` - Wraps `MdfWriter` with simplified Python API; manages ID mapping between Python and Rust IDs; provides `add_time_channel()`, `add_float_channel()`, `add_int_channel()` convenience methods
-  - `PyMdfIndex` - Wraps `MdfIndex`; supports index-based reads, name lookups, byte range calculations, pandas Series output, conversion info inspection
-  - `PyChannelInfo`, `PyChannelGroupInfo`, `PyDecodedValue`, `PyDataType` - Data transfer types
+  - `Mdf` (struct `PyMDF`) - Wraps `MDF`; `groups` property (each `GroupInfo` carries its `channels`), `group(name)`, `channel(name)`, `channel_names`; reads: `read(name, group=None)` → numpy f64, `read_raw(name, group=None)` → list with conversions, `series(name, group=None)` → pandas Series, `__getitem__` (= `read`), `file_layout()`
+  - `MdfWriter` (struct `PyMdfWriter`) - Wraps `MdfWriter`; manages ID mapping between Python and Rust IDs; provides `add_time_channel()`, `add_float_channel()`, `add_int_channel()` convenience methods (writer API unchanged in the redesign)
+  - `MdfIndex` (struct `PyMdfIndex`) - Wraps `MdfIndex`; `from_file()` / `load()` / `from_url()` / `save()`; navigation (`groups`, `group`, `channel`, `channel_names`, `groups_with_channel`); `byte_ranges()` / `byte_ranges_for_records()`; `conversion_info(name)`; **`open(path)` / `open_url(url)` return an `MdfData`** (bind the source once)
+  - `MdfData` (struct `PyMdfData`) - A reader bound to an index + one source. `read(name, group=None)` → numpy f64, `read_raw(...)` → list + conversions, `series(...)`, `__getitem__`, `byte_ranges(...)`, plus navigation delegations
+  - `ChannelInfo`, `GroupInfo`, `DecodedValue`, `DataType`, `FileLayout`/`BlockInfo`/`LinkInfo`/`GapInfo` - Data transfer / inspection types
 - Helper functions: `create_float_value()`, `create_uint_value()`, `create_int_value()`, `create_string_value()`, `create_data_type_*()` factory functions
 - Custom `MdfException` Python exception type
 - Returns native Python types (float, int, str, bytes) via `decoded_value_to_pyobject()` for zero-copy efficiency
@@ -443,9 +446,9 @@ This section documents tested interoperability and differences between `mf4-rs` 
 
 | Class | mf4-rs | asammdf |
 |-------|--------|---------|
-| Reader | `PyMDF` - 7 methods | `MDF` - 58+ methods |
-| Writer | `PyMdfWriter` - 11 methods | `MDF.append()` + `Signal` (numpy-based) |
-| Index | `PyMdfIndex` - 19 methods | No equivalent |
+| Reader | `Mdf` - name-based (`groups`, `group`, `channel`, `read`, `read_raw`, `series`, `__getitem__`) | `MDF` - 58+ methods |
+| Writer | `MdfWriter` - 11 methods | `MDF.append()` + `Signal` (numpy-based) |
+| Index | `MdfIndex` + `MdfData` - name-based (bind source once via `open`/`open_url`) | No equivalent |
 
 ### Performance (100K records, 4 x f64 channels)
 

--- a/examples/index_operations.rs
+++ b/examples/index_operations.rs
@@ -1,6 +1,6 @@
 use mf4_rs::blocks::common::DataType;
 use mf4_rs::error::MdfError;
-use mf4_rs::index::{FileRangeReader, MdfIndex};
+use mf4_rs::index::MdfIndex;
 use mf4_rs::parsing::decoder::DecodedValue;
 use mf4_rs::writer::MdfWriter;
 
@@ -25,20 +25,22 @@ fn main() -> Result<(), MdfError> {
     println!("🔄 Loading index and testing self-contained conversions...");
     let loaded_index = MdfIndex::load_from_file(index_file)?;
 
-    // Step 4: Read and convert data using only the index (no file access for conversions!)
+    // Step 4: Read and convert data using only the index + a bound data source.
     println!("📊 Reading channel values via enhanced index...");
-    let mut reader = FileRangeReader::new(mdf_file)?;
 
-    // List available channels
+    // List available channels by navigating the index by name
     println!("\nAvailable channels:");
-    if let Some(channels) = loaded_index.list_channels(0) {
-        for (idx, name, data_type) in channels {
-            println!("  Channel {}: {} ({:?})", idx, name, data_type);
-        }
+    for channel in &loaded_index.groups()[0].channels {
+        println!(
+            "  {} ({:?})",
+            channel.name.as_deref().unwrap_or("<unnamed>"),
+            channel.data_type
+        );
     }
 
-    // Read channel data
-    let values = loaded_index.read_channel_values(0, 0, &mut reader)?;
+    // Bind the data source once, then read by channel name.
+    let mut data = loaded_index.open_file(mdf_file)?;
+    let values = data.values("Time")?;
 
     println!("\nChannel values read from enhanced index:");
     for (i, value) in values.iter().enumerate().take(10) {
@@ -50,37 +52,21 @@ fn main() -> Result<(), MdfError> {
 
     // Step 5: Demonstrate byte range efficiency
     println!("\n🎯 Byte Range Analysis (Partial Reading):");
-    let byte_ranges = loaded_index.get_channel_byte_ranges(0, 0)?;
-    let (total_bytes, range_count) = loaded_index.get_channel_byte_summary(0, 0)?;
+    let byte_ranges = loaded_index.byte_ranges("Time")?;
+    let total_bytes: u64 = byte_ranges.iter().map(|(_, len)| len).sum();
 
     println!("  Total bytes needed: {}", total_bytes);
-    println!("  Number of byte ranges: {}", range_count);
+    println!("  Number of byte ranges: {}", byte_ranges.len());
     println!("  Ranges: {:?}", byte_ranges);
 
-    // Step 6: Compare with name-based access
-    println!("\n🏷️  Testing name-based access:");
-    if let Some(channels) = loaded_index.list_channels(0) {
-        if let Some((_, channel_name, _)) = channels.first() {
-            let values_by_name =
-                loaded_index.read_channel_values_by_name(channel_name, &mut reader)?;
-            println!(
-                "  Read {} values for channel '{}'",
-                values_by_name.len(),
-                channel_name
-            );
-
-            // Verify consistency
-            if values == values_by_name {
-                println!("  ✅ Index-based and name-based access produce identical results");
-            } else {
-                println!("  ❌ Mismatch between access methods");
-            }
-        }
-    }
+    // Step 6: Read another channel by name
+    println!("\n🏷️  Reading 'Temperature' by name:");
+    let temp_values = data.values("Temperature")?;
+    println!("  Read {} values for channel 'Temperature'", temp_values.len());
 
     // Step 7: Show resolved conversion information
     println!("\n🔧 Conversion Resolution Status:");
-    let group = &loaded_index.channel_groups[0];
+    let group = &loaded_index.groups()[0];
     for (i, channel) in group.channels.iter().enumerate() {
         println!(
             "  Channel {}: {}",

--- a/python/mf4_rs/_mf4_rs.pyi
+++ b/python/mf4_rs/_mf4_rs.pyi
@@ -5,7 +5,7 @@ import builtins
 import typing
 from enum import Enum, auto
 
-class PyBlockInfo:
+class BlockInfo:
     r"""
     A single MDF block discovered while walking the file's link graph.
     
@@ -17,7 +17,7 @@ class PyBlockInfo:
         Four-character MDF block tag (e.g. ``"##HD"``, ``"##CN"``).
     description : str
         Short human-readable summary (e.g. ``"channel 'Speed' [f64@0..8]"``).
-    links : list[PyLinkInfo]
+    links : list[LinkInfo]
         Outbound links to other blocks.
     extra : Optional[str]
         Block-type-specific extra information, when applicable.
@@ -27,47 +27,18 @@ class PyBlockInfo:
     size: builtins.int
     block_type: builtins.str
     description: builtins.str
-    links: builtins.list[PyLinkInfo]
+    links: builtins.list[LinkInfo]
     extra: typing.Optional[builtins.str]
     def __repr__(self) -> builtins.str:
         ...
 
 
-class PyChannelGroupInfo:
-    r"""
-    Read-only metadata describing a channel group (``##CG`` block).
-    
-    Returned by :py:meth:`PyMDF.channel_groups`.
-    
-    Attributes
-    ----------
-    name : Optional[str]
-        Group / acquisition name (often ``None`` for files written by mf4-rs).
-    comment : Optional[str]
-        Free-form comment.
-    channel_count : int
-        Number of channels in this group.
-    record_count : int
-        Number of records (cycles) recorded for this group.
-    """
-    name: typing.Optional[builtins.str]
-    comment: typing.Optional[builtins.str]
-    channel_count: builtins.int
-    record_count: builtins.int
-    def __str__(self) -> builtins.str:
-        ...
-
-    def __repr__(self) -> builtins.str:
-        ...
-
-
-class PyChannelInfo:
+class ChannelInfo:
     r"""
     Read-only metadata describing a single channel.
     
-    Returned by :py:meth:`PyMDF.get_all_channels`,
-    :py:meth:`PyMDF.get_channels_for_group`, and
-    :py:meth:`PyMdfIndex.get_channel_info_by_name`.
+    Found on :py:attr:`GroupInfo.channels`, and returned by
+    :py:meth:`Mdf.channel` / :py:meth:`MdfIndex.channel`.
     
     Attributes
     ----------
@@ -78,7 +49,7 @@ class PyChannelInfo:
     comment : Optional[str]
         Free-form comment, or ``None``. Always ``None`` when obtained via the
         index (not stored in `IndexedChannel`).
-    data_type : PyDataType
+    data_type : DataType
         The MDF data type of the raw samples.
     bit_count : int
         Width of the raw value in bits (e.g. 32 for f32, 64 for f64/u64).
@@ -86,8 +57,10 @@ class PyChannelInfo:
     name: typing.Optional[builtins.str]
     unit: typing.Optional[builtins.str]
     comment: typing.Optional[builtins.str]
-    data_type: PyDataType
+    data_type: DataType
     bit_count: builtins.int
+    is_master: builtins.bool
+    is_vlsd: builtins.bool
     def __str__(self) -> builtins.str:
         ...
 
@@ -95,7 +68,7 @@ class PyChannelInfo:
         ...
 
 
-class PyDataType:
+class DataType:
     r"""
     MDF channel data type descriptor.
     
@@ -119,19 +92,19 @@ class PyDataType:
         ...
 
 
-class PyFileLayout:
+class FileLayout:
     r"""
     Full structural layout of an MDF file: blocks, links, and gaps.
     
-    Build one with :py:meth:`from_file` or :py:meth:`PyMDF.file_layout`. Use
+    Build one with :py:meth:`from_file` or :py:meth:`Mdf.file_layout`. Use
     it to debug file structure, audit storage efficiency, or render a
     human-readable map of an MDF.
     """
     file_size: builtins.int
-    blocks: builtins.list[PyBlockInfo]
-    gaps: builtins.list[PyGapInfo]
+    blocks: builtins.list[BlockInfo]
+    gaps: builtins.list[GapInfo]
     @staticmethod
-    def from_file(path:builtins.str) -> PyFileLayout:
+    def from_file(path:builtins.str) -> FileLayout:
         r"""
         Build a layout by parsing an MDF file from disk.
         
@@ -184,7 +157,7 @@ class PyFileLayout:
         ...
 
 
-class PyGapInfo:
+class GapInfo:
     r"""
     A range of bytes in the file not covered by any visited block.
     
@@ -202,7 +175,43 @@ class PyGapInfo:
         ...
 
 
-class PyLinkInfo:
+class GroupInfo:
+    r"""
+    Read-only metadata describing a channel group (``##CG`` block).
+    
+    Returned by :py:attr:`Mdf.groups` / :py:attr:`MdfIndex.groups`.
+    
+    Attributes
+    ----------
+    name : Optional[str]
+        Group / acquisition name (often ``None`` for files written by mf4-rs).
+    comment : Optional[str]
+        Free-form comment.
+    channel_count : int
+        Number of channels in this group.
+    record_count : int
+        Number of records (cycles) recorded for this group.
+    """
+    name: typing.Optional[builtins.str]
+    comment: typing.Optional[builtins.str]
+    channel_count: builtins.int
+    record_count: builtins.int
+    channels: builtins.list[ChannelInfo]
+    channel_names: builtins.list[builtins.str]
+    def channel(self, name:builtins.str) -> typing.Optional[ChannelInfo]:
+        r"""
+        Find a channel in this group by name (first match), or ``None``.
+        """
+        ...
+
+    def __str__(self) -> builtins.str:
+        ...
+
+    def __repr__(self) -> builtins.str:
+        ...
+
+
+class LinkInfo:
     r"""
     A single outbound link from a block to another block.
     
@@ -222,580 +231,357 @@ class PyLinkInfo:
         ...
 
 
-class PyMDF:
+class Mdf:
     r"""
     Read-only handle to an MDF 4 file, backed by a memory-mapped buffer.
     
-    Opens the file lazily: metadata (block tree, channel names, conversions)
-    is parsed up front, but sample data is only decoded when you call one of
-    the ``get_channel_*`` methods. The mmap stays alive for the lifetime of
-    the ``PyMDF`` instance.
+    Metadata (block tree, channel names, conversions) is parsed up front, but
+    sample data is only decoded when you call :py:meth:`read`, :py:meth:`read_raw`
+    or :py:meth:`series`. Navigate by group / channel **name** — there are no
+    numeric indices in the public API.
     
     Example
     -------
     >>> import mf4_rs
-    >>> mdf = mf4_rs.PyMDF("recording.mf4")
-    >>> for group in mdf.channel_groups():
-    ...     print(group.name, group.record_count)
-    >>> values = mdf.get_channel_values("Temperature")  # numpy.ndarray
+    >>> mdf = mf4_rs.Mdf("recording.mf4")
+    >>> for group in mdf.groups:
+    ...     print(group.name, group.record_count, group.channel_names)
+    >>> speed = mdf["Speed"]                 # numpy float64 array
+    >>> rpm   = mdf.read("RPM", group="Engine")
+    >>> s     = mdf.series("Speed")          # pandas Series, datetime index
     """
+    groups: builtins.list[GroupInfo]
+    channel_names: builtins.list[builtins.str]
     def __new__(cls,path:builtins.str): ...
-    def channel_groups(self) -> builtins.list[PyChannelGroupInfo]:
+    def group(self, name:builtins.str) -> typing.Optional[GroupInfo]:
         r"""
-        List metadata for every channel group in the file.
-        
-        Returns
-        -------
-        list[PyChannelGroupInfo]
-            One entry per ``##CG`` block, in file order.
+        Find a channel group by name (first match), or ``None``.
         """
         ...
 
-    def get_all_channels(self) -> builtins.list[PyChannelInfo]:
+    def channel(self, name:builtins.str) -> typing.Optional[ChannelInfo]:
         r"""
-        Return metadata for every channel across every group.
-        
-        Returns
-        -------
-        list[PyChannelInfo]
-            Channels are emitted in file order, group-by-group. Channels with
-            duplicate names (common across groups) appear multiple times — use
-            :py:meth:`get_channels_for_group` if you need per-group context.
+        Find a channel by name across all groups (first match), or ``None``.
         """
         ...
 
-    def get_channels_for_group(self, group_index:builtins.int) -> builtins.list[PyChannelInfo]:
+    def read(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
         r"""
-        Return metadata for every channel in a single group.
+        Read a numeric channel by name as a numpy ``float64`` array.
+        
+        This is the fast path: values are decoded directly into a numpy buffer,
+        invalid / non-decodable samples become ``NaN``. It does **not** apply
+        non-linear conversions — use :py:meth:`read_raw` for text / table /
+        value-to-text channels.
         
         Parameters
         ----------
-        group_index : int
-            Zero-based index into :py:meth:`channel_groups`.
-        
-        Returns
-        -------
-        list[PyChannelInfo]
+        name : str
+            Channel name (case-sensitive).
+        group : Optional[str]
+            Restrict the search to a single group by name. Use this when the
+            same channel name (e.g. ``"Time"``) appears in several groups.
         
         Raises
         ------
         MdfException
-            If ``group_index`` is out of bounds.
+            If no matching channel exists.
         """
         ...
 
-    def get_all_channel_names(self) -> builtins.list[builtins.str]:
+    def read_raw(self, name:builtins.str, group:typing.Optional[builtins.str]) -> builtins.list[typing.Optional[typing.Any]]:
         r"""
-        Return the names of every named channel across all groups.
+        Read a channel by name, returning native Python values with conversions.
         
-        Channels without a name (``##TX`` link is null) are skipped.
-        Duplicates are preserved when the same name appears in multiple groups.
-        
-        Returns
-        -------
-        list[str]
-        """
-        ...
-
-    def get_channel_values(self, channel_name:builtins.str) -> typing.Optional[typing.Any]:
-        r"""
-        Read a channel's samples as a contiguous numpy ``float64`` array.
-        
-        Searches every group and returns the first channel whose name matches
-        ``channel_name``. This is the fastest read path for numeric channels —
-        values are decoded directly into a numpy buffer, with any
-        non-decodable / invalid samples set to ``NaN``. Conversions stored on
-        the channel (linear, rational, table-lookup) are applied automatically.
+        Slower than :py:meth:`read` but faithful to every conversion type
+        (linear, rational, table, value-to-text, …). ``None`` entries mark
+        invalid samples; valid samples are ``float`` / ``int`` / ``str`` /
+        ``bytes`` matching the channel.
         
         Parameters
         ----------
-        channel_name : str
-            Exact channel name (case-sensitive).
-        
-        Returns
-        -------
-        Optional[numpy.ndarray]
-            1-D ``float64`` array of length ``record_count``, or ``None`` if no
-            channel with that name exists.
+        name : str
+        group : Optional[str]
         """
         ...
 
-    def get_channel_values_by_group_and_name(self, group_name:builtins.str, channel_name:builtins.str) -> typing.Optional[typing.Any]:
-        r"""
-        Read a channel from a *specific* group, by group and channel name.
-        
-        Use this when the same channel name appears in multiple groups (e.g.
-        each group has its own ``Time``) and you need to disambiguate.
-        
-        Parameters
-        ----------
-        group_name : str
-            Exact channel-group name.
-        channel_name : str
-            Exact channel name within that group.
-        
-        Returns
-        -------
-        Optional[numpy.ndarray]
-            1-D ``float64`` array, or ``None`` if either name is not found.
-        """
-        ...
-
-    def get_channel_as_series(self, channel_name:builtins.str) -> typing.Optional[typing.Any]:
+    def series(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
         r"""
         Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
         
-        The series is indexed by the group's master channel (channel-type 2)
-        converted to a ``DatetimeIndex`` — relative master values (in seconds)
-        are added to the file's ``HD.abs_time`` start instant. If the channel
-        has no master, or the master channel itself is being requested, the
-        returned series uses the default integer index. If the file has no
-        recorded start time, the master values are kept as a numeric index.
+        The series is indexed by the channel's group master (channel-type 2)
+        converted to a ``DatetimeIndex`` (relative seconds added to the file's
+        ``HD.abs_time``). If there is no master, or the requested channel *is*
+        the master, a default integer index is used; if the file has no start
+        time, master values are kept as a numeric index.
         
         Parameters
         ----------
-        channel_name : str
-            Exact channel name; first match across all groups is used.
-        
-        Returns
-        -------
-        Optional[pandas.Series]
-            ``None`` if no channel with that name exists.
+        name : str
+        group : Optional[str]
         
         Raises
         ------
         MdfException
-            If pandas is not installed.
+            If the channel is not found or pandas is not installed.
         """
         ...
 
-    def file_layout(self) -> PyFileLayout:
+    def __getitem__(self, name:builtins.str) -> typing.Any:
         r"""
-        Build a :class:`PyFileLayout` describing every block in this file.
+        ``mdf["Speed"]`` — shorthand for :py:meth:`read` (numpy float64).
+        """
+        ...
+
+    def file_layout(self) -> FileLayout:
+        r"""
+        Build a :class:`FileLayout` describing every block in this file.
         
-        Useful for debugging or analysing the on-disk structure: returns the
-        offset, size, type, link targets and unreferenced gaps for each
-        MDF block (``##ID``, ``##HD``, ``##DG``, ``##CG``, ``##CN``, ``##DT``,
-        ``##DL``, ``##TX``, ``##CC``, ``##SI``, ``##SD`` …).
-        
-        Returns
-        -------
-        PyFileLayout
+        Useful for debugging or analysing on-disk structure: offset, size,
+        type, link targets and unreferenced gaps for each MDF block.
         """
         ...
 
 
-class PyMdfIndex:
+class MdfData:
+    r"""
+    A reader bound to an :class:`MdfIndex` and a single data source.
+    
+    Obtained from :py:meth:`MdfIndex.open` / :py:meth:`MdfIndex.open_url`. The
+    source (file path or URL) is given once; afterwards you read channels by
+    **name**:
+    
+    >>> data = idx.open("recording.mf4")
+    >>> speed = data["Speed"]                  # numpy float64 (fast path)
+    >>> status = data.read_raw("Status")       # native values + conversions
+    >>> s = data.series("Speed")               # pandas Series, datetime index
+    """
+    groups: builtins.list[GroupInfo]
+    channel_names: builtins.list[builtins.str]
+    def read(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
+        r"""
+        Read a numeric channel by name as a numpy ``float64`` array (fast path).
+        
+        Invalid / non-decodable samples become ``NaN``. Linear conversions are
+        applied inline; for text / table conversions use :py:meth:`read_raw`.
+        
+        Parameters
+        ----------
+        name : str
+        group : Optional[str]
+            Disambiguate by group when the channel name is not unique.
+        """
+        ...
+
+    def read_raw(self, name:builtins.str, group:typing.Optional[builtins.str]) -> builtins.list[typing.Optional[typing.Any]]:
+        r"""
+        Read a channel by name, returning native Python values + conversions.
+        
+        ``None`` marks invalid samples; valid samples are ``float`` / ``int`` /
+        ``str`` / ``bytes``. Faithful to every conversion type.
+        
+        Parameters
+        ----------
+        name : str
+        group : Optional[str]
+        """
+        ...
+
+    def series(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
+        r"""
+        Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
+        
+        Indexed by the channel's group master converted to a ``DatetimeIndex``
+        (relative seconds added to the index's stored start time). Falls back to
+        a numeric / default index when there is no master or no start time.
+        
+        Parameters
+        ----------
+        name : str
+        group : Optional[str]
+        
+        Raises
+        ------
+        MdfException
+            If the channel is not found or pandas is not installed.
+        """
+        ...
+
+    def __getitem__(self, name:builtins.str) -> typing.Any:
+        r"""
+        ``data["Speed"]`` — shorthand for :py:meth:`read` (numpy float64).
+        """
+        ...
+
+    def byte_ranges(self, name:builtins.str, group:typing.Optional[builtins.str]) -> builtins.list[tuple[builtins.int, builtins.int]]:
+        r"""
+        Byte ranges ``[(offset, length), ...]`` for a channel (escape hatch).
+        """
+        ...
+
+    def group(self, name:builtins.str) -> typing.Optional[GroupInfo]:
+        r"""
+        Find a channel group by name (first match), or ``None``.
+        """
+        ...
+
+    def channel(self, name:builtins.str) -> typing.Optional[ChannelInfo]:
+        r"""
+        Find a channel by name across all groups (first match), or ``None``.
+        """
+        ...
+
+
+class MdfIndex:
     r"""
     Lightweight, self-contained index over an MDF 4 file.
     
-    An index records the byte ranges of each channel, fully resolves all
-    conversion blocks, and can be serialized to JSON. Once you have a
-    ``PyMdfIndex`` you can:
+    An index records the byte ranges of each channel, fully resolves every
+    conversion block, and serialises to JSON. Navigate it by **name**
+    (:py:attr:`groups`, :py:meth:`group`, :py:meth:`channel`); to read sample
+    data, bind a source once with :py:meth:`open` / :py:meth:`open_url`, which
+    return an :class:`MdfData` you index by channel name.
     
-    - Re-read channel values quickly without re-parsing the whole file.
-    - Compute exact byte ranges for **partial** / HTTP-range / S3 reads
-      (see :py:meth:`get_channel_byte_ranges`,
-      :py:meth:`get_channel_byte_ranges_for_records`).
-    - Persist with :py:meth:`save_to_file` and reload elsewhere with
-      :py:meth:`load_from_file` — the JSON is fully self-contained, the
-      original file is only required for the actual data reads.
-    
-    **Limitation:** indexes do not support compressed (``##DZ``) data blocks.
+    **Limitation:** compressed (``##DZ``) data blocks are not supported.
     
     Example
     -------
-    >>> idx = mf4_rs.PyMdfIndex.from_file("recording.mf4")
-    >>> idx.save_to_file("recording.idx.json")
-    >>> # Later, possibly on another machine that has the same file:
-    >>> idx2 = mf4_rs.PyMdfIndex.load_from_file("recording.idx.json")
-    >>> values = idx2.read_channel_values_by_name_as_f64("Speed", "recording.mf4")
+    >>> idx = mf4_rs.MdfIndex.from_file("recording.mf4")
+    >>> idx.save("recording.idx.json")
+    >>> idx = mf4_rs.MdfIndex.load("recording.idx.json")
+    >>> data = idx.open("recording.mf4")     # bind the data source once
+    >>> speed = data["Speed"]                # numpy float64
+    >>> rpm   = data.read("RPM", group="Engine")
     """
+    groups: builtins.list[GroupInfo]
+    channel_names: builtins.list[builtins.str]
+    file_size: builtins.int
     @staticmethod
-    def from_file(path:builtins.str) -> PyMdfIndex:
+    def from_file(path:builtins.str) -> MdfIndex:
         r"""
         Build a fresh index by parsing an MDF file from disk.
         
-        All conversions are resolved during construction so the index is
-        fully self-contained afterwards.
+        All conversions are resolved during construction so the index is fully
+        self-contained afterwards.
         
         Parameters
         ----------
         path : str
             Path to a ``.mf4`` file.
-        
-        Raises
-        ------
-        MdfException
-            If the file cannot be parsed as MDF 4.10+.
         """
         ...
 
     @staticmethod
-    def load_from_file(path:builtins.str) -> PyMdfIndex:
+    def load(path:builtins.str) -> MdfIndex:
         r"""
-        Load a previously saved JSON index file.
+        Load a previously saved JSON index (companion to :py:meth:`save`).
         
-        The companion to :py:meth:`save_to_file`. Reads do not require the
-        original MDF file until you actually call ``read_channel_values_*``
-        or ``get_channel_byte_ranges_*``.
+        The original MDF file is only needed later, when you actually read
+        values via :py:meth:`open`.
         """
         ...
 
     @staticmethod
-    def from_url(url:builtins.str, chunk_size:typing.Optional[builtins.int]) -> PyMdfIndex:
+    def from_url(url:builtins.str, chunk_size:typing.Optional[builtins.int]) -> MdfIndex:
         r"""
         Build an index from an MDF file served over HTTP / S3 using range
         requests, without downloading the whole file.
         
-        Issues range reads only for metadata blocks (``##ID``, ``##HD``,
-        ``##DG``, ``##CG``, ``##CN``, name / unit / comment ``##TX``,
-        conversion ``##CC`` plus its ``cc_ref`` chain, and ``##DT``/``##DV``/
-        ``##DZ``/``##DL`` headers). Sample data is never fetched. With the
-        default 1 MiB read-ahead chunk, a typical file collapses to a handful
-        of underlying HTTP requests regardless of file size.
+        Issues range reads only for metadata blocks; sample data is never
+        fetched. With the default 1 MiB read-ahead chunk a typical file
+        collapses to a handful of HTTP requests regardless of size.
         
         Parameters
         ----------
         url : str
-            ``http://`` or ``https://`` URL of the ``.mf4`` resource. The
-            server must honour single-range ``Range: bytes=A-B`` requests.
+            ``http://`` / ``https://`` URL honouring ``Range`` requests.
         chunk_size : int, optional
-            Read-ahead chunk size in bytes for the metadata phase
-            (default 1 MiB). Smaller values reduce wasted bytes when
-            metadata is densely packed near the file head; larger values
-            reduce the number of HTTP round-trips when metadata is
-            scattered across the file.
-        
-        Raises
-        ------
-        MdfException
-            If the URL cannot be reached, the server does not honour
-            range requests, or the response is not a valid MDF file.
+            Metadata read-ahead chunk size in bytes (default 1 MiB).
         """
         ...
 
-    def save_to_file(self, path:builtins.str) -> None:
+    def save(self, path:builtins.str) -> None:
         r"""
-        Serialize the index to JSON at ``path``.
-        
-        Output is dependency-free (no references back to the source MDF) and
-        typically a few KB to a few MB depending on channel/conversion count.
+        Serialize the index to JSON at ``path`` (dependency-free).
         """
         ...
 
-    def list_channel_groups(self) -> builtins.list[tuple[builtins.int, builtins.str, builtins.int]]:
+    def group(self, name:builtins.str) -> typing.Optional[GroupInfo]:
         r"""
-        List every channel group in the index.
-        
-        Returns
-        -------
-        list[tuple[int, str, int]]
-            ``(group_index, group_name, channel_count)`` per group. Unnamed
-            groups appear with an empty string for the name.
+        Find a channel group by name (first match), or ``None``.
         """
         ...
 
-    def list_channels(self, group_index:builtins.int) -> typing.Optional[builtins.list[tuple[builtins.int, builtins.str, PyDataType]]]:
+    def channel(self, name:builtins.str) -> typing.Optional[ChannelInfo]:
         r"""
-        List channels in a single group.
+        Find a channel by name across all groups (first match), or ``None``.
+        """
+        ...
+
+    def groups_with_channel(self, name:builtins.str) -> builtins.list[builtins.str]:
+        r"""
+        Names of the groups that contain a channel called ``name``.
+        
+        Use this to disambiguate a channel name shared by several groups, then
+        pass the chosen group to :py:meth:`MdfData.read`.
+        """
+        ...
+
+    def byte_ranges(self, name:builtins.str, group:typing.Optional[builtins.str]) -> builtins.list[tuple[builtins.int, builtins.int]]:
+        r"""
+        Byte ranges ``[(offset, length), ...]`` occupied by a channel.
+        
+        Accounts for the channel's record-layout position and data-block
+        splitting. Power-user entry point for issuing your own partial reads.
         
         Parameters
         ----------
-        group_index : int
-            Index from :py:meth:`list_channel_groups`.
-        
-        Returns
-        -------
-        Optional[list[tuple[int, str, PyDataType]]]
-            ``(channel_index, channel_name, data_type)`` per channel, or
-            ``None`` if ``group_index`` is out of range.
+        name : str
+        group : Optional[str]
+            Disambiguate by group when the name is not unique.
         """
         ...
 
-    def read_channel_values(self, group_index:builtins.int, channel_index:builtins.int, file_path:builtins.str) -> builtins.list[typing.Optional[typing.Any]]:
+    def byte_ranges_for_records(self, name:builtins.str, start_record:builtins.int, record_count:builtins.int) -> builtins.list[tuple[builtins.int, builtins.int]]:
         r"""
-        Read every sample of a channel, identified by group + channel index.
-        
-        Conversions stored in the index are applied automatically.
-        
-        Parameters
-        ----------
-        group_index : int
-        channel_index : int
-        file_path : str
-            Path to the original MDF file (the index does not embed sample
-            bytes).
-        
-        Returns
-        -------
-        list[Optional[Union[float, int, str, bytes]]]
-            One entry per record. ``None`` indicates an invalid sample
-            (invalidation bit set, or undecodable). Otherwise the value is a
-            native Python type matching the channel's data type.
-        
-        Raises
-        ------
-        MdfException
-            If indices are out of range, the file cannot be read, or the
-            file contains compressed (``##DZ``) blocks.
+        Byte ranges covering a record window ``[start, start+count)``.
         """
         ...
 
-    def read_channel_values_by_name(self, channel_name:builtins.str, file_path:builtins.str) -> builtins.list[typing.Optional[typing.Any]]:
+    def conversion_info(self, name:builtins.str) -> typing.Optional[builtins.dict[builtins.str, typing.Any]]:
         r"""
-        Read every sample of a channel by name (first match across groups).
+        Inspect the conversion attached to a channel (by name).
         
-        See :py:meth:`read_channel_values` for the return / error contract.
-        If multiple groups contain the same channel name, prefer
-        :py:meth:`read_channel_values_by_group_and_name`.
+        Returns ``None`` if the channel has no conversion, otherwise a dict
+        describing it (``conversion_type``, ``values``, ``resolved_texts``,
+        ``formula`` …).
         """
         ...
 
-    def read_channel_values_from_url(self, group_index:builtins.int, channel_index:builtins.int, url:builtins.str) -> builtins.list[typing.Optional[typing.Any]]:
+    def open(self, path:builtins.str) -> MdfData:
         r"""
-        Read every sample of a channel via HTTP range requests.
+        Bind this index to a local MDF file for reading sample data.
         
-        Issues one HTTP request per data block holding this channel. Cache
-        is bypassed because data-block payloads are typically far larger
-        than any sensible chunk size; one ranged ``GET`` per block is the
-        cheapest pattern.
-        
-        Parameters
-        ----------
-        group_index : int
-        channel_index : int
-        url : str
-            URL of the same MDF file the index was built from.
-        
-        Returns
-        -------
-        list[Optional[Union[float, int, str, bytes]]]
-            One entry per record. ``None`` indicates an invalid sample.
+        Returns an :class:`MdfData`; the file path is supplied once here and
+        reused for every subsequent read.
         """
         ...
 
-    def read_channel_values_by_name_from_url(self, channel_name:builtins.str, url:builtins.str) -> builtins.list[typing.Optional[typing.Any]]:
+    def open_url(self, url:builtins.str) -> MdfData:
         r"""
-        Read every sample of a channel by name via HTTP range requests.
-        
-        See :py:meth:`read_channel_values_from_url` for the I/O contract.
-        """
-        ...
-
-    def read_channel_values_as_f64(self, group_index:builtins.int, channel_index:builtins.int, file_path:builtins.str) -> builtins.list[builtins.float]:
-        r"""
-        Fast path: read a numeric channel as a list of ``float`` values.
-        
-        Several times faster than :py:meth:`read_channel_values` for numeric
-        channels — opens the source file via ``mmap``, decodes directly into
-        ``f64`` and skips ``DecodedValue`` boxing. Invalid / non-finite
-        samples are returned as ``float('nan')`` rather than ``None``.
-        
-        Parameters
-        ----------
-        group_index : int
-        channel_index : int
-        file_path : str
-        
-        Returns
-        -------
-        list[float]
-        
-        Raises
-        ------
-        MdfException
-            If the channel is non-numeric (string / byte array), indices are
-            out of range, or the file cannot be mapped.
-        """
-        ...
-
-    def read_channel_values_by_name_as_f64(self, channel_name:builtins.str, file_path:builtins.str) -> builtins.list[builtins.float]:
-        r"""
-        Fast path: read a numeric channel as ``list[float]``, looked up by name.
-        
-        Combines :py:meth:`find_channel_by_name` and
-        :py:meth:`read_channel_values_as_f64`. Invalid samples are
-        ``float('nan')``.
-        
-        Raises
-        ------
-        MdfException
-            If no channel with that name exists, the channel is not numeric,
-            or the file cannot be mapped.
-        """
-        ...
-
-    def find_channel_by_name(self, channel_name:builtins.str) -> typing.Optional[tuple[builtins.int, builtins.int]]:
-        r"""
-        Locate a channel by name across all groups.
-        
-        Returns
-        -------
-        Optional[tuple[int, int]]
-            ``(group_index, channel_index)`` of the first match, or ``None``.
-        """
-        ...
-
-    def get_channel_byte_ranges(self, group_index:builtins.int, channel_index:builtins.int) -> builtins.list[tuple[builtins.int, builtins.int]]:
-        r"""
-        Compute the byte ranges occupied by a channel across the file.
-        
-        Each tuple is ``(offset, length)`` and accounts for the channel's
-        position inside the record layout *and* any data block splitting
-        across multiple ``##DT`` fragments. Useful for issuing HTTP-range
-        requests against a remote MDF file.
-        """
-        ...
-
-    def get_channel_byte_ranges_for_records(self, group_index:builtins.int, channel_index:builtins.int, start_record:builtins.int, record_count:builtins.int) -> builtins.list[tuple[builtins.int, builtins.int]]:
-        r"""
-        Like :py:meth:`get_channel_byte_ranges`, but limited to a record window.
-        
-        Parameters
-        ----------
-        group_index : int
-        channel_index : int
-        start_record : int
-            0-based first record to include.
-        record_count : int
-            Number of records to cover (clamped to remaining records).
-        """
-        ...
-
-    def get_channel_byte_summary(self, group_index:builtins.int, channel_index:builtins.int) -> tuple[builtins.int, builtins.int]:
-        r"""
-        Summarize :py:meth:`get_channel_byte_ranges` without listing each range.
-        
-        Returns
-        -------
-        tuple[int, int]
-            ``(total_bytes, num_ranges)``.
-        """
-        ...
-
-    def get_channel_byte_ranges_by_name(self, channel_name:builtins.str) -> builtins.list[tuple[builtins.int, builtins.int]]:
-        r"""
-        Byte ranges for a channel, looked up by name (first match).
-        """
-        ...
-
-    def get_channel_info_by_name(self, channel_name:builtins.str) -> typing.Optional[tuple[builtins.int, builtins.int, PyChannelInfo]]:
-        r"""
-        Look up a channel by name and return its position plus metadata.
-        
-        Returns
-        -------
-        Optional[tuple[int, int, PyChannelInfo]]
-            ``(group_index, channel_index, info)`` for the first match, or
-            ``None``. ``info.comment`` is always ``None`` for indexed
-            channels (comments are not stored in the index).
-        """
-        ...
-
-    def find_all_channels_by_name(self, channel_name:builtins.str) -> builtins.list[tuple[builtins.int, builtins.int]]:
-        r"""
-        Find every ``(group_index, channel_index)`` whose channel name matches.
-        
-        Useful when the same name appears in multiple groups (e.g. ``"Time"``
-        in each group).
-        """
-        ...
-
-    def get_file_size(self) -> builtins.int:
-        r"""
-        Total size, in bytes, of the source MDF file at the time the index
-        was built.
-        """
-        ...
-
-    def has_resolved_conversions(self) -> builtins.bool:
-        r"""
-        True if any conversion in the index has its dependent ``##TX`` /
-        ``##CC`` data resolved inline.
-        
-        Indexes built with :py:meth:`from_file` resolve all dependencies, so
-        this normally returns ``True``.
-        """
-        ...
-
-    def get_conversion_info(self, group_index:builtins.int, channel_index:builtins.int) -> typing.Optional[builtins.dict[builtins.str, typing.Any]]:
-        r"""
-        Inspect the conversion attached to a channel.
-        
-        Returns
-        -------
-        Optional[dict]
-            ``None`` if the channel has no conversion. Otherwise a dict with
-            keys:
-        
-            - ``conversion_type`` — debug rendering of the ``cc_type`` enum
-              (e.g. ``"Linear"``, ``"ValueToText"``).
-            - ``precision`` — decimal precision hint (``cc_precision``).
-            - ``flags`` — raw ``cc_flags`` bitfield.
-            - ``values_count`` — number of entries in ``cc_val``.
-            - ``values`` — raw ``cc_val`` numeric coefficients / table values.
-            - ``resolved_texts`` — dict[int, str] mapping ``cc_ref`` indices
-              to their resolved ``##TX`` text (when applicable).
-            - ``has_resolved_conversions`` — present when nested conversions
-              have been pre-resolved.
-            - ``formula`` — algebraic formula string (for type 3 only).
-        """
-        ...
-
-    def read_channel_values_by_group_and_name(self, group_name:builtins.str, channel_name:builtins.str, file_path:builtins.str) -> builtins.list[typing.Optional[typing.Any]]:
-        r"""
-        Read a channel by group + channel name, disambiguating duplicates.
-        
-        Looks up the channel group by name first, then finds the channel
-        within that specific group. ``None`` entries in the returned list
-        mark invalid samples; valid samples are native Python values
-        (``float`` / ``int`` / ``str`` / ``bytes``).
-        
-        Raises
-        ------
-        MdfException
-            If either ``group_name`` or ``channel_name`` is not found, or
-            the source file cannot be read.
-        """
-        ...
-
-    def read_channel_as_series(self, channel_name:builtins.str, file_path:builtins.str) -> typing.Any:
-        r"""
-        Read channel data as a pandas Series with time/master channel as DatetimeIndex.
-        
-        This method reads a channel's values from the index and returns them as a pandas Series
-        with the time/master channel values converted to absolute timestamps as a DatetimeIndex.
-        The timestamps are created by adding the relative time values to the MDF start time
-        stored in the index. If no master channel is found, or if the queried channel IS the
-        master channel, a default integer index is used. If the MDF file has no start time,
-        falls back to numeric index.
-        
-        Requires pandas to be installed.
-        
-        # Arguments
-        * `channel_name` - Name of the channel to read
-        * `file_path` - Path to the MDF file
-        
-        # Returns
-        Returns an error if the channel is not found, otherwise returns a pandas Series.
-        
-        # Errors
-        Returns an error if:
-        - pandas is not installed
-        - the channel is not found
-        - the master channel has a different number of values than the data channel
+        Bind this index to an HTTP / S3 URL for reading sample data via range
+        requests. Returns an :class:`MdfData`.
         """
         ...
 
 
-class PyMdfWriter:
+class MdfWriter:
     r"""
     Streaming writer for MDF 4 files.
     
     Build an MDF file in five logical steps:
     
-    1. ``writer = mf4_rs.PyMdfWriter("out.mf4")``
+    1. ``writer = mf4_rs.MdfWriter("out.mf4")``
     2. ``writer.init_mdf_file()`` — write ``##ID`` and ``##HD``.
     3. Define structure: :py:meth:`add_channel_group`, then any combination of
        :py:meth:`add_time_channel`, :py:meth:`add_float_channel`,
@@ -815,7 +601,7 @@ class PyMdfWriter:
     
     Example
     -------
-    >>> w = mf4_rs.PyMdfWriter("demo.mf4")
+    >>> w = mf4_rs.MdfWriter("demo.mf4")
     >>> w.init_mdf_file()
     >>> cg = w.add_channel_group("group_0")
     >>> t = w.add_time_channel(cg, "Time")
@@ -866,7 +652,7 @@ class PyMdfWriter:
         """
         ...
 
-    def add_channel(self, group_id:builtins.str, name:builtins.str, data_type:PyDataType) -> builtins.str:
+    def add_channel(self, group_id:builtins.str, name:builtins.str, data_type:DataType) -> builtins.str:
         r"""
         Add a generic channel to a channel group, using the data type's
         natural bit width.
@@ -882,7 +668,7 @@ class PyMdfWriter:
             ID returned by :py:meth:`add_channel_group`.
         name : str
             Channel name (written as a ``##TX`` block).
-        data_type : PyDataType
+        data_type : DataType
             One of the values from the ``create_data_type_*`` helpers.
         
         Returns
@@ -939,7 +725,7 @@ class PyMdfWriter:
         
         For signed integers, build a generic channel with
         :py:meth:`add_channel` and ``create_data_type_*`` helpers (or call
-        directly with the raw :class:`PyDataType`).
+        directly with the raw :class:`DataType`).
         """
         ...
 
@@ -971,14 +757,14 @@ class PyMdfWriter:
         """
         ...
 
-    def write_record(self, group_id:builtins.str, values:typing.Sequence[PyDecodedValue]) -> None:
+    def write_record(self, group_id:builtins.str, values:typing.Sequence[DecodedValue]) -> None:
         r"""
         Append a single record (one sample for each channel in the group).
         
         ``values`` must contain exactly one entry per channel, in the same
         order channels were added — typically the master channel first, then
         data channels. Each value is encoded according to its channel's data
-        type (the variant of :class:`PyDecodedValue` is *not* re-checked, so
+        type (the variant of :class:`DecodedValue` is *not* re-checked, so
         passing the wrong variant will produce nonsense bytes).
         
         This call has Python-level overhead per value; for bulk numeric data,
@@ -1059,14 +845,14 @@ class PyMdfWriter:
         ...
 
 
-class PyDecodedValue(Enum):
+class DecodedValue(Enum):
     r"""
     A single decoded channel sample, tagged with its underlying type.
     
     Returned by ``create_*_value`` helpers and consumed by
-    :py:meth:`PyMdfWriter.write_record`. When *reading*, most APIs return native
+    :py:meth:`MdfWriter.write_record`. When *reading*, most APIs return native
     Python objects (``float`` / ``int`` / ``str`` / ``bytes``) directly, so you
-    usually only construct ``PyDecodedValue`` to feed back into the writer.
+    usually only construct ``DecodedValue`` to feed back into the writer.
     
     Variants carry a single ``value`` field (use the ``value`` getter to
     retrieve the inner native Python value):
@@ -1085,59 +871,59 @@ class PyDecodedValue(Enum):
     ByteArray = auto()
     Unknown = auto()
 
-def create_data_type_float_le() -> PyDataType:
+def create_data_type_float_le() -> DataType:
     r"""
-    Return the :class:`PyDataType` for little-endian IEEE-754 floats.
+    Return the :class:`DataType` for little-endian IEEE-754 floats.
     
-    Pair with :py:meth:`PyMdfWriter.add_channel`. Defaults to 32 bits when
-    passed to ``add_channel`` — for f64 use :py:meth:`PyMdfWriter.add_float_channel`.
+    Pair with :py:meth:`MdfWriter.add_channel`. Defaults to 32 bits when
+    passed to ``add_channel`` — for f64 use :py:meth:`MdfWriter.add_float_channel`.
     """
     ...
 
-def create_data_type_string_utf8() -> PyDataType:
+def create_data_type_string_utf8() -> DataType:
     r"""
-    Return the :class:`PyDataType` for UTF-8 encoded string channels.
+    Return the :class:`DataType` for UTF-8 encoded string channels.
     """
     ...
 
-def create_data_type_uint_le() -> PyDataType:
+def create_data_type_uint_le() -> DataType:
     r"""
-    Return the :class:`PyDataType` for little-endian unsigned integers.
+    Return the :class:`DataType` for little-endian unsigned integers.
     
-    Pair with :py:meth:`PyMdfWriter.add_channel` when you need an unsigned
+    Pair with :py:meth:`MdfWriter.add_channel` when you need an unsigned
     integer channel of non-default width (otherwise see
-    :py:meth:`PyMdfWriter.add_int_channel`).
+    :py:meth:`MdfWriter.add_int_channel`).
     """
     ...
 
-def create_float_value(value:builtins.float) -> PyDecodedValue:
+def create_float_value(value:builtins.float) -> DecodedValue:
     r"""
-    Wrap a Python ``float`` in a :class:`PyDecodedValue` of variant ``Float``.
+    Wrap a Python ``float`` in a :class:`DecodedValue` of variant ``Float``.
     
-    Use this to feed values into :py:meth:`PyMdfWriter.write_record` for any
+    Use this to feed values into :py:meth:`MdfWriter.write_record` for any
     floating-point channel (32- or 64-bit; the value is truncated to the
     channel's declared bit width on encode).
     """
     ...
 
-def create_int_value(value:builtins.int) -> PyDecodedValue:
+def create_int_value(value:builtins.int) -> DecodedValue:
     r"""
-    Wrap a Python ``int`` in a ``SignedInteger`` :class:`PyDecodedValue`.
+    Wrap a Python ``int`` in a ``SignedInteger`` :class:`DecodedValue`.
     """
     ...
 
-def create_string_value(value:builtins.str) -> PyDecodedValue:
+def create_string_value(value:builtins.str) -> DecodedValue:
     r"""
-    Wrap a Python ``str`` in a ``String`` :class:`PyDecodedValue`.
+    Wrap a Python ``str`` in a ``String`` :class:`DecodedValue`.
     
     For string channels (``StringUtf8`` etc.). Encoding into the file is
     done according to the channel's declared string data type.
     """
     ...
 
-def create_uint_value(value:builtins.int) -> PyDecodedValue:
+def create_uint_value(value:builtins.int) -> DecodedValue:
     r"""
-    Wrap a Python ``int`` in a ``UnsignedInteger`` :class:`PyDecodedValue`.
+    Wrap a Python ``int`` in a ``UnsignedInteger`` :class:`DecodedValue`.
     
     Suitable for any unsigned integer channel; the value is truncated to the
     channel's bit width on encode.
@@ -1184,11 +970,11 @@ def cut_mdf_by_utc(input_path:builtins.str, output_path:builtins.str, start_utc:
     """
     ...
 
-def file_layout_from_file(path:builtins.str) -> PyFileLayout:
+def file_layout_from_file(path:builtins.str) -> FileLayout:
     r"""
-    Build a :class:`PyFileLayout` from an MDF file on disk.
+    Build a :class:`FileLayout` from an MDF file on disk.
     
-    Functional alias for :py:meth:`PyFileLayout.from_file`.
+    Functional alias for :py:meth:`FileLayout.from_file`.
     
     Parameters
     ----------
@@ -1196,7 +982,7 @@ def file_layout_from_file(path:builtins.str) -> PyFileLayout:
     
     Returns
     -------
-    PyFileLayout
+    FileLayout
     """
     ...
 

--- a/python/mf4_rs/_mf4_rs.pyi
+++ b/python/mf4_rs/_mf4_rs.pyi
@@ -305,9 +305,12 @@ class Mdf:
         """
         ...
 
-    def __getitem__(self, name:builtins.str) -> typing.Any:
+    def __getitem__(self, key:typing.Any) -> typing.Any:
         r"""
         ``mdf["Speed"]`` — shorthand for :py:meth:`read` (timestamp-indexed Series).
+        
+        Pass a ``(name, group)`` tuple to disambiguate a channel name shared by
+        several groups, e.g. ``mdf["Speed", "Engine"]``.
         """
         ...
 
@@ -498,9 +501,12 @@ class MdfIndex:
         """
         ...
 
-    def __getitem__(self, name:builtins.str) -> typing.Any:
+    def __getitem__(self, key:typing.Any) -> typing.Any:
         r"""
         ``index["Speed"]`` — shorthand for :py:meth:`read` (timestamp-indexed Series).
+        
+        Pass a ``(name, group)`` tuple to disambiguate a channel name shared by
+        several groups, e.g. ``index["Speed", "Engine"]``.
         """
         ...
 

--- a/python/mf4_rs/_mf4_rs.pyi
+++ b/python/mf4_rs/_mf4_rs.pyi
@@ -267,12 +267,13 @@ class Mdf:
 
     def read(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
         r"""
-        Read a numeric channel by name as a numpy ``float64`` array.
+        Read a channel as a ``pandas.Series`` of values indexed by timestamps.
         
-        This is the fast path: values are decoded directly into a numpy buffer,
-        invalid / non-decodable samples become ``NaN``. It does **not** apply
-        non-linear conversions — use :py:meth:`read_raw` for text / table /
-        value-to-text channels.
+        This is the primary read: the channel's samples (with all conversions
+        applied) are the data, and the group's master/time channel is the index
+        — a ``DatetimeIndex`` when the file has a start time, otherwise the raw
+        master seconds. If there is no master, or the requested channel *is* the
+        master, a default integer index is used.
         
         Parameters
         ----------
@@ -285,51 +286,28 @@ class Mdf:
         Raises
         ------
         MdfException
-            If no matching channel exists.
+            If no matching channel exists or pandas is not installed.
         """
         ...
 
-    def read_raw(self, name:builtins.str, group:typing.Optional[builtins.str]) -> builtins.list[typing.Optional[typing.Any]]:
+    def values(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
         r"""
-        Read a channel by name, returning native Python values with conversions.
+        Read a numeric channel by name as a plain numpy ``float64`` array.
         
-        Slower than :py:meth:`read` but faithful to every conversion type
-        (linear, rational, table, value-to-text, …). ``None`` entries mark
-        invalid samples; valid samples are ``float`` / ``int`` / ``str`` /
-        ``bytes`` matching the channel.
+        The fast, pandas-free path — just the values, no timestamp index.
+        Invalid / non-numeric samples are ``NaN``. Use :py:meth:`read` when you
+        want the timestamp-indexed Series and faithful (text / table) conversions.
         
         Parameters
         ----------
         name : str
         group : Optional[str]
-        """
-        ...
-
-    def series(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
-        r"""
-        Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
-        
-        The series is indexed by the channel's group master (channel-type 2)
-        converted to a ``DatetimeIndex`` (relative seconds added to the file's
-        ``HD.abs_time``). If there is no master, or the requested channel *is*
-        the master, a default integer index is used; if the file has no start
-        time, master values are kept as a numeric index.
-        
-        Parameters
-        ----------
-        name : str
-        group : Optional[str]
-        
-        Raises
-        ------
-        MdfException
-            If the channel is not found or pandas is not installed.
         """
         ...
 
     def __getitem__(self, name:builtins.str) -> typing.Any:
         r"""
-        ``mdf["Speed"]`` — shorthand for :py:meth:`read` (numpy float64).
+        ``mdf["Speed"]`` — shorthand for :py:meth:`read` (timestamp-indexed Series).
         """
         ...
 
@@ -343,119 +321,33 @@ class Mdf:
         ...
 
 
-class MdfData:
-    r"""
-    A reader bound to an :class:`MdfIndex` and a single data source.
-    
-    Obtained from :py:meth:`MdfIndex.open` / :py:meth:`MdfIndex.open_url`. The
-    source (file path or URL) is given once; afterwards you read channels by
-    **name**:
-    
-    >>> data = idx.open("recording.mf4")
-    >>> speed = data["Speed"]                  # numpy float64 (fast path)
-    >>> status = data.read_raw("Status")       # native values + conversions
-    >>> s = data.series("Speed")               # pandas Series, datetime index
-    """
-    groups: builtins.list[GroupInfo]
-    channel_names: builtins.list[builtins.str]
-    def read(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
-        r"""
-        Read a numeric channel by name as a numpy ``float64`` array (fast path).
-        
-        Invalid / non-decodable samples become ``NaN``. Linear conversions are
-        applied inline; for text / table conversions use :py:meth:`read_raw`.
-        
-        Parameters
-        ----------
-        name : str
-        group : Optional[str]
-            Disambiguate by group when the channel name is not unique.
-        """
-        ...
-
-    def read_raw(self, name:builtins.str, group:typing.Optional[builtins.str]) -> builtins.list[typing.Optional[typing.Any]]:
-        r"""
-        Read a channel by name, returning native Python values + conversions.
-        
-        ``None`` marks invalid samples; valid samples are ``float`` / ``int`` /
-        ``str`` / ``bytes``. Faithful to every conversion type.
-        
-        Parameters
-        ----------
-        name : str
-        group : Optional[str]
-        """
-        ...
-
-    def series(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
-        r"""
-        Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
-        
-        Indexed by the channel's group master converted to a ``DatetimeIndex``
-        (relative seconds added to the index's stored start time). Falls back to
-        a numeric / default index when there is no master or no start time.
-        
-        Parameters
-        ----------
-        name : str
-        group : Optional[str]
-        
-        Raises
-        ------
-        MdfException
-            If the channel is not found or pandas is not installed.
-        """
-        ...
-
-    def __getitem__(self, name:builtins.str) -> typing.Any:
-        r"""
-        ``data["Speed"]`` — shorthand for :py:meth:`read` (numpy float64).
-        """
-        ...
-
-    def byte_ranges(self, name:builtins.str, group:typing.Optional[builtins.str]) -> builtins.list[tuple[builtins.int, builtins.int]]:
-        r"""
-        Byte ranges ``[(offset, length), ...]`` for a channel (escape hatch).
-        """
-        ...
-
-    def group(self, name:builtins.str) -> typing.Optional[GroupInfo]:
-        r"""
-        Find a channel group by name (first match), or ``None``.
-        """
-        ...
-
-    def channel(self, name:builtins.str) -> typing.Optional[ChannelInfo]:
-        r"""
-        Find a channel by name across all groups (first match), or ``None``.
-        """
-        ...
-
-
 class MdfIndex:
     r"""
     Lightweight, self-contained index over an MDF 4 file.
     
     An index records the byte ranges of each channel, fully resolves every
     conversion block, and serialises to JSON. Navigate it by **name**
-    (:py:attr:`groups`, :py:meth:`group`, :py:meth:`channel`); to read sample
-    data, bind a source once with :py:meth:`open` / :py:meth:`open_url`, which
-    return an :class:`MdfData` you index by channel name.
+    (:py:attr:`groups`, :py:meth:`group`, :py:meth:`channel`). It also remembers
+    its data :py:attr:`source` (file path or URL); reading is lazy — the
+    byte-range request happens on :py:meth:`read` / :py:meth:`values`, never at
+    build time.
     
     **Limitation:** compressed (``##DZ``) data blocks are not supported.
     
     Example
     -------
-    >>> idx = mf4_rs.MdfIndex.from_file("recording.mf4")
+    >>> idx = mf4_rs.MdfIndex.from_url("https://host/recording.mf4")  # only metadata fetched
+    >>> speed = idx.read("Speed")            # pandas Series; range request happens now
+    >>> rpm   = idx.values("RPM")            # numpy float64, no timestamp index
     >>> idx.save("recording.idx.json")
     >>> idx = mf4_rs.MdfIndex.load("recording.idx.json")
-    >>> data = idx.open("recording.mf4")     # bind the data source once
-    >>> speed = data["Speed"]                # numpy float64
-    >>> rpm   = data.read("RPM", group="Engine")
+    >>> idx.source = "recording.mf4"         # re-attach a source after load
+    >>> t = idx.read("Speed")
     """
     groups: builtins.list[GroupInfo]
     channel_names: builtins.list[builtins.str]
     file_size: builtins.int
+    source: typing.Optional[builtins.str]
     @staticmethod
     def from_file(path:builtins.str) -> MdfIndex:
         r"""
@@ -523,7 +415,7 @@ class MdfIndex:
         Names of the groups that contain a channel called ``name``.
         
         Use this to disambiguate a channel name shared by several groups, then
-        pass the chosen group to :py:meth:`MdfData.read`.
+        pass the chosen group to :py:meth:`read` / :py:meth:`values`.
         """
         ...
 
@@ -558,19 +450,57 @@ class MdfIndex:
         """
         ...
 
-    def open(self, path:builtins.str) -> MdfData:
+    def set_source_prop(self, value:typing.Optional[builtins.str]) -> None:
+        ...
+
+    def set_source(self, value:typing.Optional[builtins.str]) -> None:
         r"""
-        Bind this index to a local MDF file for reading sample data.
+        Attach (or clear) the data source used by :py:meth:`read` / :py:meth:`values`.
         
-        Returns an :class:`MdfData`; the file path is supplied once here and
-        reused for every subsequent read.
+        A value starting with ``http://`` or ``https://`` is treated as a URL;
+        anything else as a local file path. Pass ``None`` to clear.
         """
         ...
 
-    def open_url(self, url:builtins.str) -> MdfData:
+    def read(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
         r"""
-        Bind this index to an HTTP / S3 URL for reading sample data via range
-        requests. Returns an :class:`MdfData`.
+        Read a channel as a ``pandas.Series`` of values indexed by timestamps.
+        
+        **Lazy:** the byte-range request to the attached source happens now, not
+        when the index was built. Values carry all conversions; the index is the
+        group master converted to a ``DatetimeIndex`` (or raw seconds / default
+        index when there is no start time / master).
+        
+        Parameters
+        ----------
+        name : str
+        group : Optional[str]
+            Disambiguate by group when the channel name is not unique.
+        
+        Raises
+        ------
+        MdfException
+            If no source is attached, the channel is missing, or pandas is absent.
+        """
+        ...
+
+    def values(self, name:builtins.str, group:typing.Optional[builtins.str]) -> typing.Any:
+        r"""
+        Read a numeric channel by name as a plain numpy ``float64`` array.
+        
+        Lazy fast path — just the values, no timestamp index, pandas-free.
+        Invalid / non-numeric samples are ``NaN``.
+        
+        Parameters
+        ----------
+        name : str
+        group : Optional[str]
+        """
+        ...
+
+    def __getitem__(self, name:builtins.str) -> typing.Any:
+        r"""
+        ``index["Speed"]`` — shorthand for :py:meth:`read` (timestamp-indexed Series).
         """
         ...
 

--- a/python/mf4_rs/_mf4_rs.pyi
+++ b/python/mf4_rs/_mf4_rs.pyi
@@ -250,9 +250,23 @@ class Mdf:
     >>> rpm   = mdf.read("RPM", group="Engine")
     >>> s     = mdf.series("Speed")          # pandas Series, datetime index
     """
+    source: builtins.str
     groups: builtins.list[GroupInfo]
     channel_names: builtins.list[builtins.str]
     def __new__(cls,path:builtins.str): ...
+    def list_signals(self) -> builtins.list[tuple[builtins.str, typing.Optional[builtins.str], typing.Optional[builtins.str]]]:
+        r"""
+        A flat catalog of every channel as ``(source, group, channel)`` tuples.
+        
+        ``source`` is this file's path (same for every row). ``group`` /
+        ``channel`` are ``None`` if unnamed. Metadata only — no samples decoded.
+        
+        Returns
+        -------
+        list[tuple[str, Optional[str], Optional[str]]]
+        """
+        ...
+
     def group(self, name:builtins.str) -> typing.Optional[GroupInfo]:
         r"""
         Find a channel group by name (first match), or ``None``.
@@ -450,6 +464,21 @@ class MdfIndex:
         Returns ``None`` if the channel has no conversion, otherwise a dict
         describing it (``conversion_type``, ``values``, ``resolved_texts``,
         ``formula`` …).
+        """
+        ...
+
+    def list_signals(self) -> builtins.list[tuple[typing.Optional[builtins.str], typing.Optional[builtins.str], typing.Optional[builtins.str]]]:
+        r"""
+        A flat catalog of every channel as ``(source, group, channel)`` tuples.
+        
+        ``source`` is this index's attached source (file path or URL) — the same
+        for every row, so catalogs from several indexes concatenate cleanly.
+        Built from metadata only; no sample data is read (cheap even for a
+        URL-backed index). ``group`` / ``channel`` are ``None`` if unnamed.
+        
+        Returns
+        -------
+        list[tuple[Optional[str], Optional[str], Optional[str]]]
         """
         ...
 

--- a/src/api/channel_group.rs
+++ b/src/api/channel_group.rs
@@ -4,6 +4,7 @@ use crate::parsing::raw_channel_group::RawChannelGroup;
 use crate::parsing::source_info::SourceInfo;
 use crate::api::channel::Channel;
 use crate::error::MdfError;
+use crate::signal::Signal;
 
 /// High level wrapper for a channel group.
 ///
@@ -68,6 +69,46 @@ impl<'a> ChannelGroup<'a> {
         }
 
         channels
+    }
+
+    /// Find a channel in this group by name (first match).
+    pub fn channel(&self, name: &str) -> Option<Channel<'a>> {
+        self.channels()
+            .into_iter()
+            .find(|c| c.name().ok().flatten().as_deref() == Some(name))
+    }
+
+    /// Read a channel by name as a [`Signal`] (values paired with the group's
+    /// master/time axis).
+    ///
+    /// Returns `Ok(None)` if no channel with that name exists in this group.
+    /// `timestamps` is empty when the group has no master channel or when the
+    /// requested channel *is* the master.
+    pub fn signal(&self, name: &str) -> Result<Option<Signal>, MdfError> {
+        let channels = self.channels();
+        let mut target: Option<usize> = None;
+        let mut master: Option<usize> = None;
+        for (i, ch) in channels.iter().enumerate() {
+            if ch.block().channel_type == 2 {
+                master = Some(i);
+            }
+            if target.is_none() && ch.name()?.as_deref() == Some(name) {
+                target = Some(i);
+            }
+        }
+        let Some(ci) = target else { return Ok(None) };
+
+        let values = channels[ci].values()?;
+        let timestamps = match master {
+            Some(mi) if mi != ci => channels[mi].values_as_f64()?,
+            _ => Vec::new(),
+        };
+        Ok(Some(Signal {
+            name: name.to_string(),
+            unit: channels[ci].unit()?,
+            timestamps,
+            values,
+        }))
     }
 
     /// Get the raw data group (for internal use)

--- a/src/api/mdf.rs
+++ b/src/api/mdf.rs
@@ -1,6 +1,7 @@
 use crate::error::MdfError;
 use crate::parsing::mdf_file::MdfFile;
 use crate::api::channel_group::ChannelGroup;
+use crate::api::channel::Channel;
 use crate::block_layout::FileLayout;
 
 #[derive(Debug)]
@@ -49,6 +50,28 @@ impl MDF {
         }
 
         groups
+    }
+
+    /// Find a channel group by name (first match).
+    ///
+    /// Convenience over [`MDF::channel_groups`] for the common case of
+    /// addressing a group by its acquisition name.
+    pub fn group(&self, name: &str) -> Option<ChannelGroup<'_>> {
+        self.channel_groups()
+            .into_iter()
+            .find(|g| g.name().ok().flatten().as_deref() == Some(name))
+    }
+
+    /// Find a channel by name across all groups (first match).
+    pub fn channel(&self, name: &str) -> Option<Channel<'_>> {
+        for group in self.channel_groups() {
+            for channel in group.channels() {
+                if channel.name().ok().flatten().as_deref() == Some(name) {
+                    return Some(channel);
+                }
+            }
+        }
+        None
     }
 
     /// Get the start time of the measurement in nanoseconds since epoch.

--- a/src/api/mdf.rs
+++ b/src/api/mdf.rs
@@ -74,6 +74,19 @@ impl MDF {
         None
     }
 
+    /// Read a channel by name as a [`Signal`] (values paired with the master
+    /// time axis of the channel's group). First match across all groups.
+    ///
+    /// Returns `Ok(None)` if no channel with that name exists.
+    pub fn signal(&self, name: &str) -> Result<Option<crate::signal::Signal>, MdfError> {
+        for group in self.channel_groups() {
+            if let Some(sig) = group.signal(name)? {
+                return Ok(Some(sig));
+            }
+        }
+        Ok(None)
+    }
+
     /// Get the start time of the measurement in nanoseconds since epoch.
     ///
     /// This is the absolute timestamp stored in the MDF file header.

--- a/src/index.rs
+++ b/src/index.rs
@@ -1202,6 +1202,32 @@ impl MdfIndex {
         self.group(group)?.channel(name)
     }
 
+    /// The attached data source rendered as a string (file path or URL).
+    pub fn source_string(&self) -> Option<String> {
+        match &self.source {
+            Some(Source::File(p)) => Some(p.clone()),
+            #[cfg(feature = "http")]
+            Some(Source::Url(u)) => Some(u.clone()),
+            None => None,
+        }
+    }
+
+    /// A flat catalog of every channel as `(source, group name, channel name)`.
+    ///
+    /// `source` is this index's attached source (the same value for every row,
+    /// handy when concatenating catalogs from many files/URLs). Built purely
+    /// from metadata — no sample data is read.
+    pub fn signal_list(&self) -> Vec<(Option<String>, Option<String>, Option<String>)> {
+        let src = self.source_string();
+        let mut out = Vec::new();
+        for group in &self.channel_groups {
+            for channel in &group.channels {
+                out.push((src.clone(), group.name.clone(), channel.name.clone()));
+            }
+        }
+        out
+    }
+
     /// Every channel name across all groups, in file order (duplicates kept).
     pub fn channel_names(&self) -> Vec<&str> {
         self.channel_groups

--- a/src/index.rs
+++ b/src/index.rs
@@ -50,6 +50,16 @@ pub struct IndexedChannel {
 }
 
 impl IndexedChannel {
+    /// `true` if this is the group's master channel (usually time).
+    pub fn is_master(&self) -> bool {
+        self.channel_type == 2
+    }
+
+    /// `true` if this is a variable-length (VLSD) channel.
+    pub fn is_vlsd(&self) -> bool {
+        self.channel_type == 1 && self.vlsd_data_address.is_some()
+    }
+
     /// Create a temporary `ChannelBlock` for use with the decoder functions.
     /// This should be called once and reused across all records.
     fn to_channel_block(&self) -> crate::blocks::channel_block::ChannelBlock {
@@ -150,6 +160,28 @@ pub struct IndexedChannelGroup {
     pub channels: Vec<IndexedChannel>,
     /// Data block locations for this channel group
     pub data_blocks: Vec<DataBlockInfo>,
+}
+
+impl IndexedChannelGroup {
+    /// Find a channel in this group by name (first match).
+    pub fn channel(&self, name: &str) -> Option<&IndexedChannel> {
+        self.channels
+            .iter()
+            .find(|c| c.name.as_deref() == Some(name))
+    }
+
+    /// Names of every named channel in this group, in record order.
+    pub fn channel_names(&self) -> Vec<&str> {
+        self.channels
+            .iter()
+            .filter_map(|c| c.name.as_deref())
+            .collect()
+    }
+
+    /// The group's master channel (channel type 2), if any.
+    pub fn master_channel(&self) -> Option<&IndexedChannel> {
+        self.channels.iter().find(|c| c.is_master())
+    }
 }
 
 /// Complete MDF file index
@@ -892,13 +924,16 @@ impl MdfIndex {
             .map_err(|e| MdfError::BlockSerializationError(format!("JSON deserialization failed: {}", e)))
     }
 
-    /// Read channel values using the index and a byte range reader
-    /// 
+    /// Read channel values using the index and a byte range reader.
+    ///
+    /// Internal positional helper — the public entry point is
+    /// [`MdfReader::values`], which resolves channels by name.
+    ///
     /// # Returns
     /// A vector of `Option<DecodedValue>` where:
     /// - `Some(value)` represents a valid decoded value
     /// - `None` represents an invalid value (invalidation bit set or decoding failed)
-    pub fn read_channel_values<R: ByteRangeReader<Error = MdfError>>(
+    pub(crate) fn read_channel_values<R: ByteRangeReader<Error = MdfError>>(
         &self, 
         group_index: usize, 
         channel_index: usize,
@@ -1097,35 +1132,99 @@ impl MdfIndex {
         ))
     }
 
-    /// Get channel information for a specific group and channel
-    pub fn get_channel_info(&self, group_index: usize, channel_index: usize) -> Option<&IndexedChannel> {
-        self.channel_groups
-            .get(group_index)?
-            .channels
-            .get(channel_index)
+    /// All channel groups in the file, in file order.
+    pub fn groups(&self) -> &[IndexedChannelGroup] {
+        &self.channel_groups
     }
 
-    /// List all channel groups with their basic information
-    pub fn list_channel_groups(&self) -> Vec<(usize, &str, usize)> {
+    /// Find a channel group by its name.
+    ///
+    /// Returns the first group whose `##CG` acquisition name matches `name`.
+    pub fn group(&self, name: &str) -> Option<&IndexedChannelGroup> {
         self.channel_groups
             .iter()
-            .enumerate()
-            .map(|(i, group)| {
-                (i, group.name.as_deref().unwrap_or("<unnamed>"), group.channels.len())
-            })
+            .find(|g| g.name.as_deref() == Some(name))
+    }
+
+    /// Look up a single channel by name across all groups (first match).
+    pub fn channel(&self, name: &str) -> Option<&IndexedChannel> {
+        let (g, c) = self.locate(name)?;
+        self.channel_groups.get(g)?.channels.get(c)
+    }
+
+    /// Look up a channel by group name + channel name.
+    pub fn channel_in(&self, group: &str, name: &str) -> Option<&IndexedChannel> {
+        self.group(group)?.channel(name)
+    }
+
+    /// Every channel name across all groups, in file order (duplicates kept).
+    pub fn channel_names(&self) -> Vec<&str> {
+        self.channel_groups
+            .iter()
+            .flat_map(|g| g.channels.iter())
+            .filter_map(|c| c.name.as_deref())
             .collect()
     }
 
-    /// List all channels in a specific group
-    pub fn list_channels(&self, group_index: usize) -> Option<Vec<(usize, &str, &DataType)>> {
-        let group = self.channel_groups.get(group_index)?;
-        Some(
-            group.channels
-                .iter()
-                .enumerate()
-                .map(|(i, ch)| (i, ch.name.as_deref().unwrap_or("<unnamed>"), &ch.data_type))
-                .collect()
-        )
+    /// Resolve a channel name to its `(group_index, channel_index)` position.
+    ///
+    /// Returns the first match across all groups. Internal helper backing the
+    /// name-based public methods.
+    pub(crate) fn locate(&self, name: &str) -> Option<(usize, usize)> {
+        for (g, group) in self.channel_groups.iter().enumerate() {
+            for (c, channel) in group.channels.iter().enumerate() {
+                if channel.name.as_deref() == Some(name) {
+                    return Some((g, c));
+                }
+            }
+        }
+        None
+    }
+
+    /// Resolve a `(group name, channel name)` pair to indices.
+    pub(crate) fn locate_in(&self, group: &str, name: &str) -> Option<(usize, usize)> {
+        let g = self
+            .channel_groups
+            .iter()
+            .position(|grp| grp.name.as_deref() == Some(group))?;
+        let c = self.channel_groups[g]
+            .channels
+            .iter()
+            .position(|ch| ch.name.as_deref() == Some(name))?;
+        Some((g, c))
+    }
+
+    /// All `(group_index, channel_index)` positions matching a channel name.
+    ///
+    /// Useful when the same name appears in several groups (e.g. a per-group
+    /// `Time` master channel).
+    pub fn find_channels(&self, name: &str) -> Vec<(usize, usize)> {
+        let mut matches = Vec::new();
+        for (g, group) in self.channel_groups.iter().enumerate() {
+            for (c, channel) in group.channels.iter().enumerate() {
+                if channel.name.as_deref() == Some(name) {
+                    matches.push((g, c));
+                }
+            }
+        }
+        matches
+    }
+
+    /// Bind this index to a byte-range source for reading sample data.
+    ///
+    /// The returned [`MdfReader`] borrows the index and owns `reader`; read
+    /// values by channel name without re-supplying the source each time.
+    pub fn open<R: ByteRangeReader<Error = MdfError>>(&self, reader: R) -> MdfReader<'_, R> {
+        MdfReader { index: self, reader }
+    }
+
+    /// Bind this index to a local file (via memory map) for reading.
+    ///
+    /// Convenience wrapper around [`MdfIndex::open`] using [`MmapRangeReader`].
+    /// Not available on `wasm32-unknown-unknown`.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn open_file(&self, path: &str) -> Result<MdfReader<'_, MmapRangeReader>, MdfError> {
+        Ok(self.open(MmapRangeReader::new(path)?))
     }
 
     /// Get the exact byte ranges needed to read all data for a specific channel
@@ -1140,7 +1239,7 @@ impl MdfIndex {
     /// # Returns
     /// * `Ok(Vec<(u64, u64)>)` - Vector of (offset, length) byte ranges
     /// * `Err(MdfError)` - If indices are invalid or channel type not supported
-    pub fn get_channel_byte_ranges(
+    pub(crate) fn get_channel_byte_ranges(
         &self,
         group_index: usize,
         channel_index: usize,
@@ -1175,7 +1274,7 @@ impl MdfIndex {
     /// # Returns
     /// * `Ok(Vec<(u64, u64)>)` - Vector of (offset, length) byte ranges
     /// * `Err(MdfError)` - If indices are invalid, range is out of bounds, or channel type not supported
-    pub fn get_channel_byte_ranges_for_records(
+    pub(crate) fn get_channel_byte_ranges_for_records(
         &self,
         group_index: usize,
         channel_index: usize,
@@ -1288,160 +1387,44 @@ impl MdfIndex {
         Ok(byte_ranges)
     }
 
-    /// Get a summary of byte ranges for a channel (total bytes, number of ranges)
-    /// 
-    /// This is useful for understanding the I/O pattern before actually reading.
-    /// 
-    /// # Returns
-    /// * `(total_bytes, number_of_ranges)` - Total bytes to read and number of separate ranges
-    pub fn get_channel_byte_summary(
+    /// Byte ranges occupied by a channel across the whole file, by name.
+    ///
+    /// Each tuple is `(offset, length)`, accounting for the channel's position
+    /// in the record layout and any data-block splitting. Resolves the first
+    /// channel matching `name`. Power-user entry point for issuing HTTP-range
+    /// or S3 partial reads yourself.
+    pub fn byte_ranges(&self, name: &str) -> Result<Vec<(u64, u64)>, MdfError> {
+        let (g, c) = self.locate(name).ok_or_else(|| {
+            MdfError::BlockSerializationError(format!("Channel '{}' not found", name))
+        })?;
+        self.get_channel_byte_ranges(g, c)
+    }
+
+    /// Byte ranges for a channel addressed by group name + channel name.
+    pub fn byte_ranges_in(&self, group: &str, name: &str) -> Result<Vec<(u64, u64)>, MdfError> {
+        let (g, c) = self.locate_in(group, name).ok_or_else(|| {
+            MdfError::BlockSerializationError(format!(
+                "Channel '{}' not found in group '{}'",
+                name, group
+            ))
+        })?;
+        self.get_channel_byte_ranges(g, c)
+    }
+
+    /// Byte ranges for a record window of a channel, by name.
+    ///
+    /// `start_record` is 0-based; `record_count` is clamped to the records
+    /// available. Useful for paging through a large channel.
+    pub fn byte_ranges_for_records(
         &self,
-        group_index: usize,
-        channel_index: usize,
-    ) -> Result<(u64, usize), MdfError> {
-        let ranges = self.get_channel_byte_ranges(group_index, channel_index)?;
-        let total_bytes: u64 = ranges.iter().map(|(_, len)| len).sum();
-        Ok((total_bytes, ranges.len()))
-    }
-
-    /// Find a channel group index by name
-    /// 
-    /// # Arguments
-    /// * `group_name` - Name of the channel group to find
-    /// 
-    /// # Returns
-    /// * `Some(group_index)` if found
-    /// * `None` if not found
-    pub fn find_channel_group_by_name(&self, group_name: &str) -> Option<usize> {
-        self.channel_groups
-            .iter()
-            .enumerate()
-            .find(|(_, group)| {
-                group.name.as_deref() == Some(group_name)
-            })
-            .map(|(index, _)| index)
-    }
-
-    /// Find a channel index by name within a specific group
-    /// 
-    /// # Arguments
-    /// * `group_index` - Index of the channel group to search in
-    /// * `channel_name` - Name of the channel to find
-    /// 
-    /// # Returns
-    /// * `Some(channel_index)` if found
-    /// * `None` if group doesn't exist or channel not found
-    pub fn find_channel_by_name(&self, group_index: usize, channel_name: &str) -> Option<usize> {
-        let group = self.channel_groups.get(group_index)?;
-        
-        group.channels
-            .iter()
-            .enumerate()
-            .find(|(_, channel)| {
-                channel.name.as_deref() == Some(channel_name)
-            })
-            .map(|(index, _)| index)
-    }
-
-    /// Find a channel by name across all groups
-    /// 
-    /// # Arguments
-    /// * `channel_name` - Name of the channel to find
-    /// 
-    /// # Returns
-    /// * `Some((group_index, channel_index))` if found
-    /// * `None` if not found
-    pub fn find_channel_by_name_global(&self, channel_name: &str) -> Option<(usize, usize)> {
-        for (group_index, group) in self.channel_groups.iter().enumerate() {
-            for (channel_index, channel) in group.channels.iter().enumerate() {
-                if channel.name.as_deref() == Some(channel_name) {
-                    return Some((group_index, channel_index));
-                }
-            }
-        }
-        None
-    }
-
-    /// Find all channels with a given name across all groups
-    /// 
-    /// This is useful when the same channel name appears in multiple groups.
-    /// 
-    /// # Arguments
-    /// * `channel_name` - Name of the channels to find
-    /// 
-    /// # Returns
-    /// * `Vec<(group_index, channel_index)>` - All matching channels
-    pub fn find_all_channels_by_name(&self, channel_name: &str) -> Vec<(usize, usize)> {
-        let mut matches = Vec::new();
-        
-        for (group_index, group) in self.channel_groups.iter().enumerate() {
-            for (channel_index, channel) in group.channels.iter().enumerate() {
-                if channel.name.as_deref() == Some(channel_name) {
-                    matches.push((group_index, channel_index));
-                }
-            }
-        }
-        
-        matches
-    }
-
-    /// Read channel values by name using a byte range reader
-    /// 
-    /// Convenience method that finds the channel by name and reads its values.
-    /// If multiple channels have the same name, uses the first one found.
-    /// 
-    /// # Arguments
-    /// * `channel_name` - Name of the channel to read
-    /// * `reader` - Byte range reader implementation
-    /// 
-    /// # Returns
-    /// * `Ok(Vec<Option<DecodedValue>>)` - Channel values (None for invalid samples)
-    /// * `Err(MdfError)` - If channel not found or reading fails
-    pub fn read_channel_values_by_name<R: ByteRangeReader<Error = MdfError>>(
-        &self,
-        channel_name: &str,
-        reader: &mut R,
-    ) -> Result<Vec<Option<DecodedValue>>, MdfError> {
-        let (group_index, channel_index) = self.find_channel_by_name_global(channel_name)
-            .ok_or_else(|| MdfError::BlockSerializationError(
-                format!("Channel '{}' not found", channel_name)
-            ))?;
-        
-        self.read_channel_values(group_index, channel_index, reader)
-    }
-
-    /// Get byte ranges for a channel by name
-    /// 
-    /// # Arguments
-    /// * `channel_name` - Name of the channel
-    /// 
-    /// # Returns
-    /// * `Ok(Vec<(u64, u64)>)` - Byte ranges as (offset, length) tuples
-    /// * `Err(MdfError)` - If channel not found or calculation fails
-    pub fn get_channel_byte_ranges_by_name(
-        &self,
-        channel_name: &str,
+        name: &str,
+        start_record: u64,
+        record_count: u64,
     ) -> Result<Vec<(u64, u64)>, MdfError> {
-        let (group_index, channel_index) = self.find_channel_by_name_global(channel_name)
-            .ok_or_else(|| MdfError::BlockSerializationError(
-                format!("Channel '{}' not found", channel_name)
-            ))?;
-        
-        self.get_channel_byte_ranges(group_index, channel_index)
-    }
-
-    /// Get channel information by name
-    ///
-    /// # Arguments
-    /// * `channel_name` - Name of the channel
-    ///
-    /// # Returns
-    /// * `Some((group_index, channel_index, &IndexedChannel))` - Channel info if found
-    /// * `None` - If channel not found
-    pub fn get_channel_info_by_name(&self, channel_name: &str) -> Option<(usize, usize, &IndexedChannel)> {
-        let (group_index, channel_index) = self.find_channel_by_name_global(channel_name)?;
-        let channel = self.get_channel_info(group_index, channel_index)?;
-        Some((group_index, channel_index, channel))
+        let (g, c) = self.locate(name).ok_or_else(|| {
+            MdfError::BlockSerializationError(format!("Channel '{}' not found", name))
+        })?;
+        self.get_channel_byte_ranges_for_records(g, c, start_record, record_count)
     }
 
     /// Fast path: read channel values as `Vec<f64>` using a byte range reader.
@@ -1449,7 +1432,7 @@ impl MdfIndex {
     /// This avoids boxing `DecodedValue` enums and applies linear conversions inline.
     /// For channels without invalidation bytes (the common case), validity checking
     /// is skipped entirely. Invalid samples are represented as `f64::NAN`.
-    pub fn read_channel_values_as_f64<R: ByteRangeReader<Error = MdfError>>(
+    pub(crate) fn read_channel_values_as_f64<R: ByteRangeReader<Error = MdfError>>(
         &self,
         group_index: usize,
         channel_index: usize,
@@ -1486,37 +1469,13 @@ impl MdfIndex {
         Ok(values)
     }
 
-    /// Fast path: read channel values as `Vec<f64>` by channel name.
-    ///
-    /// Convenience wrapper around [`read_channel_values_as_f64`] that resolves the
-    /// channel by name first. Invalid samples are represented as `f64::NAN`.
-    ///
-    /// # Arguments
-    /// * `channel_name` - Name of the channel to read
-    /// * `reader` - Byte range reader implementation
-    ///
-    /// # Returns
-    /// * `Ok(Vec<f64>)` - Channel values (NaN for invalid samples)
-    /// * `Err(MdfError)` - If channel not found or reading fails
-    pub fn read_channel_values_by_name_as_f64<R: ByteRangeReader<Error = MdfError>>(
-        &self,
-        channel_name: &str,
-        reader: &mut R,
-    ) -> Result<Vec<f64>, MdfError> {
-        let (group_index, channel_index) = self.find_channel_by_name_global(channel_name)
-            .ok_or_else(|| MdfError::BlockSerializationError(
-                format!("Channel '{}' not found", channel_name)
-            ))?;
-
-        self.read_channel_values_as_f64(group_index, channel_index, reader)
-    }
-
     /// Zero-copy fast path: read channel values directly from an `&[u8]` mmap slice.
     ///
     /// Avoids all per-block heap allocation by slicing directly into the provided
     /// memory-mapped region. This is the fastest `DecodedValue` read path when the
     /// entire file is already mapped into memory.
-    pub fn read_channel_values_from_slice(
+    #[allow(dead_code)] // used by the Python bindings (pyo3 feature)
+    pub(crate) fn read_channel_values_from_slice(
         &self,
         group_index: usize,
         channel_index: usize,
@@ -1554,7 +1513,8 @@ impl MdfIndex {
     /// Combines zero-copy slice access with the f64 fast decode path. No per-block
     /// allocation, no `DecodedValue` enum boxing. This is the fastest possible read
     /// path. Invalid or undecodable samples are `f64::NAN`.
-    pub fn read_channel_values_from_slice_as_f64(
+    #[allow(dead_code)] // used by the Python bindings (pyo3 feature)
+    pub(crate) fn read_channel_values_from_slice_as_f64(
         &self,
         group_index: usize,
         channel_index: usize,
@@ -1590,6 +1550,7 @@ impl MdfIndex {
     }
 
     /// Slice a data block from file_data, skipping the 24-byte block header.
+    #[allow(dead_code)] // used by the Python bindings (pyo3 feature)
     fn slice_data_block<'a>(file_data: &'a [u8], data_block: &DataBlockInfo) -> Result<&'a [u8], MdfError> {
         let data_start = (data_block.file_offset + 24) as usize;
         let data_end = data_start + (data_block.size - 24) as usize;
@@ -1602,5 +1563,83 @@ impl MdfIndex {
             });
         }
         Ok(&file_data[data_start..data_end])
+    }
+}
+
+/// A reader bound to an [`MdfIndex`] and a single byte-range data source.
+///
+/// Obtained from [`MdfIndex::open`] / [`MdfIndex::open_file`]. The source is
+/// supplied once; afterwards channels are read by name. Reads of the same
+/// channel re-fetch from the underlying source, so cache or memory-map the
+/// source (e.g. [`MmapRangeReader`], [`CachingRangeReader`]) when reading many
+/// channels.
+pub struct MdfReader<'a, R: ByteRangeReader<Error = MdfError>> {
+    index: &'a MdfIndex,
+    reader: R,
+}
+
+impl<'a, R: ByteRangeReader<Error = MdfError>> MdfReader<'a, R> {
+    /// The index this reader was opened against.
+    pub fn index(&self) -> &MdfIndex {
+        self.index
+    }
+
+    /// Mutable access to the underlying byte-range reader (e.g. to toggle
+    /// [`CachingRangeReader::set_bypass`] or inspect request counters).
+    pub fn reader_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    /// Consume the reader, returning the underlying byte-range source.
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
+
+    fn locate(&self, name: &str) -> Result<(usize, usize), MdfError> {
+        self.index.locate(name).ok_or_else(|| {
+            MdfError::BlockSerializationError(format!("Channel '{}' not found", name))
+        })
+    }
+
+    fn locate_in(&self, group: &str, name: &str) -> Result<(usize, usize), MdfError> {
+        self.index.locate_in(group, name).ok_or_else(|| {
+            MdfError::BlockSerializationError(format!(
+                "Channel '{}' not found in group '{}'",
+                name, group
+            ))
+        })
+    }
+
+    /// Read all samples of a channel by name (first match across groups).
+    ///
+    /// Conversions stored in the index are applied; invalid samples are `None`.
+    pub fn values(&mut self, name: &str) -> Result<Vec<Option<DecodedValue>>, MdfError> {
+        let (g, c) = self.locate(name)?;
+        self.index.read_channel_values(g, c, &mut self.reader)
+    }
+
+    /// Read all samples of a channel, addressed by group name + channel name.
+    pub fn values_in(
+        &mut self,
+        group: &str,
+        name: &str,
+    ) -> Result<Vec<Option<DecodedValue>>, MdfError> {
+        let (g, c) = self.locate_in(group, name)?;
+        self.index.read_channel_values(g, c, &mut self.reader)
+    }
+
+    /// Fast path: read a numeric channel by name as `Vec<f64>`.
+    ///
+    /// Invalid / non-numeric samples are `f64::NAN`. Conversions that reduce to
+    /// a linear scale are applied inline.
+    pub fn values_f64(&mut self, name: &str) -> Result<Vec<f64>, MdfError> {
+        let (g, c) = self.locate(name)?;
+        self.index.read_channel_values_as_f64(g, c, &mut self.reader)
+    }
+
+    /// Fast `f64` path addressed by group name + channel name.
+    pub fn values_f64_in(&mut self, group: &str, name: &str) -> Result<Vec<f64>, MdfError> {
+        let (g, c) = self.locate_in(group, name)?;
+        self.index.read_channel_values_as_f64(g, c, &mut self.reader)
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -10,6 +10,7 @@ use crate::blocks::common::{DataType, BlockParse};
 use crate::blocks::conversion::{ConversionBlock, ConversionType};
 use crate::error::MdfError;
 use crate::parsing::decoder::{check_value_validity, decode_channel_value_with_validity, decode_f64_from_record, DecodedValue};
+use crate::signal::{decoded_opt_to_f64, Signal};
 
 /// Represents the location and metadata of data blocks in the file
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -184,6 +185,21 @@ impl IndexedChannelGroup {
     }
 }
 
+/// Where an [`MdfIndex`] reads sample data from when asked to.
+///
+/// The source is *not* serialized with the index — after [`MdfIndex::load_from_file`]
+/// re-attach one with [`MdfIndex::set_file`] / [`MdfIndex::set_url`]. Building an
+/// index never reads sample data; the actual byte-range reads happen lazily on
+/// [`MdfIndex::read`].
+#[derive(Debug, Clone)]
+pub enum Source {
+    /// A local file path, read via memory map.
+    File(String),
+    /// An HTTP/S3 URL, read via range requests.
+    #[cfg(feature = "http")]
+    Url(String),
+}
+
 /// Complete MDF file index
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MdfIndex {
@@ -194,6 +210,11 @@ pub struct MdfIndex {
     pub start_time_ns: Option<u64>,
     /// Channel groups in the file
     pub channel_groups: Vec<IndexedChannelGroup>,
+    /// The data source for lazy value reads. Populated by `from_file` /
+    /// `from_url`, re-attachable after load via `set_file` / `set_url`. Never
+    /// serialized — an index file is portable; the source is environment-local.
+    #[serde(skip)]
+    pub source: Option<Source>,
 }
 
 /// Trait for reading byte ranges from different sources (files, HTTP, etc.)
@@ -609,7 +630,30 @@ impl MdfIndex {
         let file_size = std::fs::metadata(file_path)
             .map_err(|e| MdfError::IOError(e))?
             .len();
-        Self::build_index(mdf, file_size)
+        let mut index = Self::build_index(mdf, file_size)?;
+        index.source = Some(Source::File(file_path.to_string()));
+        Ok(index)
+    }
+
+    /// Build an index from an MDF file served over HTTP / S3 using range
+    /// requests, remembering the URL as the index's [`Source`].
+    ///
+    /// Only metadata blocks are fetched while building; sample data is read
+    /// lazily on [`MdfIndex::read`]. Requires the `http` feature.
+    #[cfg(feature = "http")]
+    pub fn from_url(url: &str) -> Result<Self, MdfError> {
+        Self::from_url_with_chunk_size(url, 1 << 20)
+    }
+
+    /// [`MdfIndex::from_url`] with an explicit metadata read-ahead chunk size.
+    #[cfg(feature = "http")]
+    pub fn from_url_with_chunk_size(url: &str, chunk_size: u64) -> Result<Self, MdfError> {
+        let mut http = HttpRangeReader::new(url)?;
+        let file_size = http.probe_size()?;
+        let mut cached = CachingRangeReader::with_chunk_size(http, chunk_size);
+        let mut index = Self::from_range_reader(&mut cached, file_size)?;
+        index.source = Some(Source::Url(url.to_string()));
+        Ok(index)
     }
 
     /// Shared index-building logic operating on an already-parsed [`MDF`].
@@ -667,7 +711,7 @@ impl MdfIndex {
             });
         }
 
-        Ok(MdfIndex { file_size, start_time_ns, channel_groups: indexed_groups })
+        Ok(MdfIndex { file_size, start_time_ns, channel_groups: indexed_groups, source: None })
     }
 
     /// Extract data block information from a channel group
@@ -821,6 +865,7 @@ impl MdfIndex {
             file_size,
             start_time_ns,
             channel_groups: indexed_groups,
+            source: None,
         })
     }
 
@@ -1225,6 +1270,135 @@ impl MdfIndex {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn open_file(&self, path: &str) -> Result<MdfReader<'_, MmapRangeReader>, MdfError> {
         Ok(self.open(MmapRangeReader::new(path)?))
+    }
+
+    /// The data source attached to this index, if any.
+    pub fn source(&self) -> Option<&Source> {
+        self.source.as_ref()
+    }
+
+    /// Attach (or replace) the data source used by [`MdfIndex::read`].
+    pub fn set_source(&mut self, source: Source) {
+        self.source = Some(source);
+    }
+
+    /// Attach a local file path as the data source for lazy reads.
+    pub fn set_file(&mut self, path: impl Into<String>) {
+        self.source = Some(Source::File(path.into()));
+    }
+
+    /// Attach an HTTP/S3 URL as the data source for lazy reads.
+    #[cfg(feature = "http")]
+    pub fn set_url(&mut self, url: impl Into<String>) {
+        self.source = Some(Source::Url(url.into()));
+    }
+
+    /// Read a channel by name as a [`Signal`] using the attached [`Source`].
+    ///
+    /// Values are paired with the channel's group master (time) axis. This is
+    /// the lazy read path: the byte-range request happens now, not at index
+    /// build time. Errors if no source is attached (see [`MdfIndex::set_file`] /
+    /// [`MdfIndex::set_url`]).
+    pub fn read(&self, name: &str) -> Result<Signal, MdfError> {
+        let (g, c) = self.locate(name).ok_or_else(|| {
+            MdfError::BlockSerializationError(format!("Channel '{}' not found", name))
+        })?;
+        self.read_signal(g, c)
+    }
+
+    /// [`MdfIndex::read`] addressed by group name + channel name.
+    pub fn read_in(&self, group: &str, name: &str) -> Result<Signal, MdfError> {
+        let (g, c) = self.locate_in(group, name).ok_or_else(|| {
+            MdfError::BlockSerializationError(format!(
+                "Channel '{}' not found in group '{}'",
+                name, group
+            ))
+        })?;
+        self.read_signal(g, c)
+    }
+
+    /// Decode a channel + its group master from the attached source.
+    fn read_signal(&self, g: usize, c: usize) -> Result<Signal, MdfError> {
+        let (name, unit, master) = {
+            let channel = &self.channel_groups[g].channels[c];
+            let master = self.channel_groups[g]
+                .channels
+                .iter()
+                .position(|ch| ch.is_master())
+                .filter(|&m| m != c);
+            (channel.name.clone().unwrap_or_default(), channel.unit.clone(), master)
+        };
+
+        let values = self.read_values_via_source(g, c)?;
+        let timestamps = match master {
+            Some(m) => self.read_values_f64_via_source(g, m)?,
+            None => Vec::new(),
+        };
+
+        Ok(Signal { name, unit, timestamps, values })
+    }
+
+    /// Resolve the attached [`Source`], erroring with a helpful message if none.
+    fn require_source(&self) -> Result<&Source, MdfError> {
+        self.source.as_ref().ok_or_else(|| {
+            MdfError::BlockSerializationError(
+                "no data source attached to index; build with from_file/from_url or call set_file/set_url".to_string(),
+            )
+        })
+    }
+
+    /// Read one channel's decoded values lazily through the attached source.
+    pub(crate) fn read_values_via_source(
+        &self,
+        g: usize,
+        c: usize,
+    ) -> Result<Vec<Option<DecodedValue>>, MdfError> {
+        match self.require_source()? {
+            #[cfg(not(target_arch = "wasm32"))]
+            Source::File(path) => {
+                let file = std::fs::File::open(path).map_err(MdfError::IOError)?;
+                let mmap = unsafe { memmap2::Mmap::map(&file) }.map_err(MdfError::IOError)?;
+                self.read_channel_values_from_slice(g, c, &mmap)
+            }
+            #[cfg(target_arch = "wasm32")]
+            Source::File(_) => Err(MdfError::BlockSerializationError(
+                "file sources are not available on wasm32".to_string(),
+            )),
+            #[cfg(feature = "http")]
+            Source::Url(url) => {
+                let http = HttpRangeReader::new(url)?;
+                let mut cached = CachingRangeReader::new(http);
+                cached.set_bypass(true);
+                self.read_channel_values(g, c, &mut cached)
+            }
+        }
+    }
+
+    /// Read one channel's values as `f64` lazily through the attached source.
+    pub(crate) fn read_values_f64_via_source(
+        &self,
+        g: usize,
+        c: usize,
+    ) -> Result<Vec<f64>, MdfError> {
+        match self.require_source()? {
+            #[cfg(not(target_arch = "wasm32"))]
+            Source::File(path) => {
+                let file = std::fs::File::open(path).map_err(MdfError::IOError)?;
+                let mmap = unsafe { memmap2::Mmap::map(&file) }.map_err(MdfError::IOError)?;
+                self.read_channel_values_from_slice_as_f64(g, c, &mmap)
+            }
+            #[cfg(target_arch = "wasm32")]
+            Source::File(_) => Err(MdfError::BlockSerializationError(
+                "file sources are not available on wasm32".to_string(),
+            )),
+            #[cfg(feature = "http")]
+            Source::Url(url) => {
+                let http = HttpRangeReader::new(url)?;
+                let mut cached = CachingRangeReader::new(http);
+                cached.set_bypass(true);
+                self.read_channel_values_as_f64(g, c, &mut cached)
+            }
+        }
     }
 
     /// Get the exact byte ranges needed to read all data for a specific channel
@@ -1641,5 +1815,43 @@ impl<'a, R: ByteRangeReader<Error = MdfError>> MdfReader<'a, R> {
     pub fn values_f64_in(&mut self, group: &str, name: &str) -> Result<Vec<f64>, MdfError> {
         let (g, c) = self.locate_in(group, name)?;
         self.index.read_channel_values_as_f64(g, c, &mut self.reader)
+    }
+
+    /// Read a channel by name as a [`Signal`] (values paired with the group's
+    /// master/time axis), using this reader's bound source.
+    pub fn signal(&mut self, name: &str) -> Result<Signal, MdfError> {
+        let (g, c) = self.locate(name)?;
+        self.read_signal(g, c)
+    }
+
+    /// [`MdfReader::signal`] addressed by group name + channel name.
+    pub fn signal_in(&mut self, group: &str, name: &str) -> Result<Signal, MdfError> {
+        let (g, c) = self.locate_in(group, name)?;
+        self.read_signal(g, c)
+    }
+
+    fn read_signal(&mut self, g: usize, c: usize) -> Result<Signal, MdfError> {
+        let (name, unit, master) = {
+            let group = &self.index.channel_groups[g];
+            let channel = &group.channels[c];
+            let master = group
+                .channels
+                .iter()
+                .position(|ch| ch.is_master())
+                .filter(|&m| m != c);
+            (channel.name.clone().unwrap_or_default(), channel.unit.clone(), master)
+        };
+
+        let values = self.index.read_channel_values(g, c, &mut self.reader)?;
+        let timestamps = match master {
+            Some(m) => self
+                .index
+                .read_channel_values(g, m, &mut self.reader)?
+                .iter()
+                .map(decoded_opt_to_f64)
+                .collect(),
+            None => Vec::new(),
+        };
+        Ok(Signal { name, unit, timestamps, values })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cut;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod merge;
 pub mod index;
+pub mod signal;
 pub mod block_layout;
 
 pub mod parsing {
@@ -49,15 +50,16 @@ use pyo3::prelude::*;
 /// Quick tour
 /// ----------
 ///
-/// Read::
+/// Read — ``read`` returns a ``pandas.Series`` (values indexed by the master
+/// time axis); ``values`` returns a plain numpy array::
 ///
 ///     import mf4_rs
 ///     mdf = mf4_rs.Mdf("recording.mf4")
 ///     for g in mdf.groups:
 ///         print(g.name, g.record_count, g.channel_names)
-///     speed = mdf["Speed"]                 # numpy.ndarray[float64]
+///     speed = mdf["Speed"]                 # pandas Series, datetime index
 ///     rpm   = mdf.read("RPM", group="Engine")
-///     s     = mdf.series("Speed")          # pandas Series, datetime index
+///     raw   = mdf.values("Speed")          # numpy.ndarray[float64], no index
 ///
 /// Write::
 ///
@@ -74,14 +76,15 @@ use pyo3::prelude::*;
 ///     w.finish_data_block(cg)
 ///     w.finalize()
 ///
-/// Index (HTTP-friendly random access) — bind the data source once::
+/// Index (HTTP-friendly random access) — the index remembers its source and
+/// reads lazily (range requests happen on ``read``/``values``, not at build)::
 ///
-///     idx = mf4_rs.MdfIndex.from_file("recording.mf4")
+///     idx = mf4_rs.MdfIndex.from_url("https://host/recording.mf4")  # only metadata fetched
+///     speed = idx.read("Speed")            # pandas Series; range request happens now
 ///     idx.save("recording.idx.json")
 ///     idx = mf4_rs.MdfIndex.load("recording.idx.json")
-///     data = idx.open("recording.mf4")     # or idx.open_url("https://…")
-///     speed = data["Speed"]                # numpy.ndarray[float64]
-///     status = data.read_raw("Status")     # native values + conversions
+///     idx.source = "recording.mf4"         # re-attach a source after load
+///     raw = idx.values("Speed")            # numpy, lazy
 ///
 /// Other utilities: :func:`merge_files`, :func:`cut_mdf_by_time`,
 /// :func:`cut_mdf_by_utc`, and the :class:`FileLayout` block-layout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,22 +43,27 @@ use pyo3::prelude::*;
 /// Python bindings for the ``mf4-rs`` crate: a minimal reader/writer for
 /// ASAM MDF 4 measurement files.
 ///
+/// Everything is addressed by **name** — channel-group and channel names —
+/// never by numeric index.
+///
 /// Quick tour
 /// ----------
 ///
 /// Read::
 ///
 ///     import mf4_rs
-///     mdf = mf4_rs.PyMDF("recording.mf4")
-///     for g in mdf.channel_groups():
-///         print(g.name, g.record_count)
-///     speed = mdf.get_channel_values("Speed")  # numpy.ndarray[float64]
+///     mdf = mf4_rs.Mdf("recording.mf4")
+///     for g in mdf.groups:
+///         print(g.name, g.record_count, g.channel_names)
+///     speed = mdf["Speed"]                 # numpy.ndarray[float64]
+///     rpm   = mdf.read("RPM", group="Engine")
+///     s     = mdf.series("Speed")          # pandas Series, datetime index
 ///
 /// Write::
 ///
-///     w = mf4_rs.PyMdfWriter("out.mf4")
+///     w = mf4_rs.MdfWriter("out.mf4")
 ///     w.init_mdf_file()
-///     cg = w.add_channel_group("group_0")
+///     cg = w.add_channel_group("Engine")
 ///     t  = w.add_time_channel(cg, "Time")
 ///     y  = w.add_float_channel(cg, "Speed")
 ///     w.start_data_block(cg)
@@ -69,14 +74,17 @@ use pyo3::prelude::*;
 ///     w.finish_data_block(cg)
 ///     w.finalize()
 ///
-/// Index (HTTP-friendly random access)::
+/// Index (HTTP-friendly random access) — bind the data source once::
 ///
-///     idx = mf4_rs.PyMdfIndex.from_file("recording.mf4")
-///     idx.save_to_file("recording.idx.json")
-///     vals = idx.read_channel_values_by_name_as_f64("Speed", "recording.mf4")
+///     idx = mf4_rs.MdfIndex.from_file("recording.mf4")
+///     idx.save("recording.idx.json")
+///     idx = mf4_rs.MdfIndex.load("recording.idx.json")
+///     data = idx.open("recording.mf4")     # or idx.open_url("https://…")
+///     speed = data["Speed"]                # numpy.ndarray[float64]
+///     status = data.read_raw("Status")     # native values + conversions
 ///
 /// Other utilities: :func:`merge_files`, :func:`cut_mdf_by_time`,
-/// :func:`cut_mdf_by_utc`, and the :class:`PyFileLayout` block-layout
+/// :func:`cut_mdf_by_utc`, and the :class:`FileLayout` block-layout
 /// inspector.
 ///
 /// All errors raised by this module are subclasses of :class:`MdfException`.

--- a/src/python.rs
+++ b/src/python.rs
@@ -18,8 +18,7 @@ use std::collections::HashMap;
 use crate::api::mdf::MDF;
 use crate::writer::{MdfWriter, ColumnData};
 use crate::index::{
-    ByteRangeReader, CachingRangeReader, FileRangeReader, HttpRangeReader, IndexedChannel,
-    MdfIndex,
+    CachingRangeReader, FileRangeReader, HttpRangeReader, IndexedChannel, MdfIndex,
 };
 use crate::blocks::common::DataType;
 use crate::parsing::decoder::DecodedValue;
@@ -49,7 +48,7 @@ impl From<MdfError> for PyErr {
 /// value : int
 ///     The MDF spec numeric code (0-16, or 255 for unknown).
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "DataType")]
 #[derive(Debug, Clone)]
 pub struct PyDataType {
     #[pyo3(get)]
@@ -127,9 +126,9 @@ impl From<PyDataType> for DataType {
 /// A single decoded channel sample, tagged with its underlying type.
 ///
 /// Returned by ``create_*_value`` helpers and consumed by
-/// :py:meth:`PyMdfWriter.write_record`. When *reading*, most APIs return native
+/// :py:meth:`MdfWriter.write_record`. When *reading*, most APIs return native
 /// Python objects (``float`` / ``int`` / ``str`` / ``bytes``) directly, so you
-/// usually only construct ``PyDecodedValue`` to feed back into the writer.
+/// usually only construct ``DecodedValue`` to feed back into the writer.
 ///
 /// Variants carry a single ``value`` field (use the ``value`` getter to
 /// retrieve the inner native Python value):
@@ -141,7 +140,7 @@ impl From<PyDataType> for DataType {
 /// - ``ByteArray(value: bytes)``
 /// - ``Unknown()`` — undecodable / not yet supported
 #[gen_stub_pyclass_enum]
-#[pyclass]
+#[pyclass(name = "DecodedValue")]
 #[derive(Debug, Clone)]
 pub enum PyDecodedValue {
     Float { value: f64 },
@@ -223,7 +222,7 @@ impl From<PyDecodedValue> for DecodedValue {
 }
 
 /// Direct conversion from DecodedValue to PyObject without intermediate allocation.
-/// This is more efficient than creating a PyDecodedValue and immediately extracting its value.
+/// This is more efficient than creating a DecodedValue and immediately extracting its value.
 fn decoded_value_to_pyobject(dv: DecodedValue, py: Python) -> PyObject {
     match dv {
         DecodedValue::Float(v) => v.to_object(py),
@@ -239,9 +238,8 @@ fn decoded_value_to_pyobject(dv: DecodedValue, py: Python) -> PyObject {
 
 /// Read-only metadata describing a single channel.
 ///
-/// Returned by :py:meth:`PyMDF.get_all_channels`,
-/// :py:meth:`PyMDF.get_channels_for_group`, and
-/// :py:meth:`PyMdfIndex.get_channel_info_by_name`.
+/// Found on :py:attr:`GroupInfo.channels`, and returned by
+/// :py:meth:`Mdf.channel` / :py:meth:`MdfIndex.channel`.
 ///
 /// Attributes
 /// ----------
@@ -252,12 +250,12 @@ fn decoded_value_to_pyobject(dv: DecodedValue, py: Python) -> PyObject {
 /// comment : Optional[str]
 ///     Free-form comment, or ``None``. Always ``None`` when obtained via the
 ///     index (not stored in `IndexedChannel`).
-/// data_type : PyDataType
+/// data_type : DataType
 ///     The MDF data type of the raw samples.
 /// bit_count : int
 ///     Width of the raw value in bits (e.g. 32 for f32, 64 for f64/u64).
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "ChannelInfo")]
 #[derive(Debug, Clone)]
 pub struct PyChannelInfo {
     #[pyo3(get)]
@@ -270,24 +268,59 @@ pub struct PyChannelInfo {
     pub data_type: PyDataType,
     #[pyo3(get)]
     pub bit_count: u32,
+    /// True if this is the group's master / time channel.
+    #[pyo3(get)]
+    pub is_master: bool,
+    /// True if this is a variable-length (VLSD) channel.
+    #[pyo3(get)]
+    pub is_vlsd: bool,
 }
 
 #[gen_stub_pymethods]
 #[pymethods]
 impl PyChannelInfo {
     fn __str__(&self) -> String {
-        format!("Channel(name={:?}, data_type={}, bit_count={})", 
+        format!("Channel(name={:?}, data_type={}, bit_count={})",
                 self.name, self.data_type.name, self.bit_count)
     }
-    
+
     fn __repr__(&self) -> String {
         self.__str__()
     }
 }
 
+impl PyChannelInfo {
+    /// Build from a parsed (live-file) channel.
+    fn from_channel(channel: &crate::api::channel::Channel<'_>) -> PyResult<Self> {
+        let block = channel.block();
+        Ok(PyChannelInfo {
+            name: channel.name()?,
+            unit: channel.unit()?,
+            comment: channel.comment()?,
+            data_type: PyDataType::from(&block.data_type),
+            bit_count: block.bit_count,
+            is_master: block.channel_type == 2,
+            is_vlsd: block.channel_type == 1 && block.data != 0,
+        })
+    }
+
+    /// Build from an indexed channel (comments are not stored in the index).
+    fn from_indexed(channel: &IndexedChannel) -> Self {
+        PyChannelInfo {
+            name: channel.name.clone(),
+            unit: channel.unit.clone(),
+            comment: None,
+            data_type: PyDataType::from(&channel.data_type),
+            bit_count: channel.bit_count,
+            is_master: channel.is_master(),
+            is_vlsd: channel.is_vlsd(),
+        }
+    }
+}
+
 /// Read-only metadata describing a channel group (``##CG`` block).
 ///
-/// Returned by :py:meth:`PyMDF.channel_groups`.
+/// Returned by :py:attr:`Mdf.groups` / :py:attr:`MdfIndex.groups`.
 ///
 /// Attributes
 /// ----------
@@ -300,7 +333,7 @@ impl PyChannelInfo {
 /// record_count : int
 ///     Number of records (cycles) recorded for this group.
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "GroupInfo")]
 #[derive(Debug, Clone)]
 pub struct PyChannelGroupInfo {
     #[pyo3(get)]
@@ -311,18 +344,66 @@ pub struct PyChannelGroupInfo {
     pub channel_count: usize,
     #[pyo3(get)]
     pub record_count: u64,
+    /// Metadata for every channel in this group, in record order.
+    #[pyo3(get)]
+    pub channels: Vec<PyChannelInfo>,
 }
 
 #[gen_stub_pymethods]
 #[pymethods]
 impl PyChannelGroupInfo {
+    /// Find a channel in this group by name (first match), or ``None``.
+    fn channel(&self, name: &str) -> Option<PyChannelInfo> {
+        self.channels
+            .iter()
+            .find(|c| c.name.as_deref() == Some(name))
+            .cloned()
+    }
+
+    /// Names of every named channel in this group.
+    #[getter]
+    fn channel_names(&self) -> Vec<String> {
+        self.channels.iter().filter_map(|c| c.name.clone()).collect()
+    }
+
     fn __str__(&self) -> String {
-        format!("ChannelGroup(name={:?}, channels={}, records={})", 
+        format!("Group(name={:?}, channels={}, records={})",
                 self.name, self.channel_count, self.record_count)
     }
-    
+
     fn __repr__(&self) -> String {
         self.__str__()
+    }
+}
+
+impl PyChannelGroupInfo {
+    /// Build from a live (parsed) channel group.
+    fn from_group(group: &crate::api::channel_group::ChannelGroup<'_>) -> PyResult<Self> {
+        let channels = group
+            .channels()
+            .iter()
+            .map(PyChannelInfo::from_channel)
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok(PyChannelGroupInfo {
+            name: group.name()?,
+            comment: group.comment()?,
+            channel_count: channels.len(),
+            record_count: group.raw_channel_group().block.cycles_nr,
+            channels,
+        })
+    }
+
+    /// Build from an indexed channel group.
+    fn from_indexed(group: &crate::index::IndexedChannelGroup) -> Self {
+        let channels: Vec<PyChannelInfo> =
+            group.channels.iter().map(PyChannelInfo::from_indexed).collect();
+        PyChannelGroupInfo {
+            name: group.name.clone(),
+            comment: group.comment.clone(),
+            channel_count: channels.len(),
+            record_count: group.record_count,
+            channels,
+        }
     }
 }
 
@@ -443,22 +524,51 @@ fn create_datetime_index(
 
 /// Read-only handle to an MDF 4 file, backed by a memory-mapped buffer.
 ///
-/// Opens the file lazily: metadata (block tree, channel names, conversions)
-/// is parsed up front, but sample data is only decoded when you call one of
-/// the ``get_channel_*`` methods. The mmap stays alive for the lifetime of
-/// the ``PyMDF`` instance.
+/// Metadata (block tree, channel names, conversions) is parsed up front, but
+/// sample data is only decoded when you call :py:meth:`read`, :py:meth:`read_raw`
+/// or :py:meth:`series`. Navigate by group / channel **name** — there are no
+/// numeric indices in the public API.
 ///
 /// Example
 /// -------
 /// >>> import mf4_rs
-/// >>> mdf = mf4_rs.PyMDF("recording.mf4")
-/// >>> for group in mdf.channel_groups():
-/// ...     print(group.name, group.record_count)
-/// >>> values = mdf.get_channel_values("Temperature")  # numpy.ndarray
+/// >>> mdf = mf4_rs.Mdf("recording.mf4")
+/// >>> for group in mdf.groups:
+/// ...     print(group.name, group.record_count, group.channel_names)
+/// >>> speed = mdf["Speed"]                 # numpy float64 array
+/// >>> rpm   = mdf.read("RPM", group="Engine")
+/// >>> s     = mdf.series("Speed")          # pandas Series, datetime index
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "Mdf")]
 pub struct PyMDF {
     mdf: Box<MDF>,
+}
+
+impl PyMDF {
+    /// Locate a live channel group + channel index by (optional group) name.
+    fn find_group_channel<'a>(
+        &'a self,
+        group: Option<&str>,
+        name: &str,
+    ) -> PyResult<(crate::api::channel_group::ChannelGroup<'a>, usize)> {
+        for g in self.mdf.channel_groups() {
+            if let Some(gn) = group {
+                if g.name()?.as_deref() != Some(gn) {
+                    continue;
+                }
+            }
+            let chans = g.channels();
+            for (i, ch) in chans.iter().enumerate() {
+                if ch.name()?.as_deref() == Some(name) {
+                    return Ok((g, i));
+                }
+            }
+        }
+        Err(MdfException::new_err(match group {
+            Some(gn) => format!("Channel '{}' not found in group '{}'", name, gn),
+            None => format!("Channel '{}' not found", name),
+        }))
+    }
 }
 
 #[gen_stub_pymethods]
@@ -482,280 +592,176 @@ impl PyMDF {
         Ok(PyMDF { mdf })
     }
 
-    /// List metadata for every channel group in the file.
+    /// Metadata for every channel group in the file, in file order.
     ///
-    /// Returns
-    /// -------
-    /// list[PyChannelGroupInfo]
-    ///     One entry per ``##CG`` block, in file order.
-    fn channel_groups(&self) -> PyResult<Vec<PyChannelGroupInfo>> {
-        let mut py_groups = Vec::new();
-        
-        for group in self.mdf.channel_groups() {
-            let name = group.name()?;
-            let comment = group.comment()?;
-            let channel_count = group.channels().len();
-            let record_count = group.raw_channel_group().block.cycles_nr;
-            
-            py_groups.push(PyChannelGroupInfo {
-                name,
-                comment,
-                channel_count,
-                record_count,
-            });
-        }
-        
-        Ok(py_groups)
+    /// Each :class:`GroupInfo` carries its ``channels`` (a list of
+    /// :class:`ChannelInfo`), so a single ``mdf.groups`` call gives the whole
+    /// structure.
+    #[getter]
+    fn groups(&self) -> PyResult<Vec<PyChannelGroupInfo>> {
+        self.mdf
+            .channel_groups()
+            .iter()
+            .map(PyChannelGroupInfo::from_group)
+            .collect()
     }
-    
-    /// Return metadata for every channel across every group.
-    ///
-    /// Returns
-    /// -------
-    /// list[PyChannelInfo]
-    ///     Channels are emitted in file order, group-by-group. Channels with
-    ///     duplicate names (common across groups) appear multiple times — use
-    ///     :py:meth:`get_channels_for_group` if you need per-group context.
-    fn get_all_channels(&self) -> PyResult<Vec<PyChannelInfo>> {
-        let mut channels = Vec::new();
-        
-        for group in self.mdf.channel_groups() {
-            for channel in group.channels() {
-                let block = channel.block();
-                let info = PyChannelInfo {
-                    name: channel.name()?,
-                    unit: channel.unit()?,
-                    comment: channel.comment()?,
-                    data_type: PyDataType::from(&block.data_type),
-                    bit_count: block.bit_count,
-                };
-                channels.push(info);
+
+    /// Find a channel group by name (first match), or ``None``.
+    fn group(&self, name: &str) -> PyResult<Option<PyChannelGroupInfo>> {
+        for g in self.mdf.channel_groups() {
+            if g.name()?.as_deref() == Some(name) {
+                return Ok(Some(PyChannelGroupInfo::from_group(&g)?));
             }
         }
-        
-        Ok(channels)
+        Ok(None)
     }
-    
-    /// Return metadata for every channel in a single group.
-    ///
-    /// Parameters
-    /// ----------
-    /// group_index : int
-    ///     Zero-based index into :py:meth:`channel_groups`.
-    ///
-    /// Returns
-    /// -------
-    /// list[PyChannelInfo]
-    ///
-    /// Raises
-    /// ------
-    /// MdfException
-    ///     If ``group_index`` is out of bounds.
-    fn get_channels_for_group(&self, group_index: usize) -> PyResult<Vec<PyChannelInfo>> {
-        let groups: Vec<_> = self.mdf.channel_groups().into_iter().collect();
-        if let Some(group) = groups.get(group_index) {
-            let mut channels = Vec::new();
-            
-            for channel in group.channels() {
-                let block = channel.block();
-                let info = PyChannelInfo {
-                    name: channel.name()?,
-                    unit: channel.unit()?,
-                    comment: channel.comment()?,
-                    data_type: PyDataType::from(&block.data_type),
-                    bit_count: block.bit_count,
-                };
-                channels.push(info);
+
+    /// Find a channel by name across all groups (first match), or ``None``.
+    fn channel(&self, name: &str) -> PyResult<Option<PyChannelInfo>> {
+        for g in self.mdf.channel_groups() {
+            for ch in g.channels() {
+                if ch.name()?.as_deref() == Some(name) {
+                    return Ok(Some(PyChannelInfo::from_channel(&ch)?));
+                }
             }
-            
-            Ok(channels)
-        } else {
-            Err(MdfException::new_err("Group index out of bounds"))
         }
+        Ok(None)
     }
-    
-    /// Return the names of every named channel across all groups.
-    ///
-    /// Channels without a name (``##TX`` link is null) are skipped.
-    /// Duplicates are preserved when the same name appears in multiple groups.
-    ///
-    /// Returns
-    /// -------
-    /// list[str]
-    fn get_all_channel_names(&self) -> PyResult<Vec<String>> {
+
+    /// Names of every named channel across all groups (duplicates kept).
+    #[getter]
+    fn channel_names(&self) -> PyResult<Vec<String>> {
         let mut names = Vec::new();
-        for group in self.mdf.channel_groups() {
-            for channel in group.channels() {
-                if let Some(name) = channel.name()? {
-                    names.push(name);
+        for g in self.mdf.channel_groups() {
+            for ch in g.channels() {
+                if let Some(n) = ch.name()? {
+                    names.push(n);
                 }
             }
         }
         Ok(names)
     }
-    
-    /// Read a channel's samples as a contiguous numpy ``float64`` array.
-    ///
-    /// Searches every group and returns the first channel whose name matches
-    /// ``channel_name``. This is the fastest read path for numeric channels —
-    /// values are decoded directly into a numpy buffer, with any
-    /// non-decodable / invalid samples set to ``NaN``. Conversions stored on
-    /// the channel (linear, rational, table-lookup) are applied automatically.
-    ///
-    /// Parameters
-    /// ----------
-    /// channel_name : str
-    ///     Exact channel name (case-sensitive).
-    ///
-    /// Returns
-    /// -------
-    /// Optional[numpy.ndarray]
-    ///     1-D ``float64`` array of length ``record_count``, or ``None`` if no
-    ///     channel with that name exists.
-    fn get_channel_values<'py>(&self, py: Python<'py>, channel_name: &str) -> PyResult<Option<PyObject>> {
-        for group in self.mdf.channel_groups() {
-            for channel in group.channels() {
-                if let Some(name) = channel.name()? {
-                    if name == channel_name {
-                        let values = channel.values_as_f64()?;
-                        let array = PyArray1::from_vec_bound(py, values);
-                        return Ok(Some(array.into()));
-                    }
-                }
-            }
-        }
-        Ok(None)
-    }
 
-    /// Read a channel from a *specific* group, by group and channel name.
+    /// Read a numeric channel by name as a numpy ``float64`` array.
     ///
-    /// Use this when the same channel name appears in multiple groups (e.g.
-    /// each group has its own ``Time``) and you need to disambiguate.
-    ///
-    /// Parameters
-    /// ----------
-    /// group_name : str
-    ///     Exact channel-group name.
-    /// channel_name : str
-    ///     Exact channel name within that group.
-    ///
-    /// Returns
-    /// -------
-    /// Optional[numpy.ndarray]
-    ///     1-D ``float64`` array, or ``None`` if either name is not found.
-    fn get_channel_values_by_group_and_name<'py>(&self, py: Python<'py>, group_name: &str, channel_name: &str) -> PyResult<Option<PyObject>> {
-        for group in self.mdf.channel_groups() {
-            if let Some(gname) = group.name()? {
-                if gname == group_name {
-                    for channel in group.channels() {
-                        if let Some(cname) = channel.name()? {
-                            if cname == channel_name {
-                                let values = channel.values_as_f64()?;
-                                let array = PyArray1::from_vec_bound(py, values);
-                                return Ok(Some(array.into()));
-                            }
-                        }
-                    }
-                    return Ok(None);
-                }
-            }
-        }
-        Ok(None)
-    }
-
-    /// Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
-    ///
-    /// The series is indexed by the group's master channel (channel-type 2)
-    /// converted to a ``DatetimeIndex`` — relative master values (in seconds)
-    /// are added to the file's ``HD.abs_time`` start instant. If the channel
-    /// has no master, or the master channel itself is being requested, the
-    /// returned series uses the default integer index. If the file has no
-    /// recorded start time, the master values are kept as a numeric index.
+    /// This is the fast path: values are decoded directly into a numpy buffer,
+    /// invalid / non-decodable samples become ``NaN``. It does **not** apply
+    /// non-linear conversions — use :py:meth:`read_raw` for text / table /
+    /// value-to-text channels.
     ///
     /// Parameters
     /// ----------
-    /// channel_name : str
-    ///     Exact channel name; first match across all groups is used.
-    ///
-    /// Returns
-    /// -------
-    /// Optional[pandas.Series]
-    ///     ``None`` if no channel with that name exists.
+    /// name : str
+    ///     Channel name (case-sensitive).
+    /// group : Optional[str]
+    ///     Restrict the search to a single group by name. Use this when the
+    ///     same channel name (e.g. ``"Time"``) appears in several groups.
     ///
     /// Raises
     /// ------
     /// MdfException
-    ///     If pandas is not installed.
-    fn get_channel_as_series(&self, py: Python, channel_name: &str) -> PyResult<Option<PyObject>> {
-        let pd = check_pandas_available(py)?;
-        let start_time_ns = self.mdf.start_time_ns();
-
-        for group in self.mdf.channel_groups() {
-            let channels = group.channels();
-
-            for (ch_idx, channel) in channels.iter().enumerate() {
-                if let Some(name) = channel.name()? {
-                    if name == channel_name {
-                        let values = channel.values_as_f64()?;
-                        let py_values = PyArray1::from_vec_bound(py, values);
-
-                        let index: PyObject = if let Some(master_idx) = find_master_channel(&channels) {
-                            if master_idx != ch_idx {
-                                let master_values = channels[master_idx].values_as_f64()?;
-                                let py_master = PyArray1::from_vec_bound(py, master_values);
-
-                                if let Some(start_ns) = start_time_ns {
-                                    // Vectorized datetime conversion using pandas
-                                    let to_datetime = pd.getattr(py, "to_datetime")?;
-                                    let to_timedelta = pd.getattr(py, "to_timedelta")?;
-                                    let start_ts = to_datetime.call(
-                                        py, (start_ns,),
-                                        Some([("unit", "ns")].into_py_dict(py))
-                                    )?;
-                                    let deltas = to_timedelta.call(
-                                        py, (py_master.clone(),),
-                                        Some([("unit", "s")].into_py_dict(py))
-                                    )?;
-                                    match deltas.call_method1(py, "__add__", (start_ts,)) {
-                                        Ok(datetime_index) => datetime_index,
-                                        Err(_) => py_master.into(),
-                                    }
-                                } else {
-                                    py_master.into()
-                                }
-                            } else {
-                                py.None()
-                            }
-                        } else {
-                            py.None()
-                        };
-
-                        let series_class = pd.getattr(py, "Series")?;
-                        let series = if index.is_none(py) {
-                            series_class.call1(py, (py_values,))?
-                        } else {
-                            series_class.call(py, (py_values,), Some([("index", index)].into_py_dict(py)))?
-                        };
-
-                        series.setattr(py, "name", channel_name)?;
-                        return Ok(Some(series));
-                    }
-                }
-            }
-        }
-        Ok(None)
+    ///     If no matching channel exists.
+    fn read<'py>(&self, py: Python<'py>, name: &str, group: Option<&str>) -> PyResult<PyObject> {
+        let (g, idx) = self.find_group_channel(group, name)?;
+        let values = g.channels()[idx].values_as_f64()?;
+        Ok(PyArray1::from_vec_bound(py, values).into())
     }
 
-    /// Build a :class:`PyFileLayout` describing every block in this file.
+    /// Read a channel by name, returning native Python values with conversions.
     ///
-    /// Useful for debugging or analysing the on-disk structure: returns the
-    /// offset, size, type, link targets and unreferenced gaps for each
-    /// MDF block (``##ID``, ``##HD``, ``##DG``, ``##CG``, ``##CN``, ``##DT``,
-    /// ``##DL``, ``##TX``, ``##CC``, ``##SI``, ``##SD`` …).
+    /// Slower than :py:meth:`read` but faithful to every conversion type
+    /// (linear, rational, table, value-to-text, …). ``None`` entries mark
+    /// invalid samples; valid samples are ``float`` / ``int`` / ``str`` /
+    /// ``bytes`` matching the channel.
     ///
-    /// Returns
-    /// -------
-    /// PyFileLayout
+    /// Parameters
+    /// ----------
+    /// name : str
+    /// group : Optional[str]
+    fn read_raw(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<Vec<Option<PyObject>>> {
+        let (g, idx) = self.find_group_channel(group, name)?;
+        let values = g.channels()[idx].values()?;
+        Ok(values
+            .into_iter()
+            .map(|opt| opt.map(|dv| decoded_value_to_pyobject(dv, py)))
+            .collect())
+    }
+
+    /// Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
+    ///
+    /// The series is indexed by the channel's group master (channel-type 2)
+    /// converted to a ``DatetimeIndex`` (relative seconds added to the file's
+    /// ``HD.abs_time``). If there is no master, or the requested channel *is*
+    /// the master, a default integer index is used; if the file has no start
+    /// time, master values are kept as a numeric index.
+    ///
+    /// Parameters
+    /// ----------
+    /// name : str
+    /// group : Optional[str]
+    ///
+    /// Raises
+    /// ------
+    /// MdfException
+    ///     If the channel is not found or pandas is not installed.
+    fn series(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<PyObject> {
+        let pd = check_pandas_available(py)?;
+        let start_time_ns = self.mdf.start_time_ns();
+        let (g, ch_idx) = self.find_group_channel(group, name)?;
+        let channels = g.channels();
+
+        let values = channels[ch_idx].values_as_f64()?;
+        let py_values = PyArray1::from_vec_bound(py, values);
+
+        let index: PyObject = if let Some(master_idx) = find_master_channel(&channels) {
+            if master_idx != ch_idx {
+                let master_values = channels[master_idx].values_as_f64()?;
+                let py_master = PyArray1::from_vec_bound(py, master_values);
+
+                if let Some(start_ns) = start_time_ns {
+                    let to_datetime = pd.getattr(py, "to_datetime")?;
+                    let to_timedelta = pd.getattr(py, "to_timedelta")?;
+                    let start_ts = to_datetime.call(
+                        py, (start_ns,),
+                        Some([("unit", "ns")].into_py_dict(py))
+                    )?;
+                    let deltas = to_timedelta.call(
+                        py, (py_master.clone(),),
+                        Some([("unit", "s")].into_py_dict(py))
+                    )?;
+                    match deltas.call_method1(py, "__add__", (start_ts,)) {
+                        Ok(datetime_index) => datetime_index,
+                        Err(_) => py_master.into(),
+                    }
+                } else {
+                    py_master.into()
+                }
+            } else {
+                py.None()
+            }
+        } else {
+            py.None()
+        };
+
+        let series_class = pd.getattr(py, "Series")?;
+        let series = if index.is_none(py) {
+            series_class.call1(py, (py_values,))?
+        } else {
+            series_class.call(py, (py_values,), Some([("index", index)].into_py_dict(py)))?
+        };
+        series.setattr(py, "name", name)?;
+        Ok(series)
+    }
+
+    /// ``mdf["Speed"]`` — shorthand for :py:meth:`read` (numpy float64).
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<PyObject> {
+        self.read(py, name, None)
+    }
+
+    /// Build a :class:`FileLayout` describing every block in this file.
+    ///
+    /// Useful for debugging or analysing on-disk structure: offset, size,
+    /// type, link targets and unreferenced gaps for each MDF block.
     fn file_layout(&self) -> PyResult<PyFileLayout> {
         let layout = self.mdf.file_layout()?;
         Ok(PyFileLayout { inner: layout })
@@ -766,7 +772,7 @@ impl PyMDF {
 ///
 /// Build an MDF file in five logical steps:
 ///
-/// 1. ``writer = mf4_rs.PyMdfWriter("out.mf4")``
+/// 1. ``writer = mf4_rs.MdfWriter("out.mf4")``
 /// 2. ``writer.init_mdf_file()`` — write ``##ID`` and ``##HD``.
 /// 3. Define structure: :py:meth:`add_channel_group`, then any combination of
 ///    :py:meth:`add_time_channel`, :py:meth:`add_float_channel`,
@@ -786,7 +792,7 @@ impl PyMDF {
 ///
 /// Example
 /// -------
-/// >>> w = mf4_rs.PyMdfWriter("demo.mf4")
+/// >>> w = mf4_rs.MdfWriter("demo.mf4")
 /// >>> w.init_mdf_file()
 /// >>> cg = w.add_channel_group("group_0")
 /// >>> t = w.add_time_channel(cg, "Time")
@@ -800,7 +806,7 @@ impl PyMDF {
 /// >>> w.finish_data_block(cg)
 /// >>> w.finalize()
 #[gen_stub_pyclass]
-#[pyclass(unsendable)]
+#[pyclass(unsendable, name = "MdfWriter")]
 pub struct PyMdfWriter {
     writer: Option<MdfWriter>,
     channel_groups: HashMap<String, String>, // Maps Python ID to Rust ID
@@ -939,7 +945,7 @@ impl PyMdfWriter {
     ///     ID returned by :py:meth:`add_channel_group`.
     /// name : str
     ///     Channel name (written as a ``##TX`` block).
-    /// data_type : PyDataType
+    /// data_type : DataType
     ///     One of the values from the ``create_data_type_*`` helpers.
     ///
     /// Returns
@@ -1001,7 +1007,7 @@ impl PyMdfWriter {
     ///
     /// For signed integers, build a generic channel with
     /// :py:meth:`add_channel` and ``create_data_type_*`` helpers (or call
-    /// directly with the raw :class:`PyDataType`).
+    /// directly with the raw :class:`DataType`).
     fn add_int_channel(&mut self, group_id: &str, name: &str) -> PyResult<String> {
         self.add_channel_with_bits(group_id, name, PyDataType { name: "UnsignedIntegerLE".to_string(), value: 0 }, 64)
     }
@@ -1051,7 +1057,7 @@ impl PyMdfWriter {
     /// ``values`` must contain exactly one entry per channel, in the same
     /// order channels were added — typically the master channel first, then
     /// data channels. Each value is encoded according to its channel's data
-    /// type (the variant of :class:`PyDecodedValue` is *not* re-checked, so
+    /// type (the variant of :class:`DecodedValue` is *not* re-checked, so
     /// passing the wrong variant will produce nonsense bytes).
     ///
     /// This call has Python-level overhead per value; for bulk numeric data,
@@ -1222,29 +1228,24 @@ impl PyMdfWriter {
 
 /// Lightweight, self-contained index over an MDF 4 file.
 ///
-/// An index records the byte ranges of each channel, fully resolves all
-/// conversion blocks, and can be serialized to JSON. Once you have a
-/// ``PyMdfIndex`` you can:
+/// An index records the byte ranges of each channel, fully resolves every
+/// conversion block, and serialises to JSON. Navigate it by **name**
+/// (:py:attr:`groups`, :py:meth:`group`, :py:meth:`channel`); to read sample
+/// data, bind a source once with :py:meth:`open` / :py:meth:`open_url`, which
+/// return an :class:`MdfData` you index by channel name.
 ///
-/// - Re-read channel values quickly without re-parsing the whole file.
-/// - Compute exact byte ranges for **partial** / HTTP-range / S3 reads
-///   (see :py:meth:`get_channel_byte_ranges`,
-///   :py:meth:`get_channel_byte_ranges_for_records`).
-/// - Persist with :py:meth:`save_to_file` and reload elsewhere with
-///   :py:meth:`load_from_file` — the JSON is fully self-contained, the
-///   original file is only required for the actual data reads.
-///
-/// **Limitation:** indexes do not support compressed (``##DZ``) data blocks.
+/// **Limitation:** compressed (``##DZ``) data blocks are not supported.
 ///
 /// Example
 /// -------
-/// >>> idx = mf4_rs.PyMdfIndex.from_file("recording.mf4")
-/// >>> idx.save_to_file("recording.idx.json")
-/// >>> # Later, possibly on another machine that has the same file:
-/// >>> idx2 = mf4_rs.PyMdfIndex.load_from_file("recording.idx.json")
-/// >>> values = idx2.read_channel_values_by_name_as_f64("Speed", "recording.mf4")
+/// >>> idx = mf4_rs.MdfIndex.from_file("recording.mf4")
+/// >>> idx.save("recording.idx.json")
+/// >>> idx = mf4_rs.MdfIndex.load("recording.idx.json")
+/// >>> data = idx.open("recording.mf4")     # bind the data source once
+/// >>> speed = data["Speed"]                # numpy float64
+/// >>> rpm   = data.read("RPM", group="Engine")
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "MdfIndex")]
 pub struct PyMdfIndex {
     index: MdfIndex,
 }
@@ -1254,67 +1255,42 @@ pub struct PyMdfIndex {
 impl PyMdfIndex {
     /// Build a fresh index by parsing an MDF file from disk.
     ///
-    /// All conversions are resolved during construction so the index is
-    /// fully self-contained afterwards.
+    /// All conversions are resolved during construction so the index is fully
+    /// self-contained afterwards.
     ///
     /// Parameters
     /// ----------
     /// path : str
     ///     Path to a ``.mf4`` file.
-    ///
-    /// Raises
-    /// ------
-    /// MdfException
-    ///     If the file cannot be parsed as MDF 4.10+.
     #[staticmethod]
     fn from_file(path: &str) -> PyResult<Self> {
-        let index = MdfIndex::from_file(path)?;
-        Ok(PyMdfIndex { index })
+        Ok(PyMdfIndex { index: MdfIndex::from_file(path)? })
     }
-    
-    /// Load a previously saved JSON index file.
+
+    /// Load a previously saved JSON index (companion to :py:meth:`save`).
     ///
-    /// The companion to :py:meth:`save_to_file`. Reads do not require the
-    /// original MDF file until you actually call ``read_channel_values_*``
-    /// or ``get_channel_byte_ranges_*``.
+    /// The original MDF file is only needed later, when you actually read
+    /// values via :py:meth:`open`.
     #[staticmethod]
-    fn load_from_file(path: &str) -> PyResult<Self> {
-        let index = MdfIndex::load_from_file(path)?;
-        Ok(PyMdfIndex { index })
+    fn load(path: &str) -> PyResult<Self> {
+        Ok(PyMdfIndex { index: MdfIndex::load_from_file(path)? })
     }
 
     /// Build an index from an MDF file served over HTTP / S3 using range
     /// requests, without downloading the whole file.
     ///
-    /// Issues range reads only for metadata blocks (``##ID``, ``##HD``,
-    /// ``##DG``, ``##CG``, ``##CN``, name / unit / comment ``##TX``,
-    /// conversion ``##CC`` plus its ``cc_ref`` chain, and ``##DT``/``##DV``/
-    /// ``##DZ``/``##DL`` headers). Sample data is never fetched. With the
-    /// default 1 MiB read-ahead chunk, a typical file collapses to a handful
-    /// of underlying HTTP requests regardless of file size.
+    /// Issues range reads only for metadata blocks; sample data is never
+    /// fetched. With the default 1 MiB read-ahead chunk a typical file
+    /// collapses to a handful of HTTP requests regardless of size.
     ///
     /// Parameters
     /// ----------
     /// url : str
-    ///     ``http://`` or ``https://`` URL of the ``.mf4`` resource. The
-    ///     server must honour single-range ``Range: bytes=A-B`` requests.
+    ///     ``http://`` / ``https://`` URL honouring ``Range`` requests.
     /// chunk_size : int, optional
-    ///     Read-ahead chunk size in bytes for the metadata phase
-    ///     (default 1 MiB). Smaller values reduce wasted bytes when
-    ///     metadata is densely packed near the file head; larger values
-    ///     reduce the number of HTTP round-trips when metadata is
-    ///     scattered across the file.
-    ///
-    /// Raises
-    /// ------
-    /// MdfException
-    ///     If the URL cannot be reached, the server does not honour
-    ///     range requests, or the response is not a valid MDF file.
+    ///     Metadata read-ahead chunk size in bytes (default 1 MiB).
     #[staticmethod]
     fn from_url(py: Python, url: &str, chunk_size: Option<u64>) -> PyResult<Self> {
-        // Release the GIL: ureq does blocking socket I/O and any HTTP server
-        // running in the same Python interpreter (e.g. a `http.server` test
-        // fixture) needs the GIL to handle requests.
         let url = url.to_string();
         let chunk = chunk_size.unwrap_or(1 << 20);
         let index = py.allow_threads(move || -> Result<MdfIndex, MdfError> {
@@ -1326,362 +1302,105 @@ impl PyMdfIndex {
         Ok(PyMdfIndex { index })
     }
 
-    /// Serialize the index to JSON at ``path``.
-    ///
-    /// Output is dependency-free (no references back to the source MDF) and
-    /// typically a few KB to a few MB depending on channel/conversion count.
-    fn save_to_file(&self, path: &str) -> PyResult<()> {
+    /// Serialize the index to JSON at ``path`` (dependency-free).
+    fn save(&self, path: &str) -> PyResult<()> {
         self.index.save_to_file(path)?;
         Ok(())
     }
-    
-    /// List every channel group in the index.
+
+    /// Metadata for every channel group, in file order.
     ///
-    /// Returns
-    /// -------
-    /// list[tuple[int, str, int]]
-    ///     ``(group_index, group_name, channel_count)`` per group. Unnamed
-    ///     groups appear with an empty string for the name.
-    fn list_channel_groups(&self) -> Vec<(usize, String, usize)> {
-        self.index.list_channel_groups()
+    /// Each :class:`GroupInfo` carries its ``channels`` list, so the whole
+    /// structure is available from a single ``index.groups`` access.
+    #[getter]
+    fn groups(&self) -> Vec<PyChannelGroupInfo> {
+        self.index.groups().iter().map(PyChannelGroupInfo::from_indexed).collect()
+    }
+
+    /// Find a channel group by name (first match), or ``None``.
+    fn group(&self, name: &str) -> Option<PyChannelGroupInfo> {
+        self.index.group(name).map(PyChannelGroupInfo::from_indexed)
+    }
+
+    /// Find a channel by name across all groups (first match), or ``None``.
+    fn channel(&self, name: &str) -> Option<PyChannelInfo> {
+        self.index.channel(name).map(PyChannelInfo::from_indexed)
+    }
+
+    /// Names of every named channel across all groups (duplicates kept).
+    #[getter]
+    fn channel_names(&self) -> Vec<String> {
+        self.index.channel_names().into_iter().map(String::from).collect()
+    }
+
+    /// Names of the groups that contain a channel called ``name``.
+    ///
+    /// Use this to disambiguate a channel name shared by several groups, then
+    /// pass the chosen group to :py:meth:`MdfData.read`.
+    fn groups_with_channel(&self, name: &str) -> Vec<String> {
+        self.index
+            .find_channels(name)
             .into_iter()
-            .map(|(idx, name, count)| (idx, name.to_string(), count))
+            .filter_map(|(g, _)| self.index.groups().get(g).and_then(|grp| grp.name.clone()))
             .collect()
     }
-    
-    /// List channels in a single group.
+
+    /// Byte ranges ``[(offset, length), ...]`` occupied by a channel.
+    ///
+    /// Accounts for the channel's record-layout position and data-block
+    /// splitting. Power-user entry point for issuing your own partial reads.
     ///
     /// Parameters
     /// ----------
-    /// group_index : int
-    ///     Index from :py:meth:`list_channel_groups`.
-    ///
-    /// Returns
-    /// -------
-    /// Optional[list[tuple[int, str, PyDataType]]]
-    ///     ``(channel_index, channel_name, data_type)`` per channel, or
-    ///     ``None`` if ``group_index`` is out of range.
-    fn list_channels(&self, group_index: usize) -> Option<Vec<(usize, String, PyDataType)>> {
-        self.index.list_channels(group_index)
-            .map(|channels| {
-                channels.into_iter()
-                    .map(|(idx, name, data_type)| (idx, name.to_string(), PyDataType::from(data_type)))
-                    .collect()
-            })
-    }
-    
-    /// Read every sample of a channel, identified by group + channel index.
-    ///
-    /// Conversions stored in the index are applied automatically.
-    ///
-    /// Parameters
-    /// ----------
-    /// group_index : int
-    /// channel_index : int
-    /// file_path : str
-    ///     Path to the original MDF file (the index does not embed sample
-    ///     bytes).
-    ///
-    /// Returns
-    /// -------
-    /// list[Optional[Union[float, int, str, bytes]]]
-    ///     One entry per record. ``None`` indicates an invalid sample
-    ///     (invalidation bit set, or undecodable). Otherwise the value is a
-    ///     native Python type matching the channel's data type.
-    ///
-    /// Raises
-    /// ------
-    /// MdfException
-    ///     If indices are out of range, the file cannot be read, or the
-    ///     file contains compressed (``##DZ``) blocks.
-    fn read_channel_values(&self, py: Python, group_index: usize, channel_index: usize, file_path: &str) -> PyResult<Vec<Option<PyObject>>> {
-        let mut reader = FileRangeReader::new(file_path)?;
-        let values = self.index.read_channel_values(group_index, channel_index, &mut reader)?;
-        Ok(values.into_iter().map(|opt_val| {
-            opt_val.map(|dv| decoded_value_to_pyobject(dv, py))
-        }).collect())
-    }
-    
-    /// Read every sample of a channel by name (first match across groups).
-    ///
-    /// See :py:meth:`read_channel_values` for the return / error contract.
-    /// If multiple groups contain the same channel name, prefer
-    /// :py:meth:`read_channel_values_by_group_and_name`.
-    fn read_channel_values_by_name(&self, py: Python, channel_name: &str, file_path: &str) -> PyResult<Vec<Option<PyObject>>> {
-        let mut reader = FileRangeReader::new(file_path)?;
-        let values = self.index.read_channel_values_by_name(channel_name, &mut reader)?;
-        Ok(values.into_iter().map(|opt_val| {
-            opt_val.map(|dv| decoded_value_to_pyobject(dv, py))
-        }).collect())
-    }
-
-    /// Read every sample of a channel via HTTP range requests.
-    ///
-    /// Issues one HTTP request per data block holding this channel. Cache
-    /// is bypassed because data-block payloads are typically far larger
-    /// than any sensible chunk size; one ranged ``GET`` per block is the
-    /// cheapest pattern.
-    ///
-    /// Parameters
-    /// ----------
-    /// group_index : int
-    /// channel_index : int
-    /// url : str
-    ///     URL of the same MDF file the index was built from.
-    ///
-    /// Returns
-    /// -------
-    /// list[Optional[Union[float, int, str, bytes]]]
-    ///     One entry per record. ``None`` indicates an invalid sample.
-    fn read_channel_values_from_url(
-        &self,
-        py: Python,
-        group_index: usize,
-        channel_index: usize,
-        url: &str,
-    ) -> PyResult<Vec<Option<PyObject>>> {
-        let url = url.to_string();
-        let values = py.allow_threads(move || -> Result<_, MdfError> {
-            let http = HttpRangeReader::new(&url)?;
-            let mut cached = CachingRangeReader::new(http);
-            cached.set_bypass(true);
-            self.index
-                .read_channel_values(group_index, channel_index, &mut cached)
-        })?;
-        Ok(values
-            .into_iter()
-            .map(|opt_val| opt_val.map(|dv| decoded_value_to_pyobject(dv, py)))
-            .collect())
-    }
-
-    /// Read every sample of a channel by name via HTTP range requests.
-    ///
-    /// See :py:meth:`read_channel_values_from_url` for the I/O contract.
-    fn read_channel_values_by_name_from_url(
-        &self,
-        py: Python,
-        channel_name: &str,
-        url: &str,
-    ) -> PyResult<Vec<Option<PyObject>>> {
-        let url = url.to_string();
-        let channel_name = channel_name.to_string();
-        let values = py.allow_threads(move || -> Result<_, MdfError> {
-            let http = HttpRangeReader::new(&url)?;
-            let mut cached = CachingRangeReader::new(http);
-            cached.set_bypass(true);
-            self.index
-                .read_channel_values_by_name(&channel_name, &mut cached)
-        })?;
-        Ok(values
-            .into_iter()
-            .map(|opt_val| opt_val.map(|dv| decoded_value_to_pyobject(dv, py)))
-            .collect())
-    }
-
-    /// Fast path: read a numeric channel as a list of ``float`` values.
-    ///
-    /// Several times faster than :py:meth:`read_channel_values` for numeric
-    /// channels — opens the source file via ``mmap``, decodes directly into
-    /// ``f64`` and skips ``DecodedValue`` boxing. Invalid / non-finite
-    /// samples are returned as ``float('nan')`` rather than ``None``.
-    ///
-    /// Parameters
-    /// ----------
-    /// group_index : int
-    /// channel_index : int
-    /// file_path : str
-    ///
-    /// Returns
-    /// -------
-    /// list[float]
-    ///
-    /// Raises
-    /// ------
-    /// MdfException
-    ///     If the channel is non-numeric (string / byte array), indices are
-    ///     out of range, or the file cannot be mapped.
-    fn read_channel_values_as_f64(&self, group_index: usize, channel_index: usize, file_path: &str) -> PyResult<Vec<f64>> {
-        let file = std::fs::File::open(file_path).map_err(|e| MdfError::IOError(e))?;
-        let mmap = unsafe { memmap2::Mmap::map(&file) }.map_err(|e| MdfError::IOError(e))?;
-        Ok(self.index.read_channel_values_from_slice_as_f64(group_index, channel_index, &mmap)?)
-    }
-
-    /// Fast path: read a numeric channel as ``list[float]``, looked up by name.
-    ///
-    /// Combines :py:meth:`find_channel_by_name` and
-    /// :py:meth:`read_channel_values_as_f64`. Invalid samples are
-    /// ``float('nan')``.
-    ///
-    /// Raises
-    /// ------
-    /// MdfException
-    ///     If no channel with that name exists, the channel is not numeric,
-    ///     or the file cannot be mapped.
-    fn read_channel_values_by_name_as_f64(&self, channel_name: &str, file_path: &str) -> PyResult<Vec<f64>> {
-        let (group_index, channel_index) = self.index.find_channel_by_name_global(channel_name)
-            .ok_or_else(|| MdfError::BlockSerializationError(
-                format!("Channel '{}' not found", channel_name)
-            ))?;
-        let file = std::fs::File::open(file_path).map_err(|e| MdfError::IOError(e))?;
-        let mmap = unsafe { memmap2::Mmap::map(&file) }.map_err(|e| MdfError::IOError(e))?;
-        Ok(self.index.read_channel_values_from_slice_as_f64(group_index, channel_index, &mmap)?)
-    }
-
-    /// Locate a channel by name across all groups.
-    ///
-    /// Returns
-    /// -------
-    /// Optional[tuple[int, int]]
-    ///     ``(group_index, channel_index)`` of the first match, or ``None``.
-    fn find_channel_by_name(&self, channel_name: &str) -> Option<(usize, usize)> {
-        self.index.find_channel_by_name_global(channel_name)
-    }
-
-    /// Compute the byte ranges occupied by a channel across the file.
-    ///
-    /// Each tuple is ``(offset, length)`` and accounts for the channel's
-    /// position inside the record layout *and* any data block splitting
-    /// across multiple ``##DT`` fragments. Useful for issuing HTTP-range
-    /// requests against a remote MDF file.
-    fn get_channel_byte_ranges(&self, group_index: usize, channel_index: usize) -> PyResult<Vec<(u64, u64)>> {
-        Ok(self.index.get_channel_byte_ranges(group_index, channel_index)?)
-    }
-
-    /// Like :py:meth:`get_channel_byte_ranges`, but limited to a record window.
-    ///
-    /// Parameters
-    /// ----------
-    /// group_index : int
-    /// channel_index : int
-    /// start_record : int
-    ///     0-based first record to include.
-    /// record_count : int
-    ///     Number of records to cover (clamped to remaining records).
-    fn get_channel_byte_ranges_for_records(&self, group_index: usize, channel_index: usize, start_record: u64, record_count: u64) -> PyResult<Vec<(u64, u64)>> {
-        Ok(self.index.get_channel_byte_ranges_for_records(group_index, channel_index, start_record, record_count)?)
-    }
-
-    /// Summarize :py:meth:`get_channel_byte_ranges` without listing each range.
-    ///
-    /// Returns
-    /// -------
-    /// tuple[int, int]
-    ///     ``(total_bytes, num_ranges)``.
-    fn get_channel_byte_summary(&self, group_index: usize, channel_index: usize) -> PyResult<(u64, usize)> {
-        Ok(self.index.get_channel_byte_summary(group_index, channel_index)?)
-    }
-
-    /// Byte ranges for a channel, looked up by name (first match).
-    fn get_channel_byte_ranges_by_name(&self, channel_name: &str) -> PyResult<Vec<(u64, u64)>> {
-        Ok(self.index.get_channel_byte_ranges_by_name(channel_name)?)
-    }
-
-    /// Look up a channel by name and return its position plus metadata.
-    ///
-    /// Returns
-    /// -------
-    /// Optional[tuple[int, int, PyChannelInfo]]
-    ///     ``(group_index, channel_index, info)`` for the first match, or
-    ///     ``None``. ``info.comment`` is always ``None`` for indexed
-    ///     channels (comments are not stored in the index).
-    fn get_channel_info_by_name(&self, channel_name: &str) -> Option<(usize, usize, PyChannelInfo)> {
-        self.index.get_channel_info_by_name(channel_name).map(|(group_idx, channel_idx, channel)| {
-            let info = PyChannelInfo {
-                name: channel.name.clone(),
-                unit: channel.unit.clone(),
-                comment: None, // IndexedChannel doesn't store comment
-                data_type: PyDataType::from(&channel.data_type),
-                bit_count: channel.bit_count,
-            };
-            (group_idx, channel_idx, info)
+    /// name : str
+    /// group : Optional[str]
+    ///     Disambiguate by group when the name is not unique.
+    fn byte_ranges(&self, name: &str, group: Option<&str>) -> PyResult<Vec<(u64, u64)>> {
+        Ok(match group {
+            Some(g) => self.index.byte_ranges_in(g, name)?,
+            None => self.index.byte_ranges(name)?,
         })
     }
-    
-    /// Find every ``(group_index, channel_index)`` whose channel name matches.
-    ///
-    /// Useful when the same name appears in multiple groups (e.g. ``"Time"``
-    /// in each group).
-    fn find_all_channels_by_name(&self, channel_name: &str) -> Vec<(usize, usize)> {
-        self.index.find_all_channels_by_name(channel_name)
+
+    /// Byte ranges covering a record window ``[start, start+count)``.
+    fn byte_ranges_for_records(
+        &self,
+        name: &str,
+        start_record: u64,
+        record_count: u64,
+    ) -> PyResult<Vec<(u64, u64)>> {
+        Ok(self.index.byte_ranges_for_records(name, start_record, record_count)?)
     }
 
-    /// Total size, in bytes, of the source MDF file at the time the index
-    /// was built.
-    fn get_file_size(&self) -> u64 {
-        self.index.file_size
-    }
-
-    /// True if any conversion in the index has its dependent ``##TX`` /
-    /// ``##CC`` data resolved inline.
+    /// Inspect the conversion attached to a channel (by name).
     ///
-    /// Indexes built with :py:meth:`from_file` resolve all dependencies, so
-    /// this normally returns ``True``.
-    fn has_resolved_conversions(&self) -> bool {
-        // Check if any channel has resolved conversion data
-        for group in &self.index.channel_groups {
-            for channel in &group.channels {
-                if let Some(conversion) = &channel.conversion {
-                    if conversion.resolved_texts.is_some() || conversion.resolved_conversions.is_some() {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
-    }
-    
-    /// Inspect the conversion attached to a channel.
-    ///
-    /// Returns
-    /// -------
-    /// Optional[dict]
-    ///     ``None`` if the channel has no conversion. Otherwise a dict with
-    ///     keys:
-    ///
-    ///     - ``conversion_type`` — debug rendering of the ``cc_type`` enum
-    ///       (e.g. ``"Linear"``, ``"ValueToText"``).
-    ///     - ``precision`` — decimal precision hint (``cc_precision``).
-    ///     - ``flags`` — raw ``cc_flags`` bitfield.
-    ///     - ``values_count`` — number of entries in ``cc_val``.
-    ///     - ``values`` — raw ``cc_val`` numeric coefficients / table values.
-    ///     - ``resolved_texts`` — dict[int, str] mapping ``cc_ref`` indices
-    ///       to their resolved ``##TX`` text (when applicable).
-    ///     - ``has_resolved_conversions`` — present when nested conversions
-    ///       have been pre-resolved.
-    ///     - ``formula`` — algebraic formula string (for type 3 only).
-    fn get_conversion_info(&self, group_index: usize, channel_index: usize) -> PyResult<Option<HashMap<String, PyObject>>> {
-        use pyo3::Python;
-
-        let group = self.index.channel_groups.get(group_index)
-            .ok_or_else(|| MdfException::new_err("Invalid group index"))?;
-
-        let channel = group.channels.get(channel_index)
-            .ok_or_else(|| MdfException::new_err("Invalid channel index"))?;
+    /// Returns ``None`` if the channel has no conversion, otherwise a dict
+    /// describing it (``conversion_type``, ``values``, ``resolved_texts``,
+    /// ``formula`` …).
+    fn conversion_info(&self, name: &str) -> PyResult<Option<HashMap<String, PyObject>>> {
+        let (g, c) = self.index.locate(name).ok_or_else(|| {
+            MdfException::new_err(format!("Channel '{}' not found", name))
+        })?;
+        let channel = &self.index.groups()[g].channels[c];
 
         if let Some(conversion) = &channel.conversion {
             Python::with_gil(|py| {
                 let mut info = HashMap::new();
-
                 info.insert("conversion_type".to_string(), format!("{:?}", conversion.cc_type).to_object(py));
                 info.insert("precision".to_string(), conversion.cc_precision.to_object(py));
                 info.insert("flags".to_string(), conversion.cc_flags.to_object(py));
                 info.insert("values_count".to_string(), conversion.cc_val_count.to_object(py));
                 info.insert("values".to_string(), conversion.cc_val.to_object(py));
-
-                // Include resolved data info if available
                 if let Some(resolved_texts) = &conversion.resolved_texts {
                     let texts: HashMap<usize, String> = resolved_texts.clone();
                     info.insert("resolved_texts".to_string(), texts.to_object(py));
                 }
-
-                if let Some(_) = &conversion.resolved_conversions {
+                if conversion.resolved_conversions.is_some() {
                     info.insert("has_resolved_conversions".to_string(), true.to_object(py));
                 }
-
                 if let Some(formula) = &conversion.formula {
                     info.insert("formula".to_string(), formula.to_object(py));
                 }
-
                 Ok(Some(info))
             })
         } else {
@@ -1689,154 +1408,240 @@ impl PyMdfIndex {
         }
     }
 
-    /// Read a channel by group + channel name, disambiguating duplicates.
+    /// Total size of the source MDF file when the index was built.
+    #[getter]
+    fn file_size(&self) -> u64 {
+        self.index.file_size
+    }
+
+    /// Bind this index to a local MDF file for reading sample data.
     ///
-    /// Looks up the channel group by name first, then finds the channel
-    /// within that specific group. ``None`` entries in the returned list
-    /// mark invalid samples; valid samples are native Python values
-    /// (``float`` / ``int`` / ``str`` / ``bytes``).
+    /// Returns an :class:`MdfData`; the file path is supplied once here and
+    /// reused for every subsequent read.
+    fn open(&self, path: &str) -> PyMdfData {
+        PyMdfData { index: self.index.clone(), source: DataSource::File(path.to_string()) }
+    }
+
+    /// Bind this index to an HTTP / S3 URL for reading sample data via range
+    /// requests. Returns an :class:`MdfData`.
+    fn open_url(&self, url: &str) -> PyMdfData {
+        PyMdfData { index: self.index.clone(), source: DataSource::Url(url.to_string()) }
+    }
+}
+
+/// Where an :class:`MdfData` reads its bytes from.
+enum DataSource {
+    File(String),
+    Url(String),
+}
+
+/// A reader bound to an :class:`MdfIndex` and a single data source.
+///
+/// Obtained from :py:meth:`MdfIndex.open` / :py:meth:`MdfIndex.open_url`. The
+/// source (file path or URL) is given once; afterwards you read channels by
+/// **name**:
+///
+/// >>> data = idx.open("recording.mf4")
+/// >>> speed = data["Speed"]                  # numpy float64 (fast path)
+/// >>> status = data.read_raw("Status")       # native values + conversions
+/// >>> s = data.series("Speed")               # pandas Series, datetime index
+#[gen_stub_pyclass]
+#[pyclass(name = "MdfData")]
+pub struct PyMdfData {
+    index: MdfIndex,
+    source: DataSource,
+}
+
+impl PyMdfData {
+    /// Resolve an (optional group, name) pair to indices.
+    fn locate(&self, group: Option<&str>, name: &str) -> PyResult<(usize, usize)> {
+        match group {
+            Some(g) => self.index.locate_in(g, name).ok_or_else(|| {
+                MdfException::new_err(format!("Channel '{}' not found in group '{}'", name, g))
+            }),
+            None => self.index.locate(name).ok_or_else(|| {
+                MdfException::new_err(format!("Channel '{}' not found", name))
+            }),
+        }
+    }
+
+    /// Read decoded values (with conversions) for a resolved channel index.
+    fn read_decoded(
+        &self,
+        py: Python,
+        g: usize,
+        c: usize,
+    ) -> PyResult<Vec<Option<DecodedValue>>> {
+        Ok(match &self.source {
+            DataSource::File(path) => {
+                let mut reader = FileRangeReader::new(path)?;
+                self.index.read_channel_values(g, c, &mut reader)?
+            }
+            DataSource::Url(url) => {
+                let url = url.clone();
+                py.allow_threads(move || -> Result<_, MdfError> {
+                    let http = HttpRangeReader::new(&url)?;
+                    let mut cached = CachingRangeReader::new(http);
+                    cached.set_bypass(true);
+                    self.index.read_channel_values(g, c, &mut cached)
+                })?
+            }
+        })
+    }
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyMdfData {
+    /// Read a numeric channel by name as a numpy ``float64`` array (fast path).
+    ///
+    /// Invalid / non-decodable samples become ``NaN``. Linear conversions are
+    /// applied inline; for text / table conversions use :py:meth:`read_raw`.
+    ///
+    /// Parameters
+    /// ----------
+    /// name : str
+    /// group : Optional[str]
+    ///     Disambiguate by group when the channel name is not unique.
+    fn read<'py>(&self, py: Python<'py>, name: &str, group: Option<&str>) -> PyResult<PyObject> {
+        let (g, c) = self.locate(group, name)?;
+        let values = match &self.source {
+            DataSource::File(path) => {
+                let file = std::fs::File::open(path).map_err(MdfError::IOError)?;
+                let mmap = unsafe { memmap2::Mmap::map(&file) }.map_err(MdfError::IOError)?;
+                self.index.read_channel_values_from_slice_as_f64(g, c, &mmap)?
+            }
+            DataSource::Url(url) => {
+                let url = url.clone();
+                py.allow_threads(move || -> Result<Vec<f64>, MdfError> {
+                    let http = HttpRangeReader::new(&url)?;
+                    let mut cached = CachingRangeReader::new(http);
+                    cached.set_bypass(true);
+                    self.index.read_channel_values_as_f64(g, c, &mut cached)
+                })?
+            }
+        };
+        Ok(PyArray1::from_vec_bound(py, values).into())
+    }
+
+    /// Read a channel by name, returning native Python values + conversions.
+    ///
+    /// ``None`` marks invalid samples; valid samples are ``float`` / ``int`` /
+    /// ``str`` / ``bytes``. Faithful to every conversion type.
+    ///
+    /// Parameters
+    /// ----------
+    /// name : str
+    /// group : Optional[str]
+    fn read_raw(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<Vec<Option<PyObject>>> {
+        let (g, c) = self.locate(group, name)?;
+        let values = self.read_decoded(py, g, c)?;
+        Ok(values
+            .into_iter()
+            .map(|opt| opt.map(|dv| decoded_value_to_pyobject(dv, py)))
+            .collect())
+    }
+
+    /// Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
+    ///
+    /// Indexed by the channel's group master converted to a ``DatetimeIndex``
+    /// (relative seconds added to the index's stored start time). Falls back to
+    /// a numeric / default index when there is no master or no start time.
+    ///
+    /// Parameters
+    /// ----------
+    /// name : str
+    /// group : Optional[str]
     ///
     /// Raises
     /// ------
     /// MdfException
-    ///     If either ``group_name`` or ``channel_name`` is not found, or
-    ///     the source file cannot be read.
-    fn read_channel_values_by_group_and_name(&self, py: Python, group_name: &str, channel_name: &str, file_path: &str) -> PyResult<Vec<Option<PyObject>>> {
-        // Find the group by name
-        let mut group_index = None;
-        for (idx, group) in self.index.channel_groups.iter().enumerate() {
-            if let Some(ref gname) = group.name {
-                if gname == group_name {
-                    group_index = Some(idx);
-                    break;
-                }
-            }
-        }
-
-        let group_idx = group_index.ok_or_else(||
-            MdfException::new_err(format!("Channel group '{}' not found", group_name))
-        )?;
-
-        // Find the channel by name within the group
-        let group = &self.index.channel_groups[group_idx];
-        let mut channel_index = None;
-        for (idx, channel) in group.channels.iter().enumerate() {
-            if let Some(ref cname) = channel.name {
-                if cname == channel_name {
-                    channel_index = Some(idx);
-                    break;
-                }
-            }
-        }
-
-        let channel_idx = channel_index.ok_or_else(||
-            MdfException::new_err(format!("Channel '{}' not found in group '{}'", channel_name, group_name))
-        )?;
-
-        // Read the channel values using the found indices
-        let mut reader = FileRangeReader::new(file_path)?;
-        let values = self.index.read_channel_values(group_idx, channel_idx, &mut reader)?;
-        Ok(values.into_iter().map(|opt_val| {
-            opt_val.map(|dv| decoded_value_to_pyobject(dv, py))
-        }).collect())
-    }
-
-    /// Read channel data as a pandas Series with time/master channel as DatetimeIndex.
-    ///
-    /// This method reads a channel's values from the index and returns them as a pandas Series
-    /// with the time/master channel values converted to absolute timestamps as a DatetimeIndex.
-    /// The timestamps are created by adding the relative time values to the MDF start time
-    /// stored in the index. If no master channel is found, or if the queried channel IS the
-    /// master channel, a default integer index is used. If the MDF file has no start time,
-    /// falls back to numeric index.
-    ///
-    /// Requires pandas to be installed.
-    ///
-    /// # Arguments
-    /// * `channel_name` - Name of the channel to read
-    /// * `file_path` - Path to the MDF file
-    ///
-    /// # Returns
-    /// Returns an error if the channel is not found, otherwise returns a pandas Series.
-    ///
-    /// # Errors
-    /// Returns an error if:
-    /// - pandas is not installed
-    /// - the channel is not found
-    /// - the master channel has a different number of values than the data channel
-    fn read_channel_as_series(&self, py: Python, channel_name: &str, file_path: &str) -> PyResult<PyObject> {
-        // Check if pandas is available
+    ///     If the channel is not found or pandas is not installed.
+    fn series(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<PyObject> {
         let pd = check_pandas_available(py)?;
-
-        // Get the MDF start time from the index for datetime conversion
         let start_time_ns = self.index.start_time_ns;
+        let (g, c) = self.locate(group, name)?;
 
-        // Find the channel
-        let (group_idx, channel_idx) = self.find_channel_by_name(channel_name)
-            .ok_or_else(|| MdfException::new_err(format!("Channel '{}' not found", channel_name)))?;
+        let values = self.read_decoded(py, g, c)?;
+        let py_values: Vec<PyObject> = values
+            .into_iter()
+            .map(|o| o.map(|dv| decoded_value_to_pyobject(dv, py)).unwrap_or_else(|| py.None()))
+            .collect();
 
-        // Read the channel values
-        let mut reader = FileRangeReader::new(file_path)?;
-        let values = self.index.read_channel_values(group_idx, channel_idx, &mut reader)?;
-        let py_values: Vec<PyObject> = values.into_iter().map(|opt_val| {
-            opt_val.map(|dv| decoded_value_to_pyobject(dv, py)).unwrap_or_else(|| py.None())
-        }).collect();
+        let group_ref = &self.index.groups()[g];
+        let index_obj: PyObject = if let Some(master_idx) = find_master_channel_indexed(&group_ref.channels) {
+            if master_idx != c {
+                let master_vals = self.read_decoded(py, g, master_idx)?;
+                let py_master: Vec<PyObject> = master_vals
+                    .into_iter()
+                    .map(|o| o.map(|dv| decoded_value_to_pyobject(dv, py)).unwrap_or_else(|| py.None()))
+                    .collect();
 
-        // Find the master/time channel for this group
-        let group = &self.index.channel_groups[group_idx];
-        let index: PyObject = if let Some(master_idx) = find_master_channel_indexed(&group.channels) {
-            if master_idx != channel_idx {
-                // Use the master channel values as index
-                let master_values = self.index.read_channel_values(group_idx, master_idx, &mut reader)?;
-                let py_master_values: Vec<PyObject> = master_values.into_iter().map(|opt_val| {
-                    opt_val.map(|dv| decoded_value_to_pyobject(dv, py)).unwrap_or_else(|| py.None())
-                }).collect();
-
-                // Validate that lengths match
-                if py_master_values.len() != py_values.len() {
+                if py_master.len() != py_values.len() {
                     return Err(MdfException::new_err(format!(
                         "Master channel length ({}) does not match data channel length ({}) for channel '{}'",
-                        py_master_values.len(), py_values.len(), channel_name
+                        py_master.len(), py_values.len(), name
                     )));
                 }
 
-                // Try to convert to DatetimeIndex if we have a start time
                 if let Some(start_ns) = start_time_ns {
-                    // Attempt to create DatetimeIndex from absolute timestamps
-                    match create_datetime_index(py, &pd, &py_master_values, start_ns) {
-                        Ok(datetime_index) => datetime_index,
-                        Err(_) => {
-                            // Fall back to numeric index if datetime conversion fails
-                            py_master_values.to_object(py)
-                        }
+                    match create_datetime_index(py, &pd, &py_master, start_ns) {
+                        Ok(di) => di,
+                        Err(_) => py_master.to_object(py),
                     }
                 } else {
-                    // No start time, use numeric index
-                    py_master_values.to_object(py)
+                    py_master.to_object(py)
                 }
             } else {
-                // This channel IS the master channel, use default index
                 py.None()
             }
         } else {
-            // No master channel found, use default index
             py.None()
         };
 
-        // Create pandas Series
         let series_class = pd.getattr(py, "Series")?;
-        let series = if index.is_none(py) {
-            // No index specified, pandas will use default integer index
+        let series = if index_obj.is_none(py) {
             series_class.call1(py, (py_values,))?
         } else {
-            // Use the master channel values as index
-            series_class.call(py, (py_values,), Some([("index", index)].into_py_dict(py)))?
+            series_class.call(py, (py_values,), Some([("index", index_obj)].into_py_dict(py)))?
         };
-
-        // Set the series name to the channel name
-        series.setattr(py, "name", channel_name)?;
-
+        series.setattr(py, "name", name)?;
         Ok(series)
+    }
+
+    /// ``data["Speed"]`` — shorthand for :py:meth:`read` (numpy float64).
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<PyObject> {
+        self.read(py, name, None)
+    }
+
+    /// Byte ranges ``[(offset, length), ...]`` for a channel (escape hatch).
+    fn byte_ranges(&self, name: &str, group: Option<&str>) -> PyResult<Vec<(u64, u64)>> {
+        Ok(match group {
+            Some(g) => self.index.byte_ranges_in(g, name)?,
+            None => self.index.byte_ranges(name)?,
+        })
+    }
+
+    /// Metadata for every channel group (delegates to the bound index).
+    #[getter]
+    fn groups(&self) -> Vec<PyChannelGroupInfo> {
+        self.index.groups().iter().map(PyChannelGroupInfo::from_indexed).collect()
+    }
+
+    /// Find a channel group by name (first match), or ``None``.
+    fn group(&self, name: &str) -> Option<PyChannelGroupInfo> {
+        self.index.group(name).map(PyChannelGroupInfo::from_indexed)
+    }
+
+    /// Find a channel by name across all groups (first match), or ``None``.
+    fn channel(&self, name: &str) -> Option<PyChannelInfo> {
+        self.index.channel(name).map(PyChannelInfo::from_indexed)
+    }
+
+    /// Names of every named channel across all groups (duplicates kept).
+    #[getter]
+    fn channel_names(&self) -> Vec<String> {
+        self.index.channel_names().into_iter().map(String::from).collect()
     }
 }
 
@@ -1855,7 +1660,7 @@ impl PyMdfIndex {
 /// target_type : Optional[str]
 ///     Block type at the target offset, when known (e.g. ``"##DG"``).
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "LinkInfo")]
 #[derive(Clone)]
 pub struct PyLinkInfo {
     #[pyo3(get)]
@@ -1903,12 +1708,12 @@ impl From<LinkInfo> for PyLinkInfo {
 ///     Four-character MDF block tag (e.g. ``"##HD"``, ``"##CN"``).
 /// description : str
 ///     Short human-readable summary (e.g. ``"channel 'Speed' [f64@0..8]"``).
-/// links : list[PyLinkInfo]
+/// links : list[LinkInfo]
 ///     Outbound links to other blocks.
 /// extra : Optional[str]
 ///     Block-type-specific extra information, when applicable.
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "BlockInfo")]
 #[derive(Clone)]
 pub struct PyBlockInfo {
     #[pyo3(get)]
@@ -1961,7 +1766,7 @@ impl From<BlockInfo> for PyBlockInfo {
 /// ----------
 /// start, end, size : int
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "GapInfo")]
 #[derive(Clone)]
 pub struct PyGapInfo {
     #[pyo3(get)]
@@ -1995,11 +1800,11 @@ impl From<GapInfo> for PyGapInfo {
 
 /// Full structural layout of an MDF file: blocks, links, and gaps.
 ///
-/// Build one with :py:meth:`from_file` or :py:meth:`PyMDF.file_layout`. Use
+/// Build one with :py:meth:`from_file` or :py:meth:`Mdf.file_layout`. Use
 /// it to debug file structure, audit storage efficiency, or render a
 /// human-readable map of an MDF.
 #[gen_stub_pyclass]
-#[pyclass]
+#[pyclass(name = "FileLayout")]
 pub struct PyFileLayout {
     pub(crate) inner: FileLayout,
 }
@@ -2024,13 +1829,13 @@ impl PyFileLayout {
         self.inner.file_size
     }
 
-    /// List of all discovered blocks, sorted by offset (``list[PyBlockInfo]``).
+    /// List of all discovered blocks, sorted by offset (``list[BlockInfo]``).
     #[getter]
     fn blocks(&self) -> Vec<PyBlockInfo> {
         self.inner.blocks.iter().cloned().map(Into::into).collect()
     }
 
-    /// Byte ranges not covered by any visited block (``list[PyGapInfo]``).
+    /// Byte ranges not covered by any visited block (``list[GapInfo]``).
     #[getter]
     fn gaps(&self) -> Vec<PyGapInfo> {
         self.inner.gaps.iter().cloned().map(Into::into).collect()
@@ -2082,9 +1887,9 @@ impl PyFileLayout {
     }
 }
 
-/// Build a :class:`PyFileLayout` from an MDF file on disk.
+/// Build a :class:`FileLayout` from an MDF file on disk.
 ///
-/// Functional alias for :py:meth:`PyFileLayout.from_file`.
+/// Functional alias for :py:meth:`FileLayout.from_file`.
 ///
 /// Parameters
 /// ----------
@@ -2092,7 +1897,7 @@ impl PyFileLayout {
 ///
 /// Returns
 /// -------
-/// PyFileLayout
+/// FileLayout
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn file_layout_from_file(path: &str) -> PyResult<PyFileLayout> {
@@ -2219,9 +2024,9 @@ fn cut_mdf_by_utc(
 
 // Helper functions
 
-/// Wrap a Python ``float`` in a :class:`PyDecodedValue` of variant ``Float``.
+/// Wrap a Python ``float`` in a :class:`DecodedValue` of variant ``Float``.
 ///
-/// Use this to feed values into :py:meth:`PyMdfWriter.write_record` for any
+/// Use this to feed values into :py:meth:`MdfWriter.write_record` for any
 /// floating-point channel (32- or 64-bit; the value is truncated to the
 /// channel's declared bit width on encode).
 #[gen_stub_pyfunction]
@@ -2230,7 +2035,7 @@ fn create_float_value(value: f64) -> PyDecodedValue {
     PyDecodedValue::Float { value }
 }
 
-/// Wrap a Python ``int`` in a ``UnsignedInteger`` :class:`PyDecodedValue`.
+/// Wrap a Python ``int`` in a ``UnsignedInteger`` :class:`DecodedValue`.
 ///
 /// Suitable for any unsigned integer channel; the value is truncated to the
 /// channel's bit width on encode.
@@ -2240,14 +2045,14 @@ fn create_uint_value(value: u64) -> PyDecodedValue {
     PyDecodedValue::UnsignedInteger { value }
 }
 
-/// Wrap a Python ``int`` in a ``SignedInteger`` :class:`PyDecodedValue`.
+/// Wrap a Python ``int`` in a ``SignedInteger`` :class:`DecodedValue`.
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn create_int_value(value: i64) -> PyDecodedValue {
     PyDecodedValue::SignedInteger { value }
 }
 
-/// Wrap a Python ``str`` in a ``String`` :class:`PyDecodedValue`.
+/// Wrap a Python ``str`` in a ``String`` :class:`DecodedValue`.
 ///
 /// For string channels (``StringUtf8`` etc.). Encoding into the file is
 /// done according to the channel's declared string data type.
@@ -2257,28 +2062,28 @@ fn create_string_value(value: String) -> PyDecodedValue {
     PyDecodedValue::String { value }
 }
 
-/// Return the :class:`PyDataType` for little-endian unsigned integers.
+/// Return the :class:`DataType` for little-endian unsigned integers.
 ///
-/// Pair with :py:meth:`PyMdfWriter.add_channel` when you need an unsigned
+/// Pair with :py:meth:`MdfWriter.add_channel` when you need an unsigned
 /// integer channel of non-default width (otherwise see
-/// :py:meth:`PyMdfWriter.add_int_channel`).
+/// :py:meth:`MdfWriter.add_int_channel`).
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn create_data_type_uint_le() -> PyDataType {
     PyDataType { name: "UnsignedIntegerLE".to_string(), value: 0 }
 }
 
-/// Return the :class:`PyDataType` for little-endian IEEE-754 floats.
+/// Return the :class:`DataType` for little-endian IEEE-754 floats.
 ///
-/// Pair with :py:meth:`PyMdfWriter.add_channel`. Defaults to 32 bits when
-/// passed to ``add_channel`` — for f64 use :py:meth:`PyMdfWriter.add_float_channel`.
+/// Pair with :py:meth:`MdfWriter.add_channel`. Defaults to 32 bits when
+/// passed to ``add_channel`` — for f64 use :py:meth:`MdfWriter.add_float_channel`.
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn create_data_type_float_le() -> PyDataType {
     PyDataType { name: "FloatLE".to_string(), value: 4 }
 }
 
-/// Return the :class:`PyDataType` for UTF-8 encoded string channels.
+/// Return the :class:`DataType` for UTF-8 encoded string channels.
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn create_data_type_string_utf8() -> PyDataType {
@@ -2331,6 +2136,7 @@ pub fn init_mf4_rs_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyMDF>()?;
     m.add_class::<PyMdfWriter>()?;
     m.add_class::<PyMdfIndex>()?;
+    m.add_class::<PyMdfData>()?;
     m.add_class::<PyChannelGroupInfo>()?;
     m.add_class::<PyChannelInfo>()?;
     m.add_class::<PyDecodedValue>()?;

--- a/src/python.rs
+++ b/src/python.rs
@@ -505,6 +505,7 @@ fn signal_to_series(
 #[pyclass(name = "Mdf")]
 pub struct PyMDF {
     mdf: Box<MDF>,
+    path: String,
 }
 
 impl PyMDF {
@@ -552,7 +553,32 @@ impl PyMDF {
     #[new]
     fn new(path: &str) -> PyResult<Self> {
         let mdf = Box::new(MDF::from_file(path)?);
-        Ok(PyMDF { mdf })
+        Ok(PyMDF { mdf, path: path.to_string() })
+    }
+
+    /// The file path this reader was opened from.
+    #[getter]
+    fn source(&self) -> String {
+        self.path.clone()
+    }
+
+    /// A flat catalog of every channel as ``(source, group, channel)`` tuples.
+    ///
+    /// ``source`` is this file's path (same for every row). ``group`` /
+    /// ``channel`` are ``None`` if unnamed. Metadata only — no samples decoded.
+    ///
+    /// Returns
+    /// -------
+    /// list[tuple[str, Optional[str], Optional[str]]]
+    fn list_signals(&self) -> PyResult<Vec<(String, Option<String>, Option<String>)>> {
+        let mut out = Vec::new();
+        for group in self.mdf.channel_groups() {
+            let gname = group.name()?;
+            for channel in group.channels() {
+                out.push((self.path.clone(), gname.clone(), channel.name()?));
+            }
+        }
+        Ok(out)
     }
 
     /// Metadata for every channel group in the file, in file order.
@@ -1335,7 +1361,21 @@ impl PyMdfIndex {
     /// source is only range-requested when you call :py:meth:`read` / :py:meth:`values`.
     #[getter]
     fn source(&self) -> Option<String> {
-        source_to_string(self.index.source())
+        self.index.source_string()
+    }
+
+    /// A flat catalog of every channel as ``(source, group, channel)`` tuples.
+    ///
+    /// ``source`` is this index's attached source (file path or URL) — the same
+    /// for every row, so catalogs from several indexes concatenate cleanly.
+    /// Built from metadata only; no sample data is read (cheap even for a
+    /// URL-backed index). ``group`` / ``channel`` are ``None`` if unnamed.
+    ///
+    /// Returns
+    /// -------
+    /// list[tuple[Optional[str], Optional[str], Optional[str]]]
+    fn list_signals(&self) -> Vec<(Option<String>, Option<String>, Option<String>)> {
+        self.index.signal_list()
     }
 
     #[setter(source)]
@@ -1423,15 +1463,6 @@ impl PyMdfIndex {
             }
             Some(v) => self.index.set_file(v),
         }
-    }
-}
-
-/// Render an index [`Source`](crate::index::Source) as a display string.
-fn source_to_string(source: Option<&crate::index::Source>) -> Option<String> {
-    match source {
-        Some(crate::index::Source::File(p)) => Some(p.clone()),
-        Some(crate::index::Source::Url(u)) => Some(u.clone()),
-        None => None,
     }
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -414,6 +414,22 @@ fn check_pandas_available(py: Python) -> PyResult<PyObject> {
         ))
 }
 
+/// Parse a ``__getitem__`` key into ``(channel_name, optional_group_name)``.
+///
+/// Accepts a plain ``str`` (``obj["Speed"]``) or a ``(name, group)`` tuple
+/// (``obj["Speed", "Engine"]``) for disambiguating duplicate channel names.
+fn parse_lookup_key(key: &Bound<'_, PyAny>) -> PyResult<(String, Option<String>)> {
+    if let Ok((name, group)) = key.extract::<(String, String)>() {
+        Ok((name, Some(group)))
+    } else if let Ok(name) = key.extract::<String>() {
+        Ok((name, None))
+    } else {
+        Err(MdfException::new_err(
+            "channel key must be a name string or a (name, group) tuple",
+        ))
+    }
+}
+
 /// Build a ``pandas.Series`` from a decoded [`Signal`].
 ///
 /// `values` becomes the data; `timestamps` (master values in seconds) becomes
@@ -646,8 +662,12 @@ impl PyMDF {
     }
 
     /// ``mdf["Speed"]`` — shorthand for :py:meth:`read` (timestamp-indexed Series).
-    fn __getitem__(&self, py: Python, name: &str) -> PyResult<PyObject> {
-        self.read(py, name, None)
+    ///
+    /// Pass a ``(name, group)`` tuple to disambiguate a channel name shared by
+    /// several groups, e.g. ``mdf["Speed", "Engine"]``.
+    fn __getitem__(&self, py: Python, key: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        let (name, group) = parse_lookup_key(key)?;
+        self.read(py, &name, group.as_deref())
     }
 
     /// Build a :class:`FileLayout` describing every block in this file.
@@ -1384,8 +1404,12 @@ impl PyMdfIndex {
     }
 
     /// ``index["Speed"]`` — shorthand for :py:meth:`read` (timestamp-indexed Series).
-    fn __getitem__(&self, py: Python, name: &str) -> PyResult<PyObject> {
-        self.read(py, name, None)
+    ///
+    /// Pass a ``(name, group)`` tuple to disambiguate a channel name shared by
+    /// several groups, e.g. ``index["Speed", "Engine"]``.
+    fn __getitem__(&self, py: Python, key: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        let (name, group) = parse_lookup_key(key)?;
+        self.read(py, &name, group.as_deref())
     }
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -17,9 +17,7 @@ use std::collections::HashMap;
 
 use crate::api::mdf::MDF;
 use crate::writer::{MdfWriter, ColumnData};
-use crate::index::{
-    CachingRangeReader, FileRangeReader, HttpRangeReader, IndexedChannel, MdfIndex,
-};
+use crate::index::{IndexedChannel, MdfIndex};
 use crate::blocks::common::DataType;
 use crate::parsing::decoder::DecodedValue;
 use crate::error::MdfError;
@@ -416,110 +414,59 @@ fn check_pandas_available(py: Python) -> PyResult<PyObject> {
         ))
 }
 
-/// Helper function to find the master/time channel in a channel group
-/// Returns None if no master channel is found
-fn find_master_channel<'a>(channels: &Vec<crate::api::channel::Channel<'a>>) -> Option<usize> {
-    for (idx, channel) in channels.iter().enumerate() {
-        let block = channel.block();
-        // Master channels have channel_type == 2
-        if block.channel_type == 2 {
-            return Some(idx);
-        }
-    }
-    None
-}
-
-/// Helper function to find the master/time channel in indexed channels
-/// Returns None if no master channel is found
-fn find_master_channel_indexed(channels: &Vec<IndexedChannel>) -> Option<usize> {
-    for (idx, channel) in channels.iter().enumerate() {
-        // Master channels have channel_type == 2
-        if channel.channel_type == 2 {
-            return Some(idx);
-        }
-    }
-    None
-}
-
-/// Helper function to create a pandas DatetimeIndex from relative time values
+/// Build a ``pandas.Series`` from a decoded [`Signal`].
 ///
-/// # Arguments
-/// * `py` - Python GIL token
-/// * `pd` - pandas module PyObject
-/// * `relative_times` - Vector of relative time values (in seconds) as PyObjects
-/// * `start_ns` - Start time in nanoseconds since epoch
-///
-/// # Returns
-/// PyObject representing a pandas DatetimeIndex, or an error if conversion fails
-///
-/// # Error Handling
-/// This function handles multiple edge cases:
-/// - None values in master channel (converted to NaT - Not a Time)
-/// - Integer time values (i64, u64) in addition to float values
-/// - Negative time values that would create timestamps before epoch
-/// - Overflow/underflow when adding large time deltas
-fn create_datetime_index(
+/// `values` becomes the data; `timestamps` (master values in seconds) becomes
+/// the index. With a `start_time_ns` the index is a ``DatetimeIndex`` (relative
+/// seconds added to the file start); otherwise the raw seconds are used. When
+/// `timestamps` is empty (no master, or the channel *is* the master) a default
+/// integer index is used. The series ``name`` is set to the channel name.
+fn signal_to_series(
     py: Python,
     pd: &PyObject,
-    relative_times: &[PyObject],
-    start_ns: u64,
+    name: &str,
+    timestamps: &[f64],
+    values: Vec<Option<DecodedValue>>,
+    start_time_ns: Option<u64>,
 ) -> PyResult<PyObject> {
-    // Convert start time from nanoseconds to a pandas Timestamp
-    let to_datetime = pd.getattr(py, "to_datetime")?;
-    let start_timestamp = to_datetime.call(
-        py,
-        (start_ns,),
-        Some([("unit", "ns")].into_py_dict(py))
-    )?;
+    let py_values: Vec<PyObject> = values
+        .into_iter()
+        .map(|o| o.map(|dv| decoded_value_to_pyobject(dv, py)).unwrap_or_else(|| py.None()))
+        .collect();
 
-    // Create a Timedelta for each relative time and add to start time
-    let timedelta_class = pd.getattr(py, "Timedelta")?;
-    let nat = pd.getattr(py, "NaT")?;  // Not-a-Time for None values
-    let mut absolute_times = Vec::with_capacity(relative_times.len());
-
-    for rel_time in relative_times {
-        // Handle None values (invalid samples) - convert to NaT
-        if rel_time.is_none(py) {
-            absolute_times.push(nat.clone());
-            continue;
-        }
-
-        // Try to extract the time value as f64, then i64, then u64
-        // Master channels can be float or integer type
-        let seconds: f64 = if let Ok(f) = rel_time.extract::<f64>(py) {
-            f
-        } else if let Ok(i) = rel_time.extract::<i64>(py) {
-            i as f64
-        } else if let Ok(u) = rel_time.extract::<u64>(py) {
-            u as f64
+    let index: PyObject = if timestamps.is_empty() {
+        py.None()
+    } else {
+        let py_ts = PyArray1::from_vec_bound(py, timestamps.to_vec());
+        if let Some(start_ns) = start_time_ns {
+            // Vectorized: start_timestamp + to_timedelta(seconds).
+            let to_datetime = pd.getattr(py, "to_datetime")?;
+            let to_timedelta = pd.getattr(py, "to_timedelta")?;
+            let start_ts = to_datetime.call(
+                py, (start_ns,),
+                Some([("unit", "ns")].into_py_dict(py)),
+            )?;
+            let deltas = to_timedelta.call(
+                py, (py_ts.clone(),),
+                Some([("unit", "s")].into_py_dict(py)),
+            )?;
+            match deltas.call_method1(py, "__add__", (start_ts,)) {
+                Ok(dt_index) => dt_index,
+                Err(_) => py_ts.into(),
+            }
         } else {
-            // If we can't extract as any numeric type, use NaT
-            absolute_times.push(nat.clone());
-            continue;
-        };
+            py_ts.into()
+        }
+    };
 
-        // Check for edge cases that might cause overflow or invalid timestamps
-        // pandas datetime64[ns] has range: 1678-2262 (approximately)
-        // If start_ns + seconds would overflow, pandas will raise an OutOfBoundsDatetime error
-        // We'll let pandas handle this and propagate the error up
-
-        // Create a Timedelta in seconds and add to start time
-        // This can fail if the resulting timestamp is out of pandas' valid range
-        let delta = timedelta_class.call(
-            py,
-            (seconds,),
-            Some([("unit", "s")].into_py_dict(py))
-        )?;
-
-        let absolute_time = start_timestamp.call_method1(py, "__add__", (delta,))?;
-        absolute_times.push(absolute_time);
-    }
-
-    // Create DatetimeIndex from the list of timestamps
-    let datetime_index_class = pd.getattr(py, "DatetimeIndex")?;
-    let datetime_index = datetime_index_class.call1(py, (absolute_times,))?;
-
-    Ok(datetime_index)
+    let series_class = pd.getattr(py, "Series")?;
+    let series = if index.is_none(py) {
+        series_class.call1(py, (py_values,))?
+    } else {
+        series_class.call(py, (py_values,), Some([("index", index)].into_py_dict(py)))?
+    };
+    series.setattr(py, "name", name)?;
+    Ok(series)
 }
 
 /// Read-only handle to an MDF 4 file, backed by a memory-mapped buffer.
@@ -642,12 +589,13 @@ impl PyMDF {
         Ok(names)
     }
 
-    /// Read a numeric channel by name as a numpy ``float64`` array.
+    /// Read a channel as a ``pandas.Series`` of values indexed by timestamps.
     ///
-    /// This is the fast path: values are decoded directly into a numpy buffer,
-    /// invalid / non-decodable samples become ``NaN``. It does **not** apply
-    /// non-linear conversions — use :py:meth:`read_raw` for text / table /
-    /// value-to-text channels.
+    /// This is the primary read: the channel's samples (with all conversions
+    /// applied) are the data, and the group's master/time channel is the index
+    /// — a ``DatetimeIndex`` when the file has a start time, otherwise the raw
+    /// master seconds. If there is no master, or the requested channel *is* the
+    /// master, a default integer index is used.
     ///
     /// Parameters
     /// ----------
@@ -660,101 +608,45 @@ impl PyMDF {
     /// Raises
     /// ------
     /// MdfException
-    ///     If no matching channel exists.
-    fn read<'py>(&self, py: Python<'py>, name: &str, group: Option<&str>) -> PyResult<PyObject> {
+    ///     If no matching channel exists or pandas is not installed.
+    fn read(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<PyObject> {
+        let pd = check_pandas_available(py)?;
+        let start_time_ns = self.mdf.start_time_ns();
+        let signal = match group {
+            Some(gn) => self
+                .mdf
+                .group(gn)
+                .ok_or_else(|| MdfException::new_err(format!("Channel group '{}' not found", gn)))?
+                .signal(name)?,
+            None => self.mdf.signal(name)?,
+        };
+        let signal = signal.ok_or_else(|| {
+            MdfException::new_err(match group {
+                Some(gn) => format!("Channel '{}' not found in group '{}'", name, gn),
+                None => format!("Channel '{}' not found", name),
+            })
+        })?;
+        signal_to_series(py, &pd, &signal.name, &signal.timestamps, signal.values, start_time_ns)
+    }
+
+    /// Read a numeric channel by name as a plain numpy ``float64`` array.
+    ///
+    /// The fast, pandas-free path — just the values, no timestamp index.
+    /// Invalid / non-numeric samples are ``NaN``. Use :py:meth:`read` when you
+    /// want the timestamp-indexed Series and faithful (text / table) conversions.
+    ///
+    /// Parameters
+    /// ----------
+    /// name : str
+    /// group : Optional[str]
+    fn values<'py>(&self, py: Python<'py>, name: &str, group: Option<&str>) -> PyResult<PyObject> {
         let (g, idx) = self.find_group_channel(group, name)?;
         let values = g.channels()[idx].values_as_f64()?;
         Ok(PyArray1::from_vec_bound(py, values).into())
     }
 
-    /// Read a channel by name, returning native Python values with conversions.
-    ///
-    /// Slower than :py:meth:`read` but faithful to every conversion type
-    /// (linear, rational, table, value-to-text, …). ``None`` entries mark
-    /// invalid samples; valid samples are ``float`` / ``int`` / ``str`` /
-    /// ``bytes`` matching the channel.
-    ///
-    /// Parameters
-    /// ----------
-    /// name : str
-    /// group : Optional[str]
-    fn read_raw(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<Vec<Option<PyObject>>> {
-        let (g, idx) = self.find_group_channel(group, name)?;
-        let values = g.channels()[idx].values()?;
-        Ok(values
-            .into_iter()
-            .map(|opt| opt.map(|dv| decoded_value_to_pyobject(dv, py)))
-            .collect())
-    }
-
-    /// Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
-    ///
-    /// The series is indexed by the channel's group master (channel-type 2)
-    /// converted to a ``DatetimeIndex`` (relative seconds added to the file's
-    /// ``HD.abs_time``). If there is no master, or the requested channel *is*
-    /// the master, a default integer index is used; if the file has no start
-    /// time, master values are kept as a numeric index.
-    ///
-    /// Parameters
-    /// ----------
-    /// name : str
-    /// group : Optional[str]
-    ///
-    /// Raises
-    /// ------
-    /// MdfException
-    ///     If the channel is not found or pandas is not installed.
-    fn series(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<PyObject> {
-        let pd = check_pandas_available(py)?;
-        let start_time_ns = self.mdf.start_time_ns();
-        let (g, ch_idx) = self.find_group_channel(group, name)?;
-        let channels = g.channels();
-
-        let values = channels[ch_idx].values_as_f64()?;
-        let py_values = PyArray1::from_vec_bound(py, values);
-
-        let index: PyObject = if let Some(master_idx) = find_master_channel(&channels) {
-            if master_idx != ch_idx {
-                let master_values = channels[master_idx].values_as_f64()?;
-                let py_master = PyArray1::from_vec_bound(py, master_values);
-
-                if let Some(start_ns) = start_time_ns {
-                    let to_datetime = pd.getattr(py, "to_datetime")?;
-                    let to_timedelta = pd.getattr(py, "to_timedelta")?;
-                    let start_ts = to_datetime.call(
-                        py, (start_ns,),
-                        Some([("unit", "ns")].into_py_dict(py))
-                    )?;
-                    let deltas = to_timedelta.call(
-                        py, (py_master.clone(),),
-                        Some([("unit", "s")].into_py_dict(py))
-                    )?;
-                    match deltas.call_method1(py, "__add__", (start_ts,)) {
-                        Ok(datetime_index) => datetime_index,
-                        Err(_) => py_master.into(),
-                    }
-                } else {
-                    py_master.into()
-                }
-            } else {
-                py.None()
-            }
-        } else {
-            py.None()
-        };
-
-        let series_class = pd.getattr(py, "Series")?;
-        let series = if index.is_none(py) {
-            series_class.call1(py, (py_values,))?
-        } else {
-            series_class.call(py, (py_values,), Some([("index", index)].into_py_dict(py)))?
-        };
-        series.setattr(py, "name", name)?;
-        Ok(series)
-    }
-
-    /// ``mdf["Speed"]`` — shorthand for :py:meth:`read` (numpy float64).
-    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<PyObject> {
+    /// ``mdf["Speed"]`` — shorthand for :py:meth:`read` (timestamp-indexed Series).
+    fn __getitem__(&self, py: Python, name: &str) -> PyResult<PyObject> {
         self.read(py, name, None)
     }
 
@@ -1230,20 +1122,22 @@ impl PyMdfWriter {
 ///
 /// An index records the byte ranges of each channel, fully resolves every
 /// conversion block, and serialises to JSON. Navigate it by **name**
-/// (:py:attr:`groups`, :py:meth:`group`, :py:meth:`channel`); to read sample
-/// data, bind a source once with :py:meth:`open` / :py:meth:`open_url`, which
-/// return an :class:`MdfData` you index by channel name.
+/// (:py:attr:`groups`, :py:meth:`group`, :py:meth:`channel`). It also remembers
+/// its data :py:attr:`source` (file path or URL); reading is lazy — the
+/// byte-range request happens on :py:meth:`read` / :py:meth:`values`, never at
+/// build time.
 ///
 /// **Limitation:** compressed (``##DZ``) data blocks are not supported.
 ///
 /// Example
 /// -------
-/// >>> idx = mf4_rs.MdfIndex.from_file("recording.mf4")
+/// >>> idx = mf4_rs.MdfIndex.from_url("https://host/recording.mf4")  # only metadata fetched
+/// >>> speed = idx.read("Speed")            # pandas Series; range request happens now
+/// >>> rpm   = idx.values("RPM")            # numpy float64, no timestamp index
 /// >>> idx.save("recording.idx.json")
 /// >>> idx = mf4_rs.MdfIndex.load("recording.idx.json")
-/// >>> data = idx.open("recording.mf4")     # bind the data source once
-/// >>> speed = data["Speed"]                # numpy float64
-/// >>> rpm   = data.read("RPM", group="Engine")
+/// >>> idx.source = "recording.mf4"         # re-attach a source after load
+/// >>> t = idx.read("Speed")
 #[gen_stub_pyclass]
 #[pyclass(name = "MdfIndex")]
 pub struct PyMdfIndex {
@@ -1293,11 +1187,10 @@ impl PyMdfIndex {
     fn from_url(py: Python, url: &str, chunk_size: Option<u64>) -> PyResult<Self> {
         let url = url.to_string();
         let chunk = chunk_size.unwrap_or(1 << 20);
+        // The URL is remembered as the index's source; only metadata is fetched
+        // here — sample data is range-requested lazily on `read` / `values`.
         let index = py.allow_threads(move || -> Result<MdfIndex, MdfError> {
-            let mut http = HttpRangeReader::new(&url)?;
-            let file_size = http.probe_size()?;
-            let mut cached = CachingRangeReader::with_chunk_size(http, chunk);
-            MdfIndex::from_range_reader(&mut cached, file_size)
+            MdfIndex::from_url_with_chunk_size(&url, chunk)
         })?;
         Ok(PyMdfIndex { index })
     }
@@ -1336,7 +1229,7 @@ impl PyMdfIndex {
     /// Names of the groups that contain a channel called ``name``.
     ///
     /// Use this to disambiguate a channel name shared by several groups, then
-    /// pass the chosen group to :py:meth:`MdfData.read`.
+    /// pass the chosen group to :py:meth:`read` / :py:meth:`values`.
     fn groups_with_channel(&self, name: &str) -> Vec<String> {
         self.index
             .find_channels(name)
@@ -1414,234 +1307,107 @@ impl PyMdfIndex {
         self.index.file_size
     }
 
-    /// Bind this index to a local MDF file for reading sample data.
+    /// The data source attached to this index (file path or URL), or ``None``.
     ///
-    /// Returns an :class:`MdfData`; the file path is supplied once here and
-    /// reused for every subsequent read.
-    fn open(&self, path: &str) -> PyMdfData {
-        PyMdfData { index: self.index.clone(), source: DataSource::File(path.to_string()) }
+    /// Set automatically by :py:meth:`from_file` / :py:meth:`from_url`. After
+    /// :py:meth:`load` re-attach one by assigning this property (or calling
+    /// :py:meth:`set_source`). Building the index never reads sample data; the
+    /// source is only range-requested when you call :py:meth:`read` / :py:meth:`values`.
+    #[getter]
+    fn source(&self) -> Option<String> {
+        source_to_string(self.index.source())
     }
 
-    /// Bind this index to an HTTP / S3 URL for reading sample data via range
-    /// requests. Returns an :class:`MdfData`.
-    fn open_url(&self, url: &str) -> PyMdfData {
-        PyMdfData { index: self.index.clone(), source: DataSource::Url(url.to_string()) }
-    }
-}
-
-/// Where an :class:`MdfData` reads its bytes from.
-enum DataSource {
-    File(String),
-    Url(String),
-}
-
-/// A reader bound to an :class:`MdfIndex` and a single data source.
-///
-/// Obtained from :py:meth:`MdfIndex.open` / :py:meth:`MdfIndex.open_url`. The
-/// source (file path or URL) is given once; afterwards you read channels by
-/// **name**:
-///
-/// >>> data = idx.open("recording.mf4")
-/// >>> speed = data["Speed"]                  # numpy float64 (fast path)
-/// >>> status = data.read_raw("Status")       # native values + conversions
-/// >>> s = data.series("Speed")               # pandas Series, datetime index
-#[gen_stub_pyclass]
-#[pyclass(name = "MdfData")]
-pub struct PyMdfData {
-    index: MdfIndex,
-    source: DataSource,
-}
-
-impl PyMdfData {
-    /// Resolve an (optional group, name) pair to indices.
-    fn locate(&self, group: Option<&str>, name: &str) -> PyResult<(usize, usize)> {
-        match group {
-            Some(g) => self.index.locate_in(g, name).ok_or_else(|| {
-                MdfException::new_err(format!("Channel '{}' not found in group '{}'", name, g))
-            }),
-            None => self.index.locate(name).ok_or_else(|| {
-                MdfException::new_err(format!("Channel '{}' not found", name))
-            }),
-        }
+    #[setter(source)]
+    fn set_source_prop(&mut self, value: Option<&str>) {
+        self.apply_source(value);
     }
 
-    /// Read decoded values (with conversions) for a resolved channel index.
-    fn read_decoded(
-        &self,
-        py: Python,
-        g: usize,
-        c: usize,
-    ) -> PyResult<Vec<Option<DecodedValue>>> {
-        Ok(match &self.source {
-            DataSource::File(path) => {
-                let mut reader = FileRangeReader::new(path)?;
-                self.index.read_channel_values(g, c, &mut reader)?
-            }
-            DataSource::Url(url) => {
-                let url = url.clone();
-                py.allow_threads(move || -> Result<_, MdfError> {
-                    let http = HttpRangeReader::new(&url)?;
-                    let mut cached = CachingRangeReader::new(http);
-                    cached.set_bypass(true);
-                    self.index.read_channel_values(g, c, &mut cached)
-                })?
-            }
-        })
-    }
-}
-
-#[gen_stub_pymethods]
-#[pymethods]
-impl PyMdfData {
-    /// Read a numeric channel by name as a numpy ``float64`` array (fast path).
+    /// Attach (or clear) the data source used by :py:meth:`read` / :py:meth:`values`.
     ///
-    /// Invalid / non-decodable samples become ``NaN``. Linear conversions are
-    /// applied inline; for text / table conversions use :py:meth:`read_raw`.
+    /// A value starting with ``http://`` or ``https://`` is treated as a URL;
+    /// anything else as a local file path. Pass ``None`` to clear.
+    fn set_source(&mut self, value: Option<&str>) {
+        self.apply_source(value);
+    }
+
+    /// Read a channel as a ``pandas.Series`` of values indexed by timestamps.
+    ///
+    /// **Lazy:** the byte-range request to the attached source happens now, not
+    /// when the index was built. Values carry all conversions; the index is the
+    /// group master converted to a ``DatetimeIndex`` (or raw seconds / default
+    /// index when there is no start time / master).
     ///
     /// Parameters
     /// ----------
     /// name : str
     /// group : Optional[str]
     ///     Disambiguate by group when the channel name is not unique.
-    fn read<'py>(&self, py: Python<'py>, name: &str, group: Option<&str>) -> PyResult<PyObject> {
-        let (g, c) = self.locate(group, name)?;
-        let values = match &self.source {
-            DataSource::File(path) => {
-                let file = std::fs::File::open(path).map_err(MdfError::IOError)?;
-                let mmap = unsafe { memmap2::Mmap::map(&file) }.map_err(MdfError::IOError)?;
-                self.index.read_channel_values_from_slice_as_f64(g, c, &mmap)?
-            }
-            DataSource::Url(url) => {
-                let url = url.clone();
-                py.allow_threads(move || -> Result<Vec<f64>, MdfError> {
-                    let http = HttpRangeReader::new(&url)?;
-                    let mut cached = CachingRangeReader::new(http);
-                    cached.set_bypass(true);
-                    self.index.read_channel_values_as_f64(g, c, &mut cached)
-                })?
-            }
-        };
-        Ok(PyArray1::from_vec_bound(py, values).into())
-    }
-
-    /// Read a channel by name, returning native Python values + conversions.
-    ///
-    /// ``None`` marks invalid samples; valid samples are ``float`` / ``int`` /
-    /// ``str`` / ``bytes``. Faithful to every conversion type.
-    ///
-    /// Parameters
-    /// ----------
-    /// name : str
-    /// group : Optional[str]
-    fn read_raw(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<Vec<Option<PyObject>>> {
-        let (g, c) = self.locate(group, name)?;
-        let values = self.read_decoded(py, g, c)?;
-        Ok(values
-            .into_iter()
-            .map(|opt| opt.map(|dv| decoded_value_to_pyobject(dv, py)))
-            .collect())
-    }
-
-    /// Read a channel as a ``pandas.Series`` indexed by absolute timestamps.
-    ///
-    /// Indexed by the channel's group master converted to a ``DatetimeIndex``
-    /// (relative seconds added to the index's stored start time). Falls back to
-    /// a numeric / default index when there is no master or no start time.
-    ///
-    /// Parameters
-    /// ----------
-    /// name : str
-    /// group : Optional[str]
     ///
     /// Raises
     /// ------
     /// MdfException
-    ///     If the channel is not found or pandas is not installed.
-    fn series(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<PyObject> {
+    ///     If no source is attached, the channel is missing, or pandas is absent.
+    fn read(&self, py: Python, name: &str, group: Option<&str>) -> PyResult<PyObject> {
         let pd = check_pandas_available(py)?;
-        let start_time_ns = self.index.start_time_ns;
-        let (g, c) = self.locate(group, name)?;
-
-        let values = self.read_decoded(py, g, c)?;
-        let py_values: Vec<PyObject> = values
-            .into_iter()
-            .map(|o| o.map(|dv| decoded_value_to_pyobject(dv, py)).unwrap_or_else(|| py.None()))
-            .collect();
-
-        let group_ref = &self.index.groups()[g];
-        let index_obj: PyObject = if let Some(master_idx) = find_master_channel_indexed(&group_ref.channels) {
-            if master_idx != c {
-                let master_vals = self.read_decoded(py, g, master_idx)?;
-                let py_master: Vec<PyObject> = master_vals
-                    .into_iter()
-                    .map(|o| o.map(|dv| decoded_value_to_pyobject(dv, py)).unwrap_or_else(|| py.None()))
-                    .collect();
-
-                if py_master.len() != py_values.len() {
-                    return Err(MdfException::new_err(format!(
-                        "Master channel length ({}) does not match data channel length ({}) for channel '{}'",
-                        py_master.len(), py_values.len(), name
-                    )));
-                }
-
-                if let Some(start_ns) = start_time_ns {
-                    match create_datetime_index(py, &pd, &py_master, start_ns) {
-                        Ok(di) => di,
-                        Err(_) => py_master.to_object(py),
-                    }
-                } else {
-                    py_master.to_object(py)
-                }
-            } else {
-                py.None()
-            }
-        } else {
-            py.None()
-        };
-
-        let series_class = pd.getattr(py, "Series")?;
-        let series = if index_obj.is_none(py) {
-            series_class.call1(py, (py_values,))?
-        } else {
-            series_class.call(py, (py_values,), Some([("index", index_obj)].into_py_dict(py)))?
-        };
-        series.setattr(py, "name", name)?;
-        Ok(series)
+        // Release the GIL during the (potentially blocking, e.g. HTTP) read.
+        let signal = py.allow_threads(|| match group {
+            Some(g) => self.index.read_in(g, name),
+            None => self.index.read(name),
+        })?;
+        signal_to_series(
+            py, &pd, &signal.name, &signal.timestamps, signal.values, self.index.start_time_ns,
+        )
     }
 
-    /// ``data["Speed"]`` — shorthand for :py:meth:`read` (numpy float64).
-    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<PyObject> {
+    /// Read a numeric channel by name as a plain numpy ``float64`` array.
+    ///
+    /// Lazy fast path — just the values, no timestamp index, pandas-free.
+    /// Invalid / non-numeric samples are ``NaN``.
+    ///
+    /// Parameters
+    /// ----------
+    /// name : str
+    /// group : Optional[str]
+    fn values<'py>(&self, py: Python<'py>, name: &str, group: Option<&str>) -> PyResult<PyObject> {
+        let (g, c) = match group {
+            Some(gn) => self.index.locate_in(gn, name).ok_or_else(|| {
+                MdfException::new_err(format!("Channel '{}' not found in group '{}'", name, gn))
+            })?,
+            None => self.index.locate(name).ok_or_else(|| {
+                MdfException::new_err(format!("Channel '{}' not found", name))
+            })?,
+        };
+        // Release the GIL during the (potentially blocking, e.g. HTTP) read.
+        let values = py.allow_threads(|| self.index.read_values_f64_via_source(g, c))?;
+        Ok(PyArray1::from_vec_bound(py, values).into())
+    }
+
+    /// ``index["Speed"]`` — shorthand for :py:meth:`read` (timestamp-indexed Series).
+    fn __getitem__(&self, py: Python, name: &str) -> PyResult<PyObject> {
         self.read(py, name, None)
     }
+}
 
-    /// Byte ranges ``[(offset, length), ...]`` for a channel (escape hatch).
-    fn byte_ranges(&self, name: &str, group: Option<&str>) -> PyResult<Vec<(u64, u64)>> {
-        Ok(match group {
-            Some(g) => self.index.byte_ranges_in(g, name)?,
-            None => self.index.byte_ranges(name)?,
-        })
+impl PyMdfIndex {
+    /// Apply a string source, auto-detecting URL vs file path.
+    fn apply_source(&mut self, value: Option<&str>) {
+        match value {
+            None => self.index.source = None,
+            Some(v) if v.starts_with("http://") || v.starts_with("https://") => {
+                self.index.set_url(v);
+            }
+            Some(v) => self.index.set_file(v),
+        }
     }
+}
 
-    /// Metadata for every channel group (delegates to the bound index).
-    #[getter]
-    fn groups(&self) -> Vec<PyChannelGroupInfo> {
-        self.index.groups().iter().map(PyChannelGroupInfo::from_indexed).collect()
-    }
-
-    /// Find a channel group by name (first match), or ``None``.
-    fn group(&self, name: &str) -> Option<PyChannelGroupInfo> {
-        self.index.group(name).map(PyChannelGroupInfo::from_indexed)
-    }
-
-    /// Find a channel by name across all groups (first match), or ``None``.
-    fn channel(&self, name: &str) -> Option<PyChannelInfo> {
-        self.index.channel(name).map(PyChannelInfo::from_indexed)
-    }
-
-    /// Names of every named channel across all groups (duplicates kept).
-    #[getter]
-    fn channel_names(&self) -> Vec<String> {
-        self.index.channel_names().into_iter().map(String::from).collect()
+/// Render an index [`Source`](crate::index::Source) as a display string.
+fn source_to_string(source: Option<&crate::index::Source>) -> Option<String> {
+    match source {
+        Some(crate::index::Source::File(p)) => Some(p.clone()),
+        Some(crate::index::Source::Url(u)) => Some(u.clone()),
+        None => None,
     }
 }
 
@@ -2136,7 +1902,6 @@ pub fn init_mf4_rs_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyMDF>()?;
     m.add_class::<PyMdfWriter>()?;
     m.add_class::<PyMdfIndex>()?;
-    m.add_class::<PyMdfData>()?;
     m.add_class::<PyChannelGroupInfo>()?;
     m.add_class::<PyChannelInfo>()?;
     m.add_class::<PyDecodedValue>()?;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,0 +1,59 @@
+//! A decoded signal: a channel's samples paired with their master (time) axis.
+//!
+//! [`Signal`] is the Rust equivalent of a pandas `Series` — `values` indexed by
+//! `timestamps`. It is produced by the high-level readers ([`MDF::signal`],
+//! [`crate::index::MdfReader::signal`], [`crate::index::MdfIndex::read`]).
+//!
+//! [`MDF::signal`]: crate::api::mdf::MDF::signal
+
+use crate::parsing::decoder::DecodedValue;
+
+/// A channel's samples together with the group's master (time) axis.
+///
+/// `timestamps` holds the master channel's values in seconds. It is empty when
+/// the group has no master channel, or when the requested channel *is* the
+/// master (a master signal indexes itself). `values` always has one entry per
+/// record (`None` marks an invalid sample), with conversions applied.
+#[derive(Debug, Clone)]
+pub struct Signal {
+    /// Channel name.
+    pub name: String,
+    /// Physical unit, if any.
+    pub unit: Option<String>,
+    /// Master-channel values (seconds). Empty if there is no separate master.
+    pub timestamps: Vec<f64>,
+    /// One decoded value per record (`None` = invalid sample).
+    pub values: Vec<Option<DecodedValue>>,
+}
+
+impl Signal {
+    /// Number of samples.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// `true` if the signal has no samples.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// `true` if a separate master/time axis is attached.
+    pub fn has_timestamps(&self) -> bool {
+        !self.timestamps.is_empty()
+    }
+
+    /// Values as `f64`, with `NaN` for invalid or non-numeric samples.
+    pub fn values_f64(&self) -> Vec<f64> {
+        self.values.iter().map(decoded_opt_to_f64).collect()
+    }
+}
+
+/// Map an optional decoded value to `f64` (`NaN` for `None`/non-numeric).
+pub(crate) fn decoded_opt_to_f64(v: &Option<DecodedValue>) -> f64 {
+    match v {
+        Some(DecodedValue::Float(f)) => *f,
+        Some(DecodedValue::UnsignedInteger(u)) => *u as f64,
+        Some(DecodedValue::SignedInteger(i)) => *i as f64,
+        _ => f64::NAN,
+    }
+}

--- a/tests/bench_index_read.rs
+++ b/tests/bench_index_read.rs
@@ -1,16 +1,17 @@
-/// Index-based read performance benchmarks for mf4-rs
-/// Measures index read performance across all available paths:
-/// - FileRangeReader (original)
-/// - MmapRangeReader
-/// - Slice-based (zero-copy mmap)
-/// - f64 fast paths for each of the above
+/// Index-based read performance benchmarks for mf4-rs.
+///
+/// Measures index read performance across the public read paths, all addressed
+/// by channel name through a source-bound reader (`MdfIndex::open`):
+/// - FileRangeReader (DecodedValue + f64 fast path)
+/// - MmapRangeReader (DecodedValue + f64 fast path)
 /// - Direct MDF read for comparison
 use mf4_rs::api::mdf::MDF;
 use mf4_rs::blocks::common::DataType;
 use mf4_rs::error::MdfError;
 use mf4_rs::index::{FileRangeReader, MmapRangeReader, MdfIndex};
-use mf4_rs::parsing::decoder::DecodedValue;
 use mf4_rs::writer::MdfWriter;
+
+const CHANNELS: [&str; 4] = ["Time", "A", "B", "C"];
 
 fn temp_path(name: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!("mf4rs_bench_idx_{}.mf4", name))
@@ -53,10 +54,10 @@ fn write_f64_file(path: &std::path::Path, n: usize) -> Result<(), MdfError> {
         w.write_record(
             &cg,
             &[
-                DecodedValue::Float(v),
-                DecodedValue::Float(v * 2.0),
-                DecodedValue::Float(v * 3.0),
-                DecodedValue::Float(v * 4.0),
+                mf4_rs::parsing::decoder::DecodedValue::Float(v),
+                mf4_rs::parsing::decoder::DecodedValue::Float(v * 2.0),
+                mf4_rs::parsing::decoder::DecodedValue::Float(v * 3.0),
+                mf4_rs::parsing::decoder::DecodedValue::Float(v * 4.0),
             ],
         )?;
     }
@@ -74,15 +75,16 @@ fn bench_index_all_paths_100k() -> Result<(), MdfError> {
 
     let index = MdfIndex::from_file(path.to_str().unwrap())?;
     let iterations = 5;
+    let p = path.to_str().unwrap();
 
     // 1. FileRangeReader (DecodedValue)
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
-        let mut reader = FileRangeReader::new(path.to_str().unwrap())?;
+        let mut data = index.open(FileRangeReader::new(p)?);
         let mut total = 0usize;
-        for ch in 0..4 {
-            total += index.read_channel_values(0, ch, &mut reader)?.len();
+        for ch in CHANNELS {
+            total += data.values(ch)?.len();
         }
         assert_eq!(total, n * 4);
         times.push(start.elapsed());
@@ -94,10 +96,10 @@ fn bench_index_all_paths_100k() -> Result<(), MdfError> {
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
-        let mut reader = MmapRangeReader::new(path.to_str().unwrap())?;
+        let mut data = index.open(MmapRangeReader::new(p)?);
         let mut total = 0usize;
-        for ch in 0..4 {
-            total += index.read_channel_values(0, ch, &mut reader)?.len();
+        for ch in CHANNELS {
+            total += data.values(ch)?.len();
         }
         assert_eq!(total, n * 4);
         times.push(start.elapsed());
@@ -105,30 +107,14 @@ fn bench_index_all_paths_100k() -> Result<(), MdfError> {
     times.sort();
     let mmap_reader_ms = times[iterations / 2].as_secs_f64() * 1000.0;
 
-    // 3. Slice-based zero-copy (DecodedValue)
-    let file = std::fs::File::open(path.to_str().unwrap()).unwrap();
-    let mmap = unsafe { memmap2::Mmap::map(&file) }.unwrap();
+    // 3. FileRangeReader f64 fast path
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
+        let mut data = index.open(FileRangeReader::new(p)?);
         let mut total = 0usize;
-        for ch in 0..4 {
-            total += index.read_channel_values_from_slice(0, ch, &mmap)?.len();
-        }
-        assert_eq!(total, n * 4);
-        times.push(start.elapsed());
-    }
-    times.sort();
-    let slice_ms = times[iterations / 2].as_secs_f64() * 1000.0;
-
-    // 4. FileRangeReader f64 fast path
-    let mut times = Vec::new();
-    for _ in 0..iterations {
-        let start = std::time::Instant::now();
-        let mut reader = FileRangeReader::new(path.to_str().unwrap())?;
-        let mut total = 0usize;
-        for ch in 0..4 {
-            total += index.read_channel_values_as_f64(0, ch, &mut reader)?.len();
+        for ch in CHANNELS {
+            total += data.values_f64(ch)?.len();
         }
         assert_eq!(total, n * 4);
         times.push(start.elapsed());
@@ -136,25 +122,26 @@ fn bench_index_all_paths_100k() -> Result<(), MdfError> {
     times.sort();
     let f64_file_ms = times[iterations / 2].as_secs_f64() * 1000.0;
 
-    // 5. Slice-based f64 fast path (fastest)
+    // 4. MmapRangeReader f64 fast path
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
+        let mut data = index.open(MmapRangeReader::new(p)?);
         let mut total = 0usize;
-        for ch in 0..4 {
-            total += index.read_channel_values_from_slice_as_f64(0, ch, &mmap)?.len();
+        for ch in CHANNELS {
+            total += data.values_f64(ch)?.len();
         }
         assert_eq!(total, n * 4);
         times.push(start.elapsed());
     }
     times.sort();
-    let f64_slice_ms = times[iterations / 2].as_secs_f64() * 1000.0;
+    let f64_mmap_ms = times[iterations / 2].as_secs_f64() * 1000.0;
 
-    // 6. Direct MDF read (baseline)
+    // 5. Direct MDF read (baseline)
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
-        let mdf = MDF::from_file(path.to_str().unwrap())?;
+        let mdf = MDF::from_file(p)?;
         let mut total = 0usize;
         for group in mdf.channel_groups() {
             for channel in group.channels() {
@@ -167,11 +154,11 @@ fn bench_index_all_paths_100k() -> Result<(), MdfError> {
     times.sort();
     let direct_ms = times[iterations / 2].as_secs_f64() * 1000.0;
 
-    // 7. Direct MDF values_as_f64 (fastest baseline)
+    // 6. Direct MDF values_as_f64 (fastest baseline)
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
-        let mdf = MDF::from_file(path.to_str().unwrap())?;
+        let mdf = MDF::from_file(p)?;
         let mut total = 0usize;
         for group in mdf.channel_groups() {
             for channel in group.channels() {
@@ -189,14 +176,10 @@ fn bench_index_all_paths_100k() -> Result<(), MdfError> {
     eprintln!("                          Time(ms)  Throughput(M val/s)");
     eprintln!("  FileRangeReader:        {:7.1}    {:5.1}", file_reader_ms, val_count / file_reader_ms / 1000.0);
     eprintln!("  MmapRangeReader:        {:7.1}    {:5.1}", mmap_reader_ms, val_count / mmap_reader_ms / 1000.0);
-    eprintln!("  Slice (zero-copy):      {:7.1}    {:5.1}", slice_ms, val_count / slice_ms / 1000.0);
     eprintln!("  FileReader f64:         {:7.1}    {:5.1}", f64_file_ms, val_count / f64_file_ms / 1000.0);
-    eprintln!("  Slice f64 (fastest):    {:7.1}    {:5.1}", f64_slice_ms, val_count / f64_slice_ms / 1000.0);
+    eprintln!("  MmapReader f64:         {:7.1}    {:5.1}", f64_mmap_ms, val_count / f64_mmap_ms / 1000.0);
     eprintln!("  Direct MDF values():    {:7.1}    {:5.1}", direct_ms, val_count / direct_ms / 1000.0);
     eprintln!("  Direct MDF f64:         {:7.1}    {:5.1}", direct_f64_ms, val_count / direct_f64_ms / 1000.0);
-    eprintln!("  ---");
-    eprintln!("  Speedup slice_f64 vs FileReader: {:.1}x", file_reader_ms / f64_slice_ms);
-    eprintln!("  Speedup slice_f64 vs direct_f64: {:.2}x", direct_f64_ms / f64_slice_ms);
 
     cleanup(&path);
     Ok(())
@@ -211,15 +194,16 @@ fn bench_index_all_paths_1m() -> Result<(), MdfError> {
 
     let index = MdfIndex::from_file(path.to_str().unwrap())?;
     let iterations = 3;
+    let p = path.to_str().unwrap();
 
     // 1. FileRangeReader (DecodedValue)
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
-        let mut reader = FileRangeReader::new(path.to_str().unwrap())?;
+        let mut data = index.open(FileRangeReader::new(p)?);
         let mut total = 0usize;
-        for ch in 0..4 {
-            total += index.read_channel_values(0, ch, &mut reader)?.len();
+        for ch in CHANNELS {
+            total += data.values(ch)?.len();
         }
         assert_eq!(total, n * 4);
         times.push(start.elapsed());
@@ -227,27 +211,26 @@ fn bench_index_all_paths_1m() -> Result<(), MdfError> {
     times.sort();
     let file_reader_ms = times[iterations / 2].as_secs_f64() * 1000.0;
 
-    // 2. Slice f64 (fastest)
-    let file = std::fs::File::open(path.to_str().unwrap()).unwrap();
-    let mmap = unsafe { memmap2::Mmap::map(&file) }.unwrap();
+    // 2. MmapRangeReader f64 (fastest)
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
+        let mut data = index.open(MmapRangeReader::new(p)?);
         let mut total = 0usize;
-        for ch in 0..4 {
-            total += index.read_channel_values_from_slice_as_f64(0, ch, &mmap)?.len();
+        for ch in CHANNELS {
+            total += data.values_f64(ch)?.len();
         }
         assert_eq!(total, n * 4);
         times.push(start.elapsed());
     }
     times.sort();
-    let f64_slice_ms = times[iterations / 2].as_secs_f64() * 1000.0;
+    let f64_mmap_ms = times[iterations / 2].as_secs_f64() * 1000.0;
 
     // 3. Direct MDF f64 (baseline)
     let mut times = Vec::new();
     for _ in 0..iterations {
         let start = std::time::Instant::now();
-        let mdf = MDF::from_file(path.to_str().unwrap())?;
+        let mdf = MDF::from_file(p)?;
         let mut total = 0usize;
         for group in mdf.channel_groups() {
             for channel in group.channels() {
@@ -264,62 +247,48 @@ fn bench_index_all_paths_1m() -> Result<(), MdfError> {
     eprintln!("\n=== Index Read Benchmark: {} records x 4 channels ===", n);
     eprintln!("                          Time(ms)  Throughput(M val/s)");
     eprintln!("  FileRangeReader:        {:7.1}    {:5.1}", file_reader_ms, val_count / file_reader_ms / 1000.0);
-    eprintln!("  Slice f64 (fastest):    {:7.1}    {:5.1}", f64_slice_ms, val_count / f64_slice_ms / 1000.0);
+    eprintln!("  MmapReader f64:         {:7.1}    {:5.1}", f64_mmap_ms, val_count / f64_mmap_ms / 1000.0);
     eprintln!("  Direct MDF f64:         {:7.1}    {:5.1}", direct_f64_ms, val_count / direct_f64_ms / 1000.0);
-    eprintln!("  ---");
-    eprintln!("  Speedup slice_f64 vs FileReader: {:.1}x", file_reader_ms / f64_slice_ms);
-    eprintln!("  Speedup slice_f64 vs direct_f64: {:.2}x", direct_f64_ms / f64_slice_ms);
 
     cleanup(&path);
     Ok(())
 }
 
-/// Verify correctness: all paths produce identical results
+/// Verify correctness: all public read paths produce identical results.
 #[test]
 fn test_index_read_paths_consistency() -> Result<(), MdfError> {
+    use mf4_rs::parsing::decoder::DecodedValue;
+
     let path = temp_path("idx_consistency");
     cleanup(&path);
     let n = 1000usize;
     write_f64_file(&path, n)?;
 
     let index = MdfIndex::from_file(path.to_str().unwrap())?;
+    let p = path.to_str().unwrap();
 
-    // Read via all paths
-    let mut file_reader = FileRangeReader::new(path.to_str().unwrap())?;
-    let mut mmap_reader = MmapRangeReader::new(path.to_str().unwrap())?;
-    let file = std::fs::File::open(path.to_str().unwrap()).unwrap();
-    let mmap = unsafe { memmap2::Mmap::map(&file) }.unwrap();
+    let mut file_data = index.open(FileRangeReader::new(p)?);
+    let mut mmap_data = index.open(MmapRangeReader::new(p)?);
+    let mut file_f64 = index.open(FileRangeReader::new(p)?);
+    let mut mmap_f64 = index.open(MmapRangeReader::new(p)?);
 
-    for ch in 0..4 {
-        let vals_file = index.read_channel_values(0, ch, &mut file_reader)?;
-        let vals_mmap = index.read_channel_values(0, ch, &mut mmap_reader)?;
-        let vals_slice = index.read_channel_values_from_slice(0, ch, &mmap)?;
-
-        let f64_file = index.read_channel_values_as_f64(0, ch, &mut file_reader)?;
-        let f64_slice = index.read_channel_values_from_slice_as_f64(0, ch, &mmap)?;
+    for ch in CHANNELS {
+        let vals_file = file_data.values(ch)?;
+        let vals_mmap = mmap_data.values(ch)?;
+        let f64_file = file_f64.values_f64(ch)?;
+        let f64_mmap = mmap_f64.values_f64(ch)?;
 
         assert_eq!(vals_file.len(), n);
         assert_eq!(vals_mmap.len(), n);
-        assert_eq!(vals_slice.len(), n);
         assert_eq!(f64_file.len(), n);
-        assert_eq!(f64_slice.len(), n);
+        assert_eq!(f64_mmap.len(), n);
 
-        // All DecodedValue paths should be identical
         for i in 0..n {
             assert_eq!(vals_file[i], vals_mmap[i], "mmap mismatch at ch={} i={}", ch, i);
-            assert_eq!(vals_file[i], vals_slice[i], "slice mismatch at ch={} i={}", ch, i);
-        }
-
-        // f64 paths should match
-        for i in 0..n {
             assert!(
-                (f64_file[i] - f64_slice[i]).abs() < 1e-15,
-                "f64 mismatch at ch={} i={}: {} vs {}", ch, i, f64_file[i], f64_slice[i]
+                (f64_file[i] - f64_mmap[i]).abs() < 1e-15,
+                "f64 mismatch at ch={} i={}: {} vs {}", ch, i, f64_file[i], f64_mmap[i]
             );
-        }
-
-        // f64 should match DecodedValue float values
-        for i in 0..n {
             if let Some(DecodedValue::Float(expected)) = &vals_file[i] {
                 assert!(
                     (f64_file[i] - expected).abs() < 1e-15,

--- a/tests/bench_python.py
+++ b/tests/bench_python.py
@@ -66,7 +66,7 @@ def bench_read_mf4rs(path, channel_names, iterations=5):
         start = time.perf_counter()
         reader = mf4_rs.Mdf(path)
         for name in channel_names:
-            arr = reader.read(name)
+            arr = reader.values(name)
             if arr is not None:
                 total_values += len(arr)
         elapsed = time.perf_counter() - start

--- a/tests/bench_python.py
+++ b/tests/bench_python.py
@@ -40,7 +40,7 @@ def create_test_file_asammdf(path, n_records, n_float_channels=4):
 
 def create_test_file_mf4rs(path, n_records, n_float_channels=4):
     """Create a test MDF file using mf4-rs writer."""
-    w = mf4_rs.PyMdfWriter(path)
+    w = mf4_rs.MdfWriter(path)
     w.init_mdf_file()
     cg = w.add_channel_group()
     w.add_time_channel(cg, "Time")
@@ -64,9 +64,9 @@ def bench_read_mf4rs(path, channel_names, iterations=5):
     total_values = 0
     for _ in range(iterations):
         start = time.perf_counter()
-        reader = mf4_rs.PyMDF(path)
+        reader = mf4_rs.Mdf(path)
         for name in channel_names:
-            arr = reader.get_channel_values(name)
+            arr = reader.read(name)
             if arr is not None:
                 total_values += len(arr)
         elapsed = time.perf_counter() - start

--- a/tests/bench_write_python.py
+++ b/tests/bench_write_python.py
@@ -162,12 +162,12 @@ def verify_columns_correctness():
 
     # Read back with mf4-rs
     reader = mf4_rs.Mdf(path)
-    vals = reader.read("ch_0")
+    vals = reader.values("ch_0")
     assert vals is not None, "Channel ch_0 not found"
     assert len(vals) == n, f"Expected {n} values, got {len(vals)}"
     np.testing.assert_allclose(vals, ch0, rtol=1e-10)
 
-    vals1 = reader.read("ch_1")
+    vals1 = reader.values("ch_1")
     np.testing.assert_allclose(vals1, ch1, rtol=1e-10)
 
     print("  -> Correctness verified!")

--- a/tests/bench_write_python.py
+++ b/tests/bench_write_python.py
@@ -34,7 +34,7 @@ def bench_mf4rs_record_at_a_time(path, n_records, n_channels=4, iterations=3):
     """Old API: write_record in a loop."""
     times = []
     for _ in range(iterations):
-        w = mf4_rs.PyMdfWriter(path)
+        w = mf4_rs.MdfWriter(path)
         w.init_mdf_file()
         cg = w.add_channel_group()
         w.add_time_channel(cg, "Time")
@@ -70,7 +70,7 @@ def bench_mf4rs_columns_f64(path, n_records, n_channels=4, iterations=3):
 
     times = []
     for _ in range(iterations):
-        w = mf4_rs.PyMdfWriter(path)
+        w = mf4_rs.MdfWriter(path)
         w.init_mdf_file()
         cg = w.add_channel_group()
         w.add_time_channel(cg, "Time")
@@ -149,7 +149,7 @@ def verify_columns_correctness():
     ch0 = timestamps * 2.0
     ch1 = timestamps * 3.0
 
-    w = mf4_rs.PyMdfWriter(path)
+    w = mf4_rs.MdfWriter(path)
     w.init_mdf_file()
     cg = w.add_channel_group()
     w.add_time_channel(cg, "Time")
@@ -161,13 +161,13 @@ def verify_columns_correctness():
     w.finalize()
 
     # Read back with mf4-rs
-    reader = mf4_rs.PyMDF(path)
-    vals = reader.get_channel_values("ch_0")
+    reader = mf4_rs.Mdf(path)
+    vals = reader.read("ch_0")
     assert vals is not None, "Channel ch_0 not found"
     assert len(vals) == n, f"Expected {n} values, got {len(vals)}"
     np.testing.assert_allclose(vals, ch0, rtol=1e-10)
 
-    vals1 = reader.get_channel_values("ch_1")
+    vals1 = reader.read("ch_1")
     np.testing.assert_allclose(vals1, ch1, rtol=1e-10)
 
     print("  -> Correctness verified!")

--- a/tests/cloud_index.rs
+++ b/tests/cloud_index.rs
@@ -261,9 +261,10 @@ fn cloud_index_round_trips_within_budget() -> Result<(), MdfError> {
 
     let metadata_requests = cached.underlying_requests();
 
-    // Switch to bypass for value reads — large DT bodies should not
-    // pollute the chunk cache.
-    cached.set_bypass(true);
+    // Bind the same reader to the index for value reads. Switch to bypass —
+    // large DT bodies should not pollute the chunk cache.
+    let mut data = index.open(cached);
+    data.reader_mut().set_bypass(true);
 
     let targets: &[(&str, &str)] = &[
         ("Group 0", "ch_0_9"), // value-to-text conversion
@@ -274,13 +275,7 @@ fn cloud_index_round_trips_within_budget() -> Result<(), MdfError> {
     ];
 
     for (gn, cn) in targets {
-        let g = index
-            .find_channel_group_by_name(gn)
-            .unwrap_or_else(|| panic!("group {gn} not found"));
-        let c = index
-            .find_channel_by_name(g, cn)
-            .unwrap_or_else(|| panic!("channel {cn} not found in {gn}"));
-        let vals = index.read_channel_values(g, c, &mut cached)?;
+        let vals = data.values_in(gn, cn)?;
         assert_eq!(vals.len(), RECORDS, "{gn}/{cn} record count");
 
         if *gn == "Group 0" && *cn == "ch_0_9" {
@@ -292,6 +287,7 @@ fn cloud_index_round_trips_within_budget() -> Result<(), MdfError> {
         }
     }
 
+    let cached = data.into_inner();
     let elapsed = started.elapsed();
     let total_requests = cached.underlying_requests();
     let value_requests = total_requests - metadata_requests;
@@ -432,8 +428,9 @@ fn cloud_index_handles_scattered_metadata() -> Result<(), MdfError> {
         "metadata cache too inefficient: {metadata_requests} requests for {SCATTER_GROUPS} groups"
     );
 
-    // Read 5 channels via bypass mode.
-    cached.set_bypass(true);
+    // Read 5 channels via bypass mode through a bound reader.
+    let mut data = index.open(cached);
+    data.reader_mut().set_bypass(true);
     let targets: &[(&str, &str)] = &[
         ("Group 0", "t_0"),
         ("Group 1", "ch_1_2"),
@@ -442,9 +439,7 @@ fn cloud_index_handles_scattered_metadata() -> Result<(), MdfError> {
         ("Group 4", "ch_4_3"),
     ];
     for (gn, cn) in targets {
-        let g = index.find_channel_group_by_name(gn).unwrap();
-        let c = index.find_channel_by_name(g, cn).unwrap();
-        let vals = index.read_channel_values(g, c, &mut cached)?;
+        let vals = data.values_in(gn, cn)?;
         assert_eq!(vals.len(), SCATTER_RECORDS, "{gn}/{cn}");
         // Spot-check decoded value matches what was written.
         let group_idx: usize = gn
@@ -472,6 +467,7 @@ fn cloud_index_handles_scattered_metadata() -> Result<(), MdfError> {
         }
     }
 
+    let cached = data.into_inner();
     let elapsed = started.elapsed();
     let total_requests = cached.underlying_requests();
     let value_requests = total_requests - metadata_requests;

--- a/tests/enhanced_index_conversions.rs
+++ b/tests/enhanced_index_conversions.rs
@@ -2,7 +2,7 @@ use mf4_rs::writer::MdfWriter;
 use mf4_rs::blocks::common::{DataType, BlockHeader};
 use mf4_rs::blocks::conversion::{ConversionBlock, ConversionType};
 use mf4_rs::parsing::decoder::DecodedValue;
-use mf4_rs::index::{MdfIndex, FileRangeReader, IndexedChannel, IndexedChannelGroup};
+use mf4_rs::index::{MdfIndex, IndexedChannel, IndexedChannelGroup};
 use mf4_rs::api::mdf::MDF;
 use mf4_rs::error::MdfError;
 use std::fs;
@@ -63,8 +63,8 @@ fn test_enhanced_index_with_text_conversions() -> Result<(), MdfError> {
     
     // Test 3: Read channel values via enhanced index
     println!("=== Test 3: Reading Values via Enhanced Index ===");
-    let mut reader = FileRangeReader::new(mdf_path.to_str().unwrap())?;
-    let status_values_via_index = loaded_index.read_channel_values(0, 0, &mut reader)?;
+    let mut data = loaded_index.open_file(mdf_path.to_str().unwrap())?;
+    let status_values_via_index = data.values("Status")?;
     
     assert_eq!(status_values_via_index.len(), status_values.len());
     
@@ -81,7 +81,7 @@ fn test_enhanced_index_with_text_conversions() -> Result<(), MdfError> {
     // Test 4: Compare with direct MDF reading
     println!("=== Test 4: Comparing with Direct MDF Reading ===");
     let mdf = MDF::from_file(mdf_path.to_str().unwrap())?;
-    let direct_values = mdf.channel_groups()[0].channels()[0].values()?;
+    let direct_values = mdf.channel("Status").unwrap().values()?;
     
     assert_eq!(direct_values.len(), status_values_via_index.len());
     
@@ -91,7 +91,7 @@ fn test_enhanced_index_with_text_conversions() -> Result<(), MdfError> {
 
     // Test 5: Test name-based access
     println!("=== Test 5: Testing Name-based Access ===");
-    let status_by_name = loaded_index.read_channel_values_by_name("Status", &mut reader)?;
+    let status_by_name = data.values("Status")?;
     assert_eq!(status_by_name.len(), status_values.len());
     
     for (i, (expected, actual)) in status_values.iter().zip(status_by_name.iter()).enumerate() {
@@ -104,12 +104,11 @@ fn test_enhanced_index_with_text_conversions() -> Result<(), MdfError> {
 
     // Test 6: Test byte range calculations
     println!("=== Test 6: Testing Byte Range Calculations ===");
-    let byte_ranges = loaded_index.get_channel_byte_ranges(0, 0)?;
+    let byte_ranges = loaded_index.byte_ranges("Status")?;
     assert!(!byte_ranges.is_empty(), "Should have at least one byte range");
-    
-    let (total_bytes, range_count) = loaded_index.get_channel_byte_summary(0, 0)?;
+
+    let total_bytes: u64 = byte_ranges.iter().map(|(_, len)| len).sum();
     assert!(total_bytes > 0, "Should have positive total bytes");
-    assert_eq!(range_count, byte_ranges.len(), "Range count should match");
     
     // Clean up
     fs::remove_file(mdf_path)?;
@@ -278,6 +277,7 @@ fn test_index_serialization_with_resolved_data() -> Result<(), MdfError> {
     
     let index = MdfIndex {
         file_size: 1024,
+        start_time_ns: None,
         channel_groups: vec![indexed_group],
     };
     

--- a/tests/enhanced_index_conversions.rs
+++ b/tests/enhanced_index_conversions.rs
@@ -279,6 +279,7 @@ fn test_index_serialization_with_resolved_data() -> Result<(), MdfError> {
         file_size: 1024,
         start_time_ns: None,
         channel_groups: vec![indexed_group],
+        source: None,
     };
     
     // Test serialization

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -478,6 +478,73 @@ fn test_multiple_channels_same_name() -> Result<(), MdfError> {
 }
 
 #[test]
+fn test_signal_and_lazy_source() -> Result<(), MdfError> {
+    let mdf_path = std::env::temp_dir().join("signal_source_test.mf4");
+    let index_path = std::env::temp_dir().join("signal_source_test.json");
+    let _ = fs::remove_file(&mdf_path);
+    let _ = fs::remove_file(&index_path);
+
+    // Master (Time) + one data channel.
+    let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
+    writer.init_mdf_file()?;
+    let cg_id = writer.add_channel_group(None, |_| {})?;
+    let t_id = writer.add_channel(&cg_id, None, |ch| {
+        ch.data_type = DataType::FloatLE;
+        ch.name = Some("Time".to_string());
+        ch.bit_count = 64;
+    })?;
+    writer.set_time_channel(&t_id)?;
+    writer.add_channel(&cg_id, Some(&t_id), |ch| {
+        ch.data_type = DataType::FloatLE;
+        ch.name = Some("Speed".to_string());
+        ch.bit_count = 64;
+    })?;
+    writer.start_data_block_for_cg(&cg_id, 0)?;
+    for i in 0..10 {
+        writer.write_record(&cg_id, &[
+            DecodedValue::Float(i as f64 * 0.1),
+            DecodedValue::Float(i as f64 * 2.0),
+        ])?;
+    }
+    writer.finish_data_block(&cg_id)?;
+    writer.finalize()?;
+
+    // from_file remembers the source; read() is lazy and pairs values with the
+    // master/time axis.
+    let index = MdfIndex::from_file(mdf_path.to_str().unwrap())?;
+    assert!(index.source().is_some(), "from_file should attach a source");
+
+    let speed = index.read("Speed")?;
+    assert_eq!(speed.name, "Speed");
+    assert_eq!(speed.values.len(), 10);
+    assert_eq!(speed.timestamps.len(), 10, "Speed should carry the Time axis");
+    assert!((speed.timestamps[5] - 0.5).abs() < 1e-9);
+    if let Some(DecodedValue::Float(v)) = speed.values[5] {
+        assert!((v - 10.0).abs() < 1e-9);
+    } else {
+        panic!("expected Float value");
+    }
+
+    // The master channel indexes itself: no separate timestamps.
+    let time = index.read("Time")?;
+    assert_eq!(time.values.len(), 10);
+    assert!(!time.has_timestamps(), "master channel has no separate timestamps");
+
+    // Source is not persisted; re-attach after load, then read lazily.
+    index.save_to_file(index_path.to_str().unwrap())?;
+    let mut loaded = MdfIndex::load_from_file(index_path.to_str().unwrap())?;
+    assert!(loaded.source().is_none(), "source must not be serialized");
+    assert!(loaded.read("Speed").is_err(), "read without a source should error");
+    loaded.set_file(mdf_path.to_str().unwrap());
+    let speed2 = loaded.read("Speed")?;
+    assert_eq!(speed2.values_f64(), speed.values_f64());
+
+    let _ = fs::remove_file(mdf_path);
+    let _ = fs::remove_file(index_path);
+    Ok(())
+}
+
+#[test]
 fn test_channel_group_name_lookup() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("group_name_test.mf4");
 

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -1,7 +1,7 @@
 use mf4_rs::writer::MdfWriter;
 use mf4_rs::blocks::common::DataType;
 use mf4_rs::parsing::decoder::DecodedValue;
-use mf4_rs::index::{MdfIndex, FileRangeReader};
+use mf4_rs::index::MdfIndex;
 use mf4_rs::api::mdf::MDF;
 use mf4_rs::error::MdfError;
 use std::fs;
@@ -10,7 +10,7 @@ use std::fs;
 fn test_index_roundtrip() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("index_test.mf4");
     let index_path = std::env::temp_dir().join("index_test.json");
-    
+
     // Clean up any existing files
     if mdf_path.exists() { fs::remove_file(&mdf_path)?; }
     if index_path.exists() { fs::remove_file(&index_path)?; }
@@ -18,38 +18,38 @@ fn test_index_roundtrip() -> Result<(), MdfError> {
     // Create a test MDF file
     let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
     writer.init_mdf_file()?;
-    
+
     let cg_id = writer.add_channel_group(None, |_| {})?;
-    
+
     let time_ch_id = writer.add_channel(&cg_id, None, |ch| {
         ch.data_type = DataType::FloatLE;
         ch.name = Some("Time".to_string());
         ch.bit_count = 64;
     })?;
     writer.set_time_channel(&time_ch_id)?;
-    
+
     writer.add_channel(&cg_id, Some(&time_ch_id), |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
         ch.name = Some("Value".to_string());
         ch.bit_count = 32;
     })?;
-    
+
     writer.start_data_block_for_cg(&cg_id, 0)?;
-    
+
     // Write some test data
     let test_values = vec![
         (0.0, 100u64),
         (0.1, 200u64),
         (0.2, 300u64),
     ];
-    
+
     for (time, value) in &test_values {
         writer.write_record(&cg_id, &[
             DecodedValue::Float(*time),
             DecodedValue::UnsignedInteger(*value),
         ])?;
     }
-    
+
     writer.finish_data_block(&cg_id)?;
     writer.finalize()?;
 
@@ -59,23 +59,23 @@ fn test_index_roundtrip() -> Result<(), MdfError> {
 
     // Load index and verify structure
     let loaded_index = MdfIndex::load_from_file(index_path.to_str().unwrap())?;
-    
-    assert_eq!(loaded_index.channel_groups.len(), 1);
-    
-    let group = &loaded_index.channel_groups[0];
+
+    assert_eq!(loaded_index.groups().len(), 1);
+
+    let group = &loaded_index.groups()[0];
     assert_eq!(group.channels.len(), 2);
     assert_eq!(group.record_count, test_values.len() as u64);
-    
-    // Check channel metadata
-    let time_channel = &group.channels[0];
+
+    // Check channel metadata via name-based navigation
+    let time_channel = group.channel("Time").unwrap();
     assert_eq!(time_channel.name, Some("Time".to_string()));
     assert_eq!(time_channel.data_type, DataType::FloatLE);
-    assert_eq!(time_channel.channel_type, 2); // Master channel
-    
-    let value_channel = &group.channels[1];
+    assert!(time_channel.is_master());
+
+    let value_channel = group.channel("Value").unwrap();
     assert_eq!(value_channel.name, Some("Value".to_string()));
     assert_eq!(value_channel.data_type, DataType::UnsignedIntegerLE);
-    assert_eq!(value_channel.channel_type, 0); // Data channel
+    assert!(!value_channel.is_master());
 
     // Verify data blocks are indexed
     assert!(!group.data_blocks.is_empty());
@@ -83,14 +83,14 @@ fn test_index_roundtrip() -> Result<(), MdfError> {
     assert!(!data_block.is_compressed);
     assert!(data_block.size > 0);
 
-    // Test reading channel values via index
-    let mut reader = FileRangeReader::new(mdf_path.to_str().unwrap())?;
-    let time_values = loaded_index.read_channel_values(0, 0, &mut reader)?;
-    let value_values = loaded_index.read_channel_values(0, 1, &mut reader)?;
-    
+    // Test reading channel values by name via a bound reader
+    let mut data = loaded_index.open_file(mdf_path.to_str().unwrap())?;
+    let time_values = data.values("Time")?;
+    let value_values = data.values("Value")?;
+
     assert_eq!(time_values.len(), test_values.len());
     assert_eq!(value_values.len(), test_values.len());
-    
+
     // Verify the actual values
     for (i, (expected_time, expected_value)) in test_values.iter().enumerate() {
         if let Some(DecodedValue::Float(actual_time)) = time_values[i] {
@@ -98,7 +98,7 @@ fn test_index_roundtrip() -> Result<(), MdfError> {
         } else {
             panic!("Expected Float value for time channel");
         }
-        
+
         if let Some(DecodedValue::UnsignedInteger(actual_value)) = value_values[i] {
             assert_eq!(actual_value, *expected_value);
         } else {
@@ -117,40 +117,40 @@ fn test_index_roundtrip() -> Result<(), MdfError> {
 fn test_index_vs_direct_read() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("comparison_test.mf4");
     let index_path = std::env::temp_dir().join("comparison_index.json");
-    
+
     // Clean up
-    let _ = fs::remove_file(&mdf_path); // Ignore errors if file doesn't exist
-    let _ = fs::remove_file(&index_path); // Ignore errors if file doesn't exist
+    let _ = fs::remove_file(&mdf_path);
+    let _ = fs::remove_file(&index_path);
 
     // Create test file
     let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
     writer.init_mdf_file()?;
-    
+
     let cg_id = writer.add_channel_group(None, |_| {})?;
     writer.add_channel(&cg_id, None, |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
         ch.name = Some("TestChannel".to_string());
         ch.bit_count = 32;
     })?;
-    
+
     writer.start_data_block_for_cg(&cg_id, 0)?;
-    
+
     let test_data = vec![42u64, 123u64, 456u64, 789u64];
     for &value in &test_data {
         writer.write_record(&cg_id, &[DecodedValue::UnsignedInteger(value)])?;
     }
-    
+
     writer.finish_data_block(&cg_id)?;
     writer.finalize()?;
 
     // Read via direct MDF parsing
     let mdf = MDF::from_file(mdf_path.to_str().unwrap())?;
-    let direct_values = mdf.channel_groups()[0].channels()[0].values()?;
+    let direct_values = mdf.channel("TestChannel").unwrap().values()?;
 
-    // Read via index
+    // Read via index (bound reader, by name)
     let index = MdfIndex::from_file(mdf_path.to_str().unwrap())?;
-    let mut reader = FileRangeReader::new(mdf_path.to_str().unwrap())?;
-    let indexed_values = index.read_channel_values(0, 0, &mut reader)?;
+    let mut data = index.open_file(mdf_path.to_str().unwrap())?;
+    let indexed_values = data.values("TestChannel")?;
 
     // Compare results
     assert_eq!(direct_values.len(), indexed_values.len());
@@ -158,7 +158,7 @@ fn test_index_vs_direct_read() -> Result<(), MdfError> {
 
     for i in 0..test_data.len() {
         assert_eq!(direct_values[i], indexed_values[i]);
-        
+
         if let Some(DecodedValue::UnsignedInteger(value)) = indexed_values[i] {
             assert_eq!(value, test_data[i]);
         } else {
@@ -176,26 +176,26 @@ fn test_index_vs_direct_read() -> Result<(), MdfError> {
 #[test]
 fn test_index_metadata() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("metadata_test.mf4");
-    
+
     if mdf_path.exists() { fs::remove_file(&mdf_path)?; }
 
     // Create file with specific metadata
     let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
     writer.init_mdf_file()?;
-    
+
     let cg_id = writer.add_channel_group(None, |_| {})?;
     let float_ch_id = writer.add_channel(&cg_id, None, |ch| {
         ch.data_type = DataType::FloatLE;
         ch.name = Some("TestFloat".to_string());
         ch.bit_count = 32;
     })?;
-    
+
     writer.add_channel(&cg_id, Some(&float_ch_id), |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
         ch.name = Some("TestInt".to_string());
         ch.bit_count = 16;
     })?;
-    
+
     writer.start_data_block_for_cg(&cg_id, 0)?;
     writer.write_record(&cg_id, &[
         DecodedValue::Float(3.14),
@@ -204,32 +204,26 @@ fn test_index_metadata() -> Result<(), MdfError> {
     writer.finish_data_block(&cg_id)?;
     writer.finalize()?;
 
-    // Create index and verify metadata
+    // Create index and verify metadata via the name-based navigation
     let index = MdfIndex::from_file(mdf_path.to_str().unwrap())?;
-    
-    // Test channel groups listing
-    let groups = index.list_channel_groups();
+
+    let groups = index.groups();
     assert_eq!(groups.len(), 1);
-    assert_eq!(groups[0].1, "<unnamed>"); // group name
-    assert_eq!(groups[0].2, 2); // channel count
-    
-    // Test channels listing
-    let channels = index.list_channels(0).unwrap();
-    assert_eq!(channels.len(), 2);
-    
-    assert_eq!(channels[0].1, "TestFloat");
-    assert_eq!(channels[0].2, &DataType::FloatLE);
-    
-    assert_eq!(channels[1].1, "TestInt"); 
-    assert_eq!(channels[1].2, &DataType::UnsignedIntegerLE);
-    
-    // Test channel info retrieval
-    let float_info = index.get_channel_info(0, 0).unwrap();
+    assert_eq!(groups[0].name, None); // unnamed group
+    assert_eq!(groups[0].channels.len(), 2);
+
+    let channel_names = groups[0].channel_names();
+    assert_eq!(channel_names, vec!["TestFloat", "TestInt"]);
+
+    // Channel info retrieval by name
+    let float_info = index.channel("TestFloat").unwrap();
     assert_eq!(float_info.name, Some("TestFloat".to_string()));
+    assert_eq!(float_info.data_type, DataType::FloatLE);
     assert_eq!(float_info.bit_count, 32);
-    
-    let int_info = index.get_channel_info(0, 1).unwrap();
+
+    let int_info = index.channel("TestInt").unwrap();
     assert_eq!(int_info.name, Some("TestInt".to_string()));
+    assert_eq!(int_info.data_type, DataType::UnsignedIntegerLE);
     assert_eq!(int_info.bit_count, 16);
 
     fs::remove_file(mdf_path)?;
@@ -239,30 +233,30 @@ fn test_index_metadata() -> Result<(), MdfError> {
 #[test]
 fn test_byte_ranges() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("byte_ranges_test.mf4");
-    
+
     let _ = fs::remove_file(&mdf_path);
 
     // Create test file with known structure
     let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
     writer.init_mdf_file()?;
-    
+
     let cg_id = writer.add_channel_group(None, |_| {})?;
-    
+
     // Create channels with predictable sizes
-    writer.add_channel(&cg_id, None, |ch| {
+    let ch1_id = writer.add_channel(&cg_id, None, |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
         ch.name = Some("Ch1".to_string());
         ch.bit_count = 32; // 4 bytes
     })?;
-    
-    writer.add_channel(&cg_id, None, |ch| {
+
+    writer.add_channel(&cg_id, Some(&ch1_id), |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
         ch.name = Some("Ch2".to_string());
         ch.bit_count = 16; // 2 bytes
     })?;
-    
+
     writer.start_data_block_for_cg(&cg_id, 0)?;
-    
+
     // Write exactly 5 records
     for i in 0..5 {
         writer.write_record(&cg_id, &[
@@ -270,34 +264,30 @@ fn test_byte_ranges() -> Result<(), MdfError> {
             DecodedValue::UnsignedInteger(i * 10),
         ])?;
     }
-    
+
     writer.finish_data_block(&cg_id)?;
     writer.finalize()?;
 
-    // Create index and test byte ranges
+    // Create index and test byte ranges by name
     let index = MdfIndex::from_file(mdf_path.to_str().unwrap())?;
-    
-    // Test getting byte ranges for all data
-    let ranges = index.get_channel_byte_ranges(0, 0)?; // First channel
+
+    // Byte ranges for all data of a channel
+    let ranges = index.byte_ranges("Ch1")?;
     assert!(!ranges.is_empty(), "Should have at least one byte range");
-    
-    // Test byte summary
-    let (total_bytes, range_count) = index.get_channel_byte_summary(0, 0)?;
+
+    let total_bytes: u64 = ranges.iter().map(|(_, len)| len).sum();
     assert!(total_bytes > 0, "Should have positive total bytes");
-    assert_eq!(range_count, ranges.len(), "Range count should match");
-    
-    // Test partial record reading
-    let partial_ranges = index.get_channel_byte_ranges_for_records(0, 0, 1, 3)?; // Records 1-3
+
+    // Partial record reading
+    let partial_ranges = index.byte_ranges_for_records("Ch1", 1, 3)?;
     assert!(!partial_ranges.is_empty(), "Should have byte ranges for partial records");
-    
-    // Verify that partial range is smaller than full range
+
     let partial_total: u64 = partial_ranges.iter().map(|(_, len)| len).sum();
     assert!(partial_total <= total_bytes, "Partial range should be <= total range");
-    
-    // Test error conditions
-    assert!(index.get_channel_byte_ranges(99, 0).is_err(), "Invalid group index should error");
-    assert!(index.get_channel_byte_ranges(0, 99).is_err(), "Invalid channel index should error");
-    assert!(index.get_channel_byte_ranges_for_records(0, 0, 10, 1).is_err(), "Out of range records should error");
+
+    // Error conditions
+    assert!(index.byte_ranges("DoesNotExist").is_err(), "Unknown channel should error");
+    assert!(index.byte_ranges_for_records("Ch1", 10, 1).is_err(), "Out of range records should error");
 
     let _ = fs::remove_file(mdf_path);
     Ok(())
@@ -306,52 +296,50 @@ fn test_byte_ranges() -> Result<(), MdfError> {
 #[test]
 fn test_byte_ranges_accuracy() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("byte_accuracy_test.mf4");
-    
+
     let _ = fs::remove_file(&mdf_path);
 
     // Create simple test file
     let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
     writer.init_mdf_file()?;
-    
+
     let cg_id = writer.add_channel_group(None, |_| {})?;
     writer.add_channel(&cg_id, None, |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
+        ch.name = Some("Val".to_string());
         ch.bit_count = 32;
     })?;
-    
+
     writer.start_data_block_for_cg(&cg_id, 0)?;
     writer.write_record(&cg_id, &[DecodedValue::UnsignedInteger(0x12345678)])?;
     writer.write_record(&cg_id, &[DecodedValue::UnsignedInteger(0xABCDEF00)])?;
     writer.finish_data_block(&cg_id)?;
     writer.finalize()?;
 
-    // Create index and test reading via byte ranges vs direct reading
+    // Create index and read values via the bound reader
     let index = MdfIndex::from_file(mdf_path.to_str().unwrap())?;
-    let mut reader = FileRangeReader::new(mdf_path.to_str().unwrap())?;
-    let direct_values = index.read_channel_values(0, 0, &mut reader)?;
-    
+    let mut data = index.open_file(mdf_path.to_str().unwrap())?;
+    let values = data.values("Val")?;
+
     // Verify the values are what we expect
-    assert_eq!(direct_values.len(), 2);
-    if let Some(DecodedValue::UnsignedInteger(val)) = direct_values[0] {
+    assert_eq!(values.len(), 2);
+    if let Some(DecodedValue::UnsignedInteger(val)) = values[0] {
         assert_eq!(val, 0x12345678);
     } else {
         panic!("Expected UnsignedInteger");
     }
-    
-    if let Some(DecodedValue::UnsignedInteger(val)) = direct_values[1] {
+
+    if let Some(DecodedValue::UnsignedInteger(val)) = values[1] {
         assert_eq!(val, 0xABCDEF00);
     } else {
         panic!("Expected UnsignedInteger");
     }
 
-    // Get byte ranges and verify they make sense
-    let _ranges = index.get_channel_byte_ranges(0, 0)?;
-    let (total_bytes, _) = index.get_channel_byte_summary(0, 0)?;
-    
-    // For 2 records of 32-bit integers, we expect at least 8 bytes of data
-    // (though there might be more due to record structure)
+    // Byte ranges should make sense
+    let ranges = index.byte_ranges("Val")?;
+    let total_bytes: u64 = ranges.iter().map(|(_, len)| len).sum();
     assert!(total_bytes >= 8, "Should have at least 8 bytes for 2x32-bit values");
-    
+
     let _ = fs::remove_file(mdf_path);
     Ok(())
 }
@@ -359,86 +347,81 @@ fn test_byte_ranges_accuracy() -> Result<(), MdfError> {
 #[test]
 fn test_name_based_lookup() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("name_lookup_test.mf4");
-    
+
     let _ = fs::remove_file(&mdf_path);
 
     // Create test file with named channels
     let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
     writer.init_mdf_file()?;
-    
+
     let cg_id = writer.add_channel_group(None, |_| {})?;
-    
-    // Create master channel (following working test pattern)
+
+    // Create master channel
     let temp_ch_id = writer.add_channel(&cg_id, None, |ch| {
         ch.data_type = DataType::FloatLE;
         ch.name = Some("Temperature".to_string());
         ch.bit_count = 32;
     })?;
     writer.set_time_channel(&temp_ch_id)?;
-    
+
     // Create data channel with master as parent
     writer.add_channel(&cg_id, Some(&temp_ch_id), |ch| {
         ch.data_type = DataType::UnsignedIntegerLE;
         ch.name = Some("Speed".to_string());
         ch.bit_count = 16;
     })?;
-    
+
     writer.start_data_block_for_cg(&cg_id, 0)?;
     writer.write_record(&cg_id, &[
-        DecodedValue::Float(25.5),     // Temperature
-        DecodedValue::UnsignedInteger(120),  // Speed 
+        DecodedValue::Float(25.5),           // Temperature
+        DecodedValue::UnsignedInteger(120),  // Speed
     ])?;
     writer.finish_data_block(&cg_id)?;
     writer.finalize()?;
 
     // Create index and test name-based lookups
     let index = MdfIndex::from_file(mdf_path.to_str().unwrap())?;
-    
-    // Test name-based lookups
-    
-    // Test finding channels by name
-    assert_eq!(index.find_channel_by_name_global("Temperature"), Some((0, 0)));
-    assert_eq!(index.find_channel_by_name_global("Speed"), Some((0, 1)));
-    assert_eq!(index.find_channel_by_name_global("NonExistent"), None);
-    
-    // Test finding channel within specific group
-    assert_eq!(index.find_channel_by_name(0, "Temperature"), Some(0));
-    assert_eq!(index.find_channel_by_name(0, "Speed"), Some(1));
-    assert_eq!(index.find_channel_by_name(0, "NonExistent"), None);
-    assert_eq!(index.find_channel_by_name(99, "Temperature"), None); // Invalid group
-    
-    // Test get channel info by name
-    let (group_idx, channel_idx, channel_info) = index.get_channel_info_by_name("Temperature").unwrap();
-    assert_eq!(group_idx, 0);
-    assert_eq!(channel_idx, 0);
+
+    // Locating channels by name
+    assert_eq!(index.find_channels("Temperature"), vec![(0, 0)]);
+    assert_eq!(index.find_channels("Speed"), vec![(0, 1)]);
+    assert!(index.channel("NonExistent").is_none());
+
+    // Group-scoped lookup
+    assert!(index.groups()[0].channel("Temperature").is_some());
+    assert!(index.groups()[0].channel("Speed").is_some());
+    assert!(index.groups()[0].channel("NonExistent").is_none());
+
+    // Channel info by name
+    let channel_info = index.channel("Temperature").unwrap();
     assert_eq!(channel_info.name, Some("Temperature".to_string()));
     assert_eq!(channel_info.data_type, DataType::FloatLE);
-    
-    // Test reading channel by name
-    let mut reader = FileRangeReader::new(mdf_path.to_str().unwrap())?;
-    let temp_values = index.read_channel_values_by_name("Temperature", &mut reader)?;
+
+    // Reading channels by name through the bound reader
+    let mut data = index.open_file(mdf_path.to_str().unwrap())?;
+    let temp_values = data.values("Temperature")?;
     assert_eq!(temp_values.len(), 1);
     if let Some(DecodedValue::Float(temp)) = temp_values[0] {
         assert!((temp - 25.5).abs() < 0.001);
     } else {
         panic!("Expected Float value");
     }
-    
-    let speed_values = index.read_channel_values_by_name("Speed", &mut reader)?;
+
+    let speed_values = data.values("Speed")?;
     assert_eq!(speed_values.len(), 1);
     if let Some(DecodedValue::UnsignedInteger(speed)) = speed_values[0] {
         assert_eq!(speed, 120);
     } else {
         panic!("Expected UnsignedInteger value");
     }
-    
-    // Test error for non-existent channel
-    assert!(index.read_channel_values_by_name("NonExistent", &mut reader).is_err());
-    
-    // Test byte ranges by name
-    let ranges = index.get_channel_byte_ranges_by_name("Temperature")?;
+
+    // Error for non-existent channel
+    assert!(data.values("NonExistent").is_err());
+
+    // Byte ranges by name
+    let ranges = index.byte_ranges("Temperature")?;
     assert!(!ranges.is_empty());
-    
+
     let _ = fs::remove_file(mdf_path);
     Ok(())
 }
@@ -446,13 +429,13 @@ fn test_name_based_lookup() -> Result<(), MdfError> {
 #[test]
 fn test_multiple_channels_same_name() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("duplicate_names_test.mf4");
-    
+
     let _ = fs::remove_file(&mdf_path);
 
     // Create test file with duplicate channel names across groups
     let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
     writer.init_mdf_file()?;
-    
+
     // First group
     let cg1_id = writer.add_channel_group(None, |_| {})?;
     writer.add_channel(&cg1_id, None, |ch| {
@@ -460,7 +443,7 @@ fn test_multiple_channels_same_name() -> Result<(), MdfError> {
         ch.name = Some("Temperature".to_string());
         ch.bit_count = 32;
     })?;
-    
+
     // Second group
     let cg2_id = writer.add_channel_group(Some(&cg1_id), |_| {})?;
     writer.add_channel(&cg2_id, None, |ch| {
@@ -468,28 +451,28 @@ fn test_multiple_channels_same_name() -> Result<(), MdfError> {
         ch.name = Some("Temperature".to_string());
         ch.bit_count = 32;
     })?;
-    
+
     writer.start_data_block_for_cg(&cg1_id, 0)?;
     writer.write_record(&cg1_id, &[DecodedValue::Float(25.0)])?;
     writer.finish_data_block(&cg1_id)?;
-    
+
     writer.start_data_block_for_cg(&cg2_id, 0)?;
     writer.write_record(&cg2_id, &[DecodedValue::Float(30.0)])?;
     writer.finish_data_block(&cg2_id)?;
-    
+
     writer.finalize()?;
 
     // Test finding all channels with same name
     let index = MdfIndex::from_file(mdf_path.to_str().unwrap())?;
-    
-    let all_temp_channels = index.find_all_channels_by_name("Temperature");
+
+    let all_temp_channels = index.find_channels("Temperature");
     assert_eq!(all_temp_channels.len(), 2);
     assert!(all_temp_channels.contains(&(0, 0))); // First group, first channel
     assert!(all_temp_channels.contains(&(1, 0))); // Second group, first channel
-    
-    // find_channel_by_name_global should return the first match
-    assert_eq!(index.find_channel_by_name_global("Temperature"), Some((0, 0)));
-    
+
+    // index.channel() should return the first match
+    assert_eq!(index.find_channels("Temperature")[0], (0, 0));
+
     let _ = fs::remove_file(mdf_path);
     Ok(())
 }
@@ -497,22 +480,20 @@ fn test_multiple_channels_same_name() -> Result<(), MdfError> {
 #[test]
 fn test_channel_group_name_lookup() -> Result<(), MdfError> {
     let mdf_path = std::env::temp_dir().join("group_name_test.mf4");
-    
+
     let _ = fs::remove_file(&mdf_path);
 
-    // Create test file - note: the current writer doesn't seem to support 
-    // setting channel group names directly, so we'll test with unnamed groups
     let mut writer = MdfWriter::new(mdf_path.to_str().unwrap())?;
     writer.init_mdf_file()?;
-    
+
     let _cg1_id = writer.add_channel_group(None, |_| {})?;
     writer.finalize()?;
 
     let index = MdfIndex::from_file(mdf_path.to_str().unwrap())?;
-    
-    // Test that unnamed groups return None when searching by name
-    assert_eq!(index.find_channel_group_by_name("SomeGroup"), None);
-    
+
+    // Unnamed groups are not found by name
+    assert!(index.group("SomeGroup").is_none());
+
     let _ = fs::remove_file(mdf_path);
     Ok(())
 }

--- a/tests/test_asammdf_interop.py
+++ b/tests/test_asammdf_interop.py
@@ -91,7 +91,7 @@ def cleanup(*paths):
 def write_mf4rs_basic():
     """Write a basic file with mf4-rs: time + float + int, 100 records."""
     path = tmp("mf4rs_basic")
-    w = mf4_rs.PyMdfWriter(path)
+    w = mf4_rs.MdfWriter(path)
     w.init_mdf_file()
     cg = w.add_channel_group("Group1")
     t = w.add_time_channel(cg, "Time")
@@ -156,11 +156,11 @@ def test_mf4rs_reads_asammdf_basic():
     """mf4-rs can read a basic asammdf file and get correct values."""
     path = write_asammdf_basic()
     try:
-        mdf = mf4_rs.PyMDF(path)
-        groups = mdf.channel_groups()
+        mdf = mf4_rs.Mdf(path)
+        groups = mdf.groups
         assert len(groups) >= 1, f"expected >=1 groups, got {len(groups)}"
 
-        temp_vals = mdf.get_channel_values("Temperature")
+        temp_vals = mdf.read("Temperature")
         assert temp_vals is not None, "Temperature channel not found"
         assert len(temp_vals) == 100, f"expected 100 values, got {len(temp_vals)}"
         assert abs(temp_vals[0] - 20.0) < 0.001, f"first temp should be 20.0, got {temp_vals[0]}"
@@ -174,9 +174,9 @@ def test_cross_read_values_match():
     path = write_mf4rs_basic()
     try:
         # Read with mf4-rs (returns numpy arrays)
-        rs_mdf = mf4_rs.PyMDF(path)
-        rs_temp = rs_mdf.get_channel_values("Temperature")
-        rs_count = rs_mdf.get_channel_values("Counter")
+        rs_mdf = mf4_rs.Mdf(path)
+        rs_temp = rs_mdf.read("Temperature")
+        rs_count = rs_mdf.read("Counter")
 
         # Read with asammdf
         a_mdf = AsamMDF(path)
@@ -218,8 +218,8 @@ def test_all_integer_types_roundtrip():
             mdf.save(path, overwrite=True)
             mdf.close()
 
-            rs_mdf = mf4_rs.PyMDF(path)
-            rs_vals = rs_mdf.get_channel_values(name)
+            rs_mdf = mf4_rs.Mdf(path)
+            rs_vals = rs_mdf.read(name)
             assert len(rs_vals) == len(values), f"{name}: expected {len(values)}, got {len(rs_vals)}"
             for orig, read in zip(values, rs_vals):
                 # Values are returned as float64, which has 53 bits of precision.
@@ -250,8 +250,8 @@ def test_float_types_roundtrip():
             mdf.save(path, overwrite=True)
             mdf.close()
 
-            rs_mdf = mf4_rs.PyMDF(path)
-            rs_vals = rs_mdf.get_channel_values(name)
+            rs_mdf = mf4_rs.Mdf(path)
+            rs_vals = rs_mdf.read(name)
             assert len(rs_vals) == len(values), f"{name}: expected {len(values)}, got {len(rs_vals)}"
             for orig, read in zip(values, rs_vals):
                 tol = 1e-2 if name == "float32" else 1e-10
@@ -264,7 +264,7 @@ def test_multi_group_cross_read():
     """Multi-group mf4-rs files are correctly parsed by asammdf."""
     path = tmp("multi_group")
     try:
-        w = mf4_rs.PyMdfWriter(path)
+        w = mf4_rs.MdfWriter(path)
         w.init_mdf_file()
 
         cg1 = w.add_channel_group("G1")
@@ -348,8 +348,8 @@ def test_compressed_file_fails_gracefully():
         mdf.close()
 
         try:
-            rs_mdf = mf4_rs.PyMDF(path)
-            _ = rs_mdf.get_channel_values("data")
+            rs_mdf = mf4_rs.Mdf(path)
+            _ = rs_mdf.read("data")
             # If we get here without error, compression support was added
             print("    (NOTE: ##DZ reading now works - update comparison docs)")
         except Exception as e:
@@ -364,7 +364,7 @@ def test_data_block_splitting_cross_read():
     path = tmp("dl_split")
     try:
         # Write enough data to trigger 4MB split: 300K records x 16 bytes = 4.8MB
-        w = mf4_rs.PyMdfWriter(path)
+        w = mf4_rs.MdfWriter(path)
         w.init_mdf_file()
         cg = w.add_channel_group("big")
         w.add_float_channel(cg, "a")
@@ -458,8 +458,8 @@ def test_units_and_comments_readable():
         mdf.save(path, overwrite=True)
         mdf.close()
 
-        rs_mdf = mf4_rs.PyMDF(path)
-        channels = rs_mdf.get_all_channels()
+        rs_mdf = mf4_rs.Mdf(path)
+        channels = [ch for g in rs_mdf.groups for ch in g.channels]
         temp_ch = [ch for ch in channels if ch.name == "Temperature"]
         assert len(temp_ch) >= 1, "Temperature channel not found"
         assert temp_ch[0].unit == "degC", f"expected unit='degC', got '{temp_ch[0].unit}'"
@@ -475,7 +475,7 @@ def test_performance_write():
     path = tmp("perf_write")
     try:
         n = 100_000
-        w = mf4_rs.PyMdfWriter(path)
+        w = mf4_rs.MdfWriter(path)
         w.init_mdf_file()
         cg = w.add_channel_group("perf")
         w.add_time_channel(cg, "Time")
@@ -548,8 +548,8 @@ def test_cut_asammdf_vlsd_string():
         # mf4-rs reads numeric channels of the cut output correctly. (The
         # Python binding's f64 fast path can't return strings — strings round
         # through native Rust APIs and through asammdf below.)
-        cut_mdf = mf4_rs.PyMDF(out)
-        ctrs = cut_mdf.get_channel_values("Counter")
+        cut_mdf = mf4_rs.Mdf(out)
+        ctrs = cut_mdf.read("Counter")
         assert ctrs is not None, "Counter not found in cut file"
         assert [int(c) for c in ctrs] == [20, 30, 40, 50, 60], list(ctrs)
 
@@ -576,9 +576,9 @@ def test_performance_read():
     try:
         start = time.time()
         for _ in range(10):
-            mdf = mf4_rs.PyMDF(path)
+            mdf = mf4_rs.Mdf(path)
             for name in ["Time", "Temperature", "Counter"]:
-                mdf.get_channel_values(name)
+                mdf.read(name)
         elapsed = time.time() - start
         assert elapsed < 10, f"10x read took {elapsed:.1f}s - performance regression"
         print(f"    (10x read in {elapsed:.3f}s)")

--- a/tests/test_asammdf_interop.py
+++ b/tests/test_asammdf_interop.py
@@ -160,7 +160,7 @@ def test_mf4rs_reads_asammdf_basic():
         groups = mdf.groups
         assert len(groups) >= 1, f"expected >=1 groups, got {len(groups)}"
 
-        temp_vals = mdf.read("Temperature")
+        temp_vals = mdf.values("Temperature")
         assert temp_vals is not None, "Temperature channel not found"
         assert len(temp_vals) == 100, f"expected 100 values, got {len(temp_vals)}"
         assert abs(temp_vals[0] - 20.0) < 0.001, f"first temp should be 20.0, got {temp_vals[0]}"
@@ -175,8 +175,8 @@ def test_cross_read_values_match():
     try:
         # Read with mf4-rs (returns numpy arrays)
         rs_mdf = mf4_rs.Mdf(path)
-        rs_temp = rs_mdf.read("Temperature")
-        rs_count = rs_mdf.read("Counter")
+        rs_temp = rs_mdf.values("Temperature")
+        rs_count = rs_mdf.values("Counter")
 
         # Read with asammdf
         a_mdf = AsamMDF(path)
@@ -219,7 +219,7 @@ def test_all_integer_types_roundtrip():
             mdf.close()
 
             rs_mdf = mf4_rs.Mdf(path)
-            rs_vals = rs_mdf.read(name)
+            rs_vals = rs_mdf.values(name)
             assert len(rs_vals) == len(values), f"{name}: expected {len(values)}, got {len(rs_vals)}"
             for orig, read in zip(values, rs_vals):
                 # Values are returned as float64, which has 53 bits of precision.
@@ -251,7 +251,7 @@ def test_float_types_roundtrip():
             mdf.close()
 
             rs_mdf = mf4_rs.Mdf(path)
-            rs_vals = rs_mdf.read(name)
+            rs_vals = rs_mdf.values(name)
             assert len(rs_vals) == len(values), f"{name}: expected {len(values)}, got {len(rs_vals)}"
             for orig, read in zip(values, rs_vals):
                 tol = 1e-2 if name == "float32" else 1e-10
@@ -349,7 +349,7 @@ def test_compressed_file_fails_gracefully():
 
         try:
             rs_mdf = mf4_rs.Mdf(path)
-            _ = rs_mdf.read("data")
+            _ = rs_mdf.values("data")
             # If we get here without error, compression support was added
             print("    (NOTE: ##DZ reading now works - update comparison docs)")
         except Exception as e:
@@ -549,7 +549,7 @@ def test_cut_asammdf_vlsd_string():
         # Python binding's f64 fast path can't return strings — strings round
         # through native Rust APIs and through asammdf below.)
         cut_mdf = mf4_rs.Mdf(out)
-        ctrs = cut_mdf.read("Counter")
+        ctrs = cut_mdf.values("Counter")
         assert ctrs is not None, "Counter not found in cut file"
         assert [int(c) for c in ctrs] == [20, 30, 40, 50, 60], list(ctrs)
 
@@ -578,7 +578,7 @@ def test_performance_read():
         for _ in range(10):
             mdf = mf4_rs.Mdf(path)
             for name in ["Time", "Temperature", "Counter"]:
-                mdf.read(name)
+                mdf.values(name)
         elapsed = time.time() - start
         assert elapsed < 10, f"10x read took {elapsed:.1f}s - performance regression"
         print(f"    (10x read in {elapsed:.3f}s)")

--- a/tests/test_cloud_index.py
+++ b/tests/test_cloud_index.py
@@ -1,9 +1,9 @@
 """Python integration test for cloud (HTTP) MDF indexing.
 
-Builds a fixture MF4 file using ``mf4_rs.PyMdfWriter``, serves it from a
+Builds a fixture MF4 file using ``mf4_rs.MdfWriter``, serves it from a
 local HTTP server with single-range ``Range: bytes=A-B`` support, then
-exercises ``PyMdfIndex.from_url`` and the ``*_from_url`` value-read
-methods.
+exercises ``MdfIndex.from_url`` and the ``MdfData`` reads bound to a URL
+source.
 
 Exits 0 (skip) if the bindings are not importable so this can sit in CI
 without forcing a maturin build on every runner.
@@ -34,7 +34,7 @@ RECORDS = 200
 
 
 def build_fixture(path: str) -> None:
-    w = mf4_rs.PyMdfWriter(path)
+    w = mf4_rs.MdfWriter(path)
     w.init_mdf_file()
     cg_ids: list[str] = []
     cn_ids_per_group: list[list[str]] = []
@@ -151,17 +151,19 @@ def main() -> int:
             time.sleep(0.05)
 
             t0 = time.perf_counter()
-            idx = mf4_rs.PyMdfIndex.from_url(url)
+            idx = mf4_rs.MdfIndex.from_url(url)
             print(f"index built in {(time.perf_counter() - t0)*1000:.1f} ms")
 
-            groups = idx.list_channel_groups()
+            groups = idx.groups
             assert len(groups) == GROUPS, f"got {len(groups)} groups, want {GROUPS}"
-            for i, (gi, name, count) in enumerate(groups):
-                assert gi == i
-                assert name == f"Group {i}", f"group {i} name = {name!r}"
-                assert count == CHANNELS_PER_GROUP
+            for i, g in enumerate(groups):
+                assert g.name == f"Group {i}", f"group {i} name = {g.name!r}"
+                assert g.channel_count == CHANNELS_PER_GROUP
 
-            # Read 5 channels via URL.
+            # Bind sources once: a local file and the same file over HTTP.
+            local = idx.open(str(mf4_path))
+            remote = idx.open_url(url)
+
             t0 = time.perf_counter()
             targets = [
                 ("Group 0", "t_0"),
@@ -171,8 +173,8 @@ def main() -> int:
                 ("Group 4", "ch_4_3"),
             ]
             for gn, cn in targets:
-                vals = idx.read_channel_values_by_group_and_name(gn, cn, str(mf4_path))
-                vals_url = idx.read_channel_values_by_name_from_url(cn, url)
+                vals = local.read_raw(cn, group=gn)
+                vals_url = remote.read_raw(cn)
                 assert len(vals) == RECORDS, f"{gn}/{cn} local len {len(vals)}"
                 assert len(vals_url) == RECORDS, f"{gn}/{cn} url len {len(vals_url)}"
                 # Spot-check one decoded value matches between local and URL paths.
@@ -184,10 +186,10 @@ def main() -> int:
             # Round-trip via JSON to confirm the index is self-contained after
             # being built over HTTP.
             json_path = tmp_path / "fixture.idx.json"
-            idx.save_to_file(str(json_path))
-            idx2 = mf4_rs.PyMdfIndex.load_from_file(str(json_path))
-            vals_a = idx.read_channel_values_by_name_from_url("ch_2_4", url)
-            vals_b = idx2.read_channel_values_by_name_from_url("ch_2_4", url)
+            idx.save(str(json_path))
+            idx2 = mf4_rs.MdfIndex.load(str(json_path))
+            vals_a = remote.read_raw("ch_2_4")
+            vals_b = idx2.open_url(url).read_raw("ch_2_4")
             assert vals_a == vals_b, "JSON round-trip changed decoded values"
             print(f"index json: {json_path.stat().st_size} bytes")
 

--- a/tests/test_cloud_index.py
+++ b/tests/test_cloud_index.py
@@ -160,9 +160,11 @@ def main() -> int:
                 assert g.name == f"Group {i}", f"group {i} name = {g.name!r}"
                 assert g.channel_count == CHANNELS_PER_GROUP
 
-            # Bind sources once: a local file and the same file over HTTP.
-            local = idx.open(str(mf4_path))
-            remote = idx.open_url(url)
+            # The index built over HTTP remembers its URL source.
+            assert idx.source == url, f"index source = {idx.source!r}"
+
+            # A second index over the same file on disk, for cross-checking.
+            idx_local = mf4_rs.MdfIndex.from_file(str(mf4_path))
 
             t0 = time.perf_counter()
             targets = [
@@ -173,23 +175,25 @@ def main() -> int:
                 ("Group 4", "ch_4_3"),
             ]
             for gn, cn in targets:
-                vals = local.read_raw(cn, group=gn)
-                vals_url = remote.read_raw(cn)
+                vals = idx_local.values(cn, group=gn)   # local file, lazy
+                vals_url = idx.values(cn)               # URL range request, lazy
                 assert len(vals) == RECORDS, f"{gn}/{cn} local len {len(vals)}"
                 assert len(vals_url) == RECORDS, f"{gn}/{cn} url len {len(vals_url)}"
-                # Spot-check one decoded value matches between local and URL paths.
+                # Spot-check one value matches between local and URL paths.
                 assert vals[10] == vals_url[10], (
                     f"{gn}/{cn}[10] differs: local={vals[10]!r} url={vals_url[10]!r}"
                 )
             print(f"5 channel reads (local + url) in {(time.perf_counter() - t0)*1000:.1f} ms")
 
-            # Round-trip via JSON to confirm the index is self-contained after
-            # being built over HTTP.
+            # Round-trip via JSON: the source is environment-local, so it is not
+            # persisted — re-attach the URL after loading.
             json_path = tmp_path / "fixture.idx.json"
             idx.save(str(json_path))
             idx2 = mf4_rs.MdfIndex.load(str(json_path))
-            vals_a = remote.read_raw("ch_2_4")
-            vals_b = idx2.open_url(url).read_raw("ch_2_4")
+            assert idx2.source is None, "source should not be persisted in JSON"
+            idx2.source = url
+            vals_a = idx.values("ch_2_4").tolist()
+            vals_b = idx2.values("ch_2_4").tolist()
             assert vals_a == vals_b, "JSON round-trip changed decoded values"
             print(f"index json: {json_path.stat().st_size} bytes")
 


### PR DESCRIPTION
## Summary

Complete, user-friendly redesign of the reader and index interfaces (Rust crate + Python bindings). Everything is addressed by **name** (channel-group name + signal name) — there are no `(group_index, channel_index)` arguments in the public API anymore — reads return a signal (timestamps **and** values), and the index remembers its data source so reads are a single, lazy step.

This is a **breaking change** to the public Rust crate API and the Python bindings.

## Name-based navigation (clean break)

The ~25 `*_by_name` / `*_by_index` / `list_*` / `find_*` index variants are gone from the public surface (kept `pub(crate)` as internals).

- **Rust `MdfIndex`**: `groups()`, `group(name)`, `channel(name)`, `channel_in(group, name)`, `channel_names()`, `find_channels(name)`; `IndexedChannelGroup::channel()/channel_names()/master_channel()`; `IndexedChannel::is_master()/is_vlsd()`.
- **Rust `MDF`** reader gains `group(name)` / `channel(name)`.
- **Python**: `Py` prefix dropped (`Mdf`, `MdfWriter`, `MdfIndex`, `ChannelInfo`, `GroupInfo`, `DataType`, `DecodedValue`, `FileLayout`/`BlockInfo`/`LinkInfo`/`GapInfo`). `GroupInfo` now carries its `channels`.

## Signals: timestamps + values

- New Rust `Signal { name, unit, timestamps: Vec<f64>, values: Vec<Option<DecodedValue>> }` (`src/signal.rs`) — the equivalent of a pandas `Series` — produced by `MDF::signal()`, `ChannelGroup::signal()`, `MdfReader::signal()`, and `MdfIndex::read()`.
- **Python**: `read(name, group=None)` returns a `pandas.Series` (values indexed by the group master, conversions applied); `values(name, group=None)` returns a plain numpy `float64` array (no timestamps, pandas-free). `__getitem__` == `read`.

## Source-aware, lazy index

- `MdfIndex` remembers its data `Source` (`File(path)` / `Url(url)`), set by `from_file` / `from_url`. The source is **not** serialized — re-attach after `load` via `set_file`/`set_url`/`set_source` (Python: settable `source` property that autodetects `http(s)://`).
- Building an index never reads sample data; the byte-range request happens lazily on `read` / `values` (GIL released in Python so concurrent/remote reads don't block).
- `open()` / `open_file()` still return an `MdfReader` for explicit/custom `ByteRangeReader` backends.

## Duplicate names

Every read takes an optional `group=` (Rust `*_in` variants), `groups_with_channel(name)` lists where a name lives, and `__getitem__` accepts a `(name, group)` tuple, e.g. `idx["Speed", "Engine"]`.

## Signal catalog

`MdfIndex.list_signals()` (Rust `signal_list()`) returns `(source, group, channel)` rows — built from metadata only, so it's cheap even for a URL-backed index. `Mdf` gains a `source` getter + `list_signals()` for parity.

## Testing

- Full Rust suite green (incl. the previously-broken `enhanced_index_conversions`, the http `cloud_index` tests, and a new `test_signal_and_lazy_source`).
- Python: asammdf interop 15/15, the cloud index test (lazy URL reads), and manual smoke tests of signals/source/duplicate-name/tuple lookup/catalog.
- Type stubs (`.pyi`) regenerated; `CLAUDE.md` and module docs updated.

BREAKING CHANGE: the public Rust crate API and Python binding class/method names are reworked around name-based navigation; positional index reads and the old `*_by_name`/`list_*`/`find_*` methods are removed, and Python classes lose the `Py` prefix.

https://claude.ai/code/session_011C4Y63JyNVHeDCAM8HKW8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_011C4Y63JyNVHeDCAM8HKW8Q)_