### PR TITLE
feat: support VLSD channel reads through the index reader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ The codebase is organized into distinct layers. The module structure is defined 
   - Metadata navigation: `groups()`, `group(name)`, `channel(name)`, `channel_in(group, name)`, `channel_names()`, `find_channels(name)`; `IndexedChannelGroup::channel(name)` / `channel_names()` / `master_channel()`; `IndexedChannel::is_master()` / `is_vlsd()`
   - Lazy reads via the attached source: `read(name)` / `read_in(group, name)` return a [`Signal`](src/signal.rs) (values paired with the group master/time axis); `source()` / `set_file()` / `set_url()` / `set_source()` manage the source
   - Explicit/custom readers: bind with `open(reader)` / `open_file(path)` → returns an `MdfReader` with `values(name)` / `values_in()` / `values_f64()` / `signal(name)` / `signal_in()`; `reader_mut()` / `into_inner()` expose the underlying `ByteRangeReader`
-  - Byte ranges (power-user / partial reads): `byte_ranges(name)`, `byte_ranges_in(group, name)`, `byte_ranges_for_records(name, start, count)`
+  - Byte ranges (power-user / partial reads): `byte_ranges(name)`, `byte_ranges_in(group, name)`, `byte_ranges_for_records(name, start, count)` — refused for VLSD channels, whose offset indirection a static range cannot express (use `read()` / `values()` instead)
   - Conversions are resolved during index creation, enabling reads with empty `file_data` (`&[]`)
 - `Signal` (`src/signal.rs`) is the Rust equivalent of a pandas `Series`: `{ name, unit, timestamps: Vec<f64>, values: Vec<Option<DecodedValue>> }`, with `values_f64()` / `has_timestamps()`. Produced by `MDF::signal()`, `ChannelGroup::signal()`, `MdfReader::signal()`, and `MdfIndex::read()`.
 
@@ -307,6 +307,7 @@ Channels with `channel_type == 1` and a non-zero `data` field store variable-len
 - `IndexedChannel.conversion` stores a `ConversionBlock` with `resolved_texts`, `resolved_conversions`, and `default_conversion` populated
 - When reading via index, conversions are applied with empty file data (`&[]`) since all dependencies are resolved
 - `ByteRangeReader` trait allows plugging in HTTP, S3, or other data sources
+- VLSD channels (`channel_type == 1`) are readable through the index: each channel's `##SD` fragment chain is captured at build time in `IndexedChannel.vlsd_data_blocks`, and `read()` / `values()` resolve each record's inline 8-byte offset into that stream. `byte_ranges()` still refuses VLSD channels (a static range cannot express the offset indirection). Old JSON indexes without `vlsd_data_blocks` load fine but error on VLSD reads with a "rebuild the index" message.
 - Compressed blocks (`##DZ`) are not yet supported in the index reader
 
 ### When Modifying Conversions
@@ -487,4 +488,4 @@ release the GIL during decoding.
 2. **64-bit float default**: The Python `add_float_channel()` writes 64-bit; the generic `add_channel` with `create_data_type_float_le()` still defaults to 32 bits via `default_bits()`
 3. **Channel group metadata**: The `add_channel_group(name)` parameter is silently ignored - either implement it or remove the parameter
 4. **File history block**: Write a `##FH` block for tool identification and traceability (the header timestamp is now written; `##FH` is still absent)
-5. **Unsorted files / VLSD via index**: unsorted data groups and index-based VLSD reads are refused with clear errors; implementing them would unlock CANedge-style bus logs
+5. **Unsorted files via index**: index-based VLSD reads are now supported (string/byte-array VLSD channels resolve through `read()` / `values()`; `byte_ranges()` still refuses them). Unsorted data groups are still refused with a clear error; implementing them would unlock CANedge-style bus logs

--- a/js/src/mdf-index.ts
+++ b/js/src/mdf-index.ts
@@ -108,12 +108,13 @@ export class MdfIndex {
    * Full data-section byte ranges for the group owning `name`, merged.
    *
    * Returns one span per data-block fragment covering the entire data section
-   * (block bytes minus the 24-byte header). This is exactly the range set the
-   * fragment readers need: `valuesFromFragments`/`readFromFragments` decode
-   * whole data sections (all channels interleave per record), so fetch these
-   * and pass the fetched fragments straight through — the requested channel
-   * and its master are both covered for any record layout. This is also what
-   * `values`/`read` fetch under the hood.
+   * (block bytes minus the 24-byte header); for a VLSD channel the spans of
+   * its `##SD` fragment chain are included too. This is exactly the range set
+   * the fragment readers need: `valuesFromFragments`/`readFromFragments`
+   * decode whole data sections (all channels interleave per record), so fetch
+   * these and pass the fetched fragments straight through — the requested
+   * channel and its master are both covered for any record layout. This is
+   * also what `values`/`read` fetch under the hood.
    */
   signalByteRanges(name: string, group?: string | null): ByteRange[] {
     return this.inner.signalByteRanges(name, group) as ByteRange[];

--- a/js/test/vlsd-index.test.ts
+++ b/js/test/vlsd-index.test.ts
@@ -9,10 +9,12 @@ import { BytesRangeSource } from "../src/range-source";
 /**
  * VLSD (variable-length string) contract for the lazy index path.
  *
- * Index-based reads of VLSD channels are not yet supported: they must fail
- * with a clear error — and that failure must not affect reads of the
- * fixed-width channels in the same group, which must keep working through
- * the index path (validated against the direct reader).
+ * Index-based reads of VLSD channels resolve each record's inline 8-byte
+ * offset into the channel's ##SD fragment chain: `read` returns the strings
+ * (aligned with the group master timestamps) and `values` returns NaN per
+ * sample (strings are not numeric). `signalByteRanges` includes the ##SD
+ * spans so the fragment path fetches everything the decoder needs — and the
+ * JSON round trip preserves the fragment list.
  */
 
 function buildVlsdFile(): { bytes: Uint8Array; strs: string[] } {
@@ -41,32 +43,52 @@ test("VLSD channel reads correctly via the direct reader", () => {
   mdf.dispose();
 });
 
-test("VLSD channel via the index path fails with a clear error", async () => {
-  const { bytes } = buildVlsdFile();
+test("VLSD channel reads via the lazy index path (JSON round trip)", async () => {
+  const { bytes, strs } = buildVlsdFile();
   const idx = MdfIndex.fromJson(MdfIndex.fromBytes(bytes).toJson());
   const source = new BytesRangeSource(bytes);
 
-  await assert.rejects(
-    () => idx.read("Label", source),
-    (e: Error) => /VLSD channel 'Label' not yet supported/.test(e.message),
-  );
-  await assert.rejects(
-    () => idx.values("Label", source),
-    (e: Error) => /VLSD channel 'Label' not yet supported/.test(e.message),
-  );
+  // read: strings, one per record, timestamps aligned with the master.
+  const sig = await idx.read("Label", source);
+  assert.deepEqual(sig.values, strs);
+  assert.equal(sig.timestamps.length, strs.length);
+
+  // values: the numeric fast path maps strings to NaN, one per record.
+  const vals = await idx.values("Label", source);
+  assert.equal(vals.length, strs.length);
+  assert.ok(Array.from(vals).every((v) => Number.isNaN(v)));
+
   idx.dispose();
 });
 
-test("a failed VLSD index read does not poison other channels in the group", async () => {
+test("signalByteRanges for a VLSD channel covers its ##SD stream", () => {
+  const { bytes } = buildVlsdFile();
+  const idx = MdfIndex.fromBytes(bytes);
+
+  // The VLSD channel needs more bytes than its group's fixed records alone:
+  // its ranges must strictly contain the fixed-width channel's ranges.
+  const fixed = idx.signalByteRanges("Value");
+  const vlsd = idx.signalByteRanges("Label");
+  const total = (rs: [number, number][]) => rs.reduce((n, [, len]) => n + len, 0);
+  assert.ok(
+    total(vlsd as [number, number][]) > total(fixed as [number, number][]),
+    "VLSD ranges must include the ##SD data on top of the record data",
+  );
+
+  // byteRanges (static per-channel spans) still refuses VLSD channels.
+  assert.throws(() => idx.byteRanges("Label"), /VLSD/);
+
+  idx.dispose();
+});
+
+test("VLSD and fixed-width channels coexist on the index path", async () => {
   const { bytes } = buildVlsdFile();
   const mdf = Mdf.fromBytes(bytes);
   const idx = MdfIndex.fromJson(MdfIndex.fromBytes(bytes).toJson());
   const source = new BytesRangeSource(bytes);
 
-  await assert.rejects(() => idx.read("Label", source));
-
-  // Fixed-width channel in the same (VLSD-containing) group still reads via
-  // the index path, and matches the direct reader.
+  // Fixed-width channel in the same (VLSD-containing) group reads via the
+  // index path and matches the direct reader.
   const lazy = await idx.read("Value", source);
   const direct = mdf.read("Value");
   assert.deepEqual(Array.from(lazy.values as number[]), Array.from(direct.values as number[]));
@@ -74,6 +96,10 @@ test("a failed VLSD index read does not poison other channels in the group", asy
 
   const lazyVals = await idx.values("Value", source);
   assert.deepEqual(Array.from(lazyVals), Array.from(mdf.values("Value")));
+
+  // And the VLSD channel matches the direct reader too.
+  const lazyLabel = await idx.read("Label", source);
+  assert.deepEqual(lazyLabel.values, mdf.read("Label").values);
 
   idx.dispose();
   mdf.dispose();

--- a/src/index.rs
+++ b/src/index.rs
@@ -9,7 +9,7 @@ use crate::api::mdf::MDF;
 use crate::blocks::common::{DataType, BlockParse};
 use crate::blocks::conversion::{ConversionBlock, ConversionType};
 use crate::error::MdfError;
-use crate::parsing::decoder::{check_value_validity, decode_channel_value_with_validity, decode_f64_from_record, DecodedValue};
+use crate::parsing::decoder::{check_value_validity, decode_channel_value, decode_channel_value_with_validity, decode_f64_from_record, DecodedValue};
 use crate::signal::{decoded_opt_to_f64, Signal};
 
 /// Represents the location and metadata of data blocks in the file
@@ -48,6 +48,9 @@ pub struct IndexedChannel {
     pub conversion: Option<ConversionBlock>,
     /// For VLSD channels: address of signal data blocks
     pub vlsd_data_address: Option<u64>,
+    /// For VLSD channels: locations of the ##SD fragments in chain order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vlsd_data_blocks: Vec<DataBlockInfo>,
 }
 
 impl IndexedChannel {
@@ -335,6 +338,36 @@ impl SliceRangeReader {
 }
 
 impl ByteRangeReader for SliceRangeReader {
+    type Error = MdfError;
+
+    fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, Self::Error> {
+        // Checked arithmetic: a forged offset/length must error, not wrap.
+        let end = match offset
+            .checked_add(length)
+            .and_then(|e| usize::try_from(e).ok())
+        {
+            Some(end) if end <= self.data.len() => end,
+            _ => {
+                return Err(MdfError::TooShortBuffer {
+                    actual: self.data.len(),
+                    expected: offset.saturating_add(length).min(usize::MAX as u64) as usize,
+                    file: file!(),
+                    line: line!(),
+                });
+            }
+        };
+        Ok(self.data[offset as usize..end].to_vec())
+    }
+}
+
+/// Borrowing counterpart to [`SliceRangeReader`] — a [`ByteRangeReader`] over a
+/// borrowed `&[u8]` (e.g. a memory map), so the mmap-based index paths can
+/// reuse the generic reader logic without cloning the whole file into a `Vec`.
+struct BorrowedSliceReader<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> ByteRangeReader for BorrowedSliceReader<'a> {
     type Error = MdfError;
 
     fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, Self::Error> {
@@ -813,6 +846,13 @@ impl MdfIndex {
                     None
                 };
 
+                let vlsd_data_blocks = if block.channel_type == 1 && block.data != 0 {
+                    let mut slice_reader = BorrowedSliceReader { data: mmap };
+                    Self::extract_vlsd_data_blocks(&mut slice_reader, block.data)?
+                } else {
+                    Vec::new()
+                };
+
                 indexed_channels.push(IndexedChannel {
                     name: channel.name()?,
                     unit: channel.unit()?,
@@ -829,6 +869,7 @@ impl MdfIndex {
                     } else {
                         None
                     },
+                    vlsd_data_blocks,
                 });
             }
 
@@ -962,6 +1003,11 @@ impl MdfIndex {
             let mut indexed_channels = Vec::with_capacity(group.channels.len());
             for ch in group.channels {
                 let block = ch.block;
+                let vlsd_data_blocks = if block.channel_type == 1 && block.data != 0 {
+                    Self::extract_vlsd_data_blocks(reader, block.data)?
+                } else {
+                    Vec::new()
+                };
                 indexed_channels.push(IndexedChannel {
                     name: ch.name,
                     unit: ch.unit,
@@ -978,6 +1024,7 @@ impl MdfIndex {
                     } else {
                         None
                     },
+                    vlsd_data_blocks,
                 });
             }
 
@@ -1071,6 +1118,134 @@ impl MdfIndex {
         Ok(data_blocks)
     }
 
+    /// Walk a VLSD channel's `data` chain (a single `##SD`, or a `##DL` chain
+    /// of `##SD`/`##DZ` fragments) and record each fragment's location in chain
+    /// order.
+    ///
+    /// Generic over [`ByteRangeReader`] so the mmap path (via
+    /// [`BorrowedSliceReader`]) and the remote path share one implementation.
+    /// Cycle-detects the `##DL` `next` chain, rejects unexpected block IDs, and
+    /// validates that a variable-length `##DL`'s per-fragment virtual offsets
+    /// reproduce the running sum of prior fragments' data-section sizes — the
+    /// invariant the offset-based reader relies on.
+    fn extract_vlsd_data_blocks<R>(
+        reader: &mut R,
+        data_addr: u64,
+    ) -> Result<Vec<DataBlockInfo>, MdfError>
+    where
+        R: ByteRangeReader<Error = MdfError>,
+    {
+        let mut data_blocks: Vec<DataBlockInfo> = Vec::new();
+        let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        // Running sum of fragment data-section sizes (size - 24), i.e. the
+        // virtual start offset of the next fragment in the concatenated stream.
+        let mut running_offset: u64 = 0;
+        let mut current = data_addr;
+
+        while current != 0 {
+            let header_bytes = reader.read_range(current, 24)?;
+            let header = crate::blocks::common::BlockHeader::from_bytes(&header_bytes)?;
+
+            match header.id.as_str() {
+                "##SD" => {
+                    data_blocks.push(DataBlockInfo {
+                        file_offset: current,
+                        size: header.block_len,
+                        is_compressed: false,
+                    });
+                    current = 0;
+                }
+                "##DZ" => {
+                    data_blocks.push(DataBlockInfo {
+                        file_offset: current,
+                        size: header.block_len,
+                        is_compressed: true,
+                    });
+                    current = 0;
+                }
+                "##DL" => {
+                    // Cycle detection on the DL chain: a chain revisiting an
+                    // address would otherwise loop forever.
+                    if !visited.insert(current) {
+                        return Err(MdfError::BlockLinkError(format!(
+                            "cycle detected in VLSD data list chain at address {:#x}",
+                            current
+                        )));
+                    }
+                    let dl_bytes = reader.read_range(current, header.block_len)?;
+                    let dl = crate::blocks::data_list_block::DataListBlock::from_bytes(&dl_bytes)?;
+
+                    for (i, &fragment_address) in dl.data_links.iter().enumerate() {
+                        if fragment_address == 0 {
+                            continue;
+                        }
+                        let frag_header_bytes = reader.read_range(fragment_address, 24)?;
+                        let frag_header =
+                            crate::blocks::common::BlockHeader::from_bytes(&frag_header_bytes)?;
+                        let is_compressed = match frag_header.id.as_str() {
+                            "##SD" => false,
+                            "##DZ" => true,
+                            other => {
+                                return Err(MdfError::BlockIDError {
+                                    actual: other.to_string(),
+                                    expected: "##SD / ##DZ".to_string(),
+                                });
+                            }
+                        };
+
+                        // A variable-length DL carries an explicit virtual
+                        // offset per fragment. The offset-based read path maps
+                        // an inline offset to a fragment via cumulative
+                        // data-section sizes, so a non-contiguous chain would
+                        // silently mislocate entries — reject it here.
+                        if let Some(offsets) = &dl.offsets {
+                            if let Some(&declared) = offsets.get(i) {
+                                if declared != running_offset {
+                                    return Err(MdfError::BlockSerializationError(format!(
+                                        "non-contiguous VLSD ##SD chain is unsupported: \
+                                         fragment at offset {} declares virtual start {} \
+                                         but the running data-section sum is {}",
+                                        fragment_address, declared, running_offset
+                                    )));
+                                }
+                            }
+                        }
+
+                        let data_section = frag_header.block_len.checked_sub(24).ok_or_else(|| {
+                            MdfError::BlockSerializationError(format!(
+                                "VLSD fragment at offset {} has size {} \
+                                 (smaller than the 24-byte block header)",
+                                fragment_address, frag_header.block_len
+                            ))
+                        })?;
+                        running_offset = running_offset.checked_add(data_section).ok_or_else(|| {
+                            MdfError::BlockSerializationError(
+                                "VLSD ##SD chain total size overflows the address space"
+                                    .to_string(),
+                            )
+                        })?;
+
+                        data_blocks.push(DataBlockInfo {
+                            file_offset: fragment_address,
+                            size: frag_header.block_len,
+                            is_compressed,
+                        });
+                    }
+
+                    current = dl.next;
+                }
+                other => {
+                    return Err(MdfError::BlockIDError {
+                        actual: other.to_string(),
+                        expected: "##SD / ##DL / ##DZ".to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(data_blocks)
+    }
+
     /// Save the index to a JSON file.
     ///
     /// Not available on `wasm32-unknown-unknown`; use [`to_json`] instead.
@@ -1136,6 +1311,24 @@ impl MdfIndex {
             if !group.data_blocks.is_empty() {
                 Self::checked_record_size(group)?;
             }
+            for channel in &group.channels {
+                for db in &channel.vlsd_data_blocks {
+                    if db.size < 24 {
+                        return Err(MdfError::BlockSerializationError(format!(
+                            "invalid index: group '{}' VLSD data block at offset {} has size {} \
+                             (smaller than the 24-byte block header)",
+                            group_name, db.file_offset, db.size
+                        )));
+                    }
+                    if db.file_offset.checked_add(db.size).is_none() {
+                        return Err(MdfError::BlockSerializationError(format!(
+                            "invalid index: group '{}' VLSD data block at offset {} with size {} \
+                             overflows the file address space",
+                            group_name, db.file_offset, db.size
+                        )));
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -1185,14 +1378,18 @@ impl MdfIndex {
         Ok(data_len / record_size as u64)
     }
 
-    /// Error for VLSD channels on read paths that only handle fixed-size
-    /// records. Triggers on `channel_type == 1` regardless of whether the SD
-    /// address was captured: a VLSD channel without one is equally unreadable,
-    /// and decoding the inline 8-byte SD offsets would return garbage.
+    /// Error for VLSD channels on the byte-range calculation paths.
+    ///
+    /// A VLSD channel's fixed record field holds an 8-byte offset into a
+    /// separate `##SD` stream, not the value bytes, so a static
+    /// `(offset, length)` range cannot describe where a sample's payload
+    /// lives. Value reads (`read` / `values`) resolve the indirection and are
+    /// fully supported; only byte-range calculation refuses VLSD channels.
     fn ensure_not_vlsd(channel: &IndexedChannel) -> Result<(), MdfError> {
         if channel.channel_type == 1 {
             return Err(MdfError::BlockSerializationError(format!(
-                "VLSD channel '{}' not yet supported in index reader",
+                "byte ranges cannot represent offset-indirected VLSD channel '{}'; \
+                 use read()/values() instead",
                 channel.name.as_deref().unwrap_or("<unnamed>")
             )));
         }
@@ -1220,9 +1417,9 @@ impl MdfIndex {
         let channel = group.channels.get(channel_index)
             .ok_or_else(|| MdfError::BlockSerializationError("Invalid channel index".to_string()))?;
 
-        // VLSD channels are not supported: decoding their inline SD offsets
-        // as payload would return garbage.
-        Self::ensure_not_vlsd(channel)?;
+        if channel.channel_type == 1 {
+            return self.read_vlsd_channel_values(group, channel, reader);
+        }
 
         // For regular channels, read from data blocks
         self.read_regular_channel_values(group, channel, reader)
@@ -1269,6 +1466,196 @@ impl MdfIndex {
         }
 
         Ok(values)
+    }
+
+    /// Read values for a VLSD channel (channel type 1) via a byte-range reader.
+    ///
+    /// The channel's fixed record field holds an 8-byte little-endian virtual
+    /// offset into the concatenation of the `##SD` fragments' data sections;
+    /// at that offset lives one `[u32 length][payload]` entry. This resolves
+    /// each record's offset into the captured fragment chain and decodes the
+    /// payload, preserving one value per record so [`Signal`] timestamps stay
+    /// aligned and per-record invalidation can be honoured.
+    fn read_vlsd_channel_values<R: ByteRangeReader<Error = MdfError>>(
+        &self,
+        group: &IndexedChannelGroup,
+        channel: &IndexedChannel,
+        reader: &mut R,
+    ) -> Result<Vec<Option<DecodedValue>>, MdfError> {
+        // Compressed fragments (either the fixed records or the SD stream) are
+        // not decodable yet.
+        if group.data_blocks.iter().any(|b| b.is_compressed)
+            || channel.vlsd_data_blocks.iter().any(|b| b.is_compressed)
+        {
+            return Err(MdfError::BlockSerializationError(
+                "Compressed blocks not yet supported in index reader".to_string(),
+            ));
+        }
+
+        // A VLSD channel without a data link has no signal data at all —
+        // rebuilding the index cannot help, so distinguish it from an index
+        // built before VLSD chains were captured.
+        if channel.vlsd_data_blocks.is_empty() {
+            if channel.vlsd_data_address.is_none() {
+                return Err(MdfError::BlockSerializationError(format!(
+                    "VLSD channel '{}' has no signal data (its ##SD data link is 0)",
+                    channel.name.as_deref().unwrap_or("<unnamed>")
+                )));
+            }
+            return Err(MdfError::BlockSerializationError(format!(
+                "VLSD channel '{}' has no signal-data fragments recorded in the index; \
+                 rebuild the index with this version to read it",
+                channel.name.as_deref().unwrap_or("<unnamed>")
+            )));
+        }
+
+        // The VLSD offset field is fixed at 64 bits by the spec and is
+        // byte-aligned; a nonzero bit offset would silently shift every
+        // resolved stream offset.
+        if channel.bit_count != 64 || channel.bit_offset != 0 {
+            return Err(MdfError::BlockSerializationError(format!(
+                "VLSD channel '{}' has a {}-bit record field at bit offset {}; the \
+                 inline VLSD offset must be a byte-aligned 64-bit field",
+                channel.name.as_deref().unwrap_or("<unnamed>"),
+                channel.bit_count,
+                channel.bit_offset
+            )));
+        }
+
+        // Fetch each SD fragment's data section, tracking each fragment's
+        // virtual start offset in the concatenated stream.
+        let mut fragments: Vec<Vec<u8>> = Vec::with_capacity(channel.vlsd_data_blocks.len());
+        let mut frag_starts: Vec<u64> = Vec::with_capacity(channel.vlsd_data_blocks.len());
+        let mut running: u64 = 0;
+        for db in &channel.vlsd_data_blocks {
+            let data_len = Self::data_section_size(db)?;
+            let bytes = reader.read_range(db.file_offset + 24, data_len)?;
+            frag_starts.push(running);
+            running = running.checked_add(bytes.len() as u64).ok_or_else(|| {
+                MdfError::BlockSerializationError(
+                    "VLSD ##SD chain total size overflows the address space".to_string(),
+                )
+            })?;
+            fragments.push(bytes);
+        }
+        let stream_len = running;
+
+        let record_size = Self::checked_record_size(group)?;
+        let record_id_len = group.record_id_len as usize;
+        let cg_data_bytes = group.record_size;
+        let has_invalidation = group.invalidation_bytes > 0;
+        let all_invalid = channel.flags & 0x1 != 0;
+        let offset_pos = record_id_len + channel.byte_offset as usize;
+
+        // A fixed-record channel block (data == 0) drives the validity check;
+        // a separate VLSD block (data != 0) drives payload decoding.
+        let validity_cb = channel.to_channel_block();
+        let mut payload_cb = channel.to_channel_block();
+        payload_cb.data = 1;
+
+        let mut total_records: usize = 0;
+        for data_block in &group.data_blocks {
+            total_records += Self::records_in_block(data_block, record_size)? as usize;
+        }
+        let mut values = Vec::with_capacity(total_records.min(1 << 24));
+
+        for data_block in &group.data_blocks {
+            let block_data = reader
+                .read_range(data_block.file_offset + 24, Self::data_section_size(data_block)?)?;
+            if block_data.len() % record_size != 0 {
+                return Err(MdfError::BlockSerializationError(format!(
+                    "data block length {} is not a multiple of the {}-byte record — \
+                     record spans data block fragments, which is unsupported",
+                    block_data.len(),
+                    record_size
+                )));
+            }
+            let record_count = block_data.len() / record_size;
+            for i in 0..record_count {
+                let record = &block_data[i * record_size..(i + 1) * record_size];
+
+                if all_invalid
+                    || (has_invalidation
+                        && !check_value_validity(record, record_id_len, cg_data_bytes, &validity_cb))
+                {
+                    values.push(None);
+                    continue;
+                }
+
+                // Read the inline 8-byte virtual offset.
+                if offset_pos + 8 > record.len() {
+                    return Err(MdfError::TooShortBuffer {
+                        actual: record.len(),
+                        expected: offset_pos + 8,
+                        file: file!(),
+                        line: line!(),
+                    });
+                }
+                let virtual_offset =
+                    u64::from_le_bytes(record[offset_pos..offset_pos + 8].try_into().unwrap());
+
+                if virtual_offset >= stream_len {
+                    return Err(MdfError::BlockSerializationError(format!(
+                        "VLSD inline offset {} is past the end of the {}-byte signal-data stream",
+                        virtual_offset, stream_len
+                    )));
+                }
+
+                // Locate the fragment whose virtual span contains the offset.
+                let frag_idx = frag_starts.partition_point(|&s| s <= virtual_offset) - 1;
+                let frag = &fragments[frag_idx];
+                let pos = (virtual_offset - frag_starts[frag_idx]) as usize;
+
+                if pos + 4 > frag.len() {
+                    return Err(MdfError::BlockSerializationError(format!(
+                        "VLSD entry at virtual offset {} is truncated: no room for its \
+                         length prefix in fragment {}",
+                        virtual_offset, frag_idx
+                    )));
+                }
+                let len = u32::from_le_bytes(frag[pos..pos + 4].try_into().unwrap()) as usize;
+                let start = pos + 4;
+                let end = match start.checked_add(len) {
+                    Some(e) if e <= frag.len() => e,
+                    _ => {
+                        return Err(MdfError::BlockSerializationError(format!(
+                            "VLSD entry at virtual offset {} declares length {} which \
+                             exceeds fragment {} (size {})",
+                            virtual_offset, len, frag_idx, frag.len()
+                        )));
+                    }
+                };
+                let payload = &frag[start..end];
+
+                if let Some(value) = decode_channel_value(payload, 0, &payload_cb) {
+                    let final_value = if let Some(conversion) = &channel.conversion {
+                        conversion.apply_decoded(value, &[])?
+                    } else {
+                        value
+                    };
+                    values.push(Some(final_value));
+                } else {
+                    values.push(None);
+                }
+            }
+        }
+
+        Ok(values)
+    }
+
+    /// Map VLSD decoded values to `f64`, matching `Channel::values_as_f64`:
+    /// numeric variants convert, everything else (strings, bytes, invalid) is
+    /// NaN.
+    fn vlsd_values_to_f64(values: Vec<Option<DecodedValue>>) -> Vec<f64> {
+        values
+            .into_iter()
+            .map(|v| match v {
+                Some(DecodedValue::Float(f)) => f,
+                Some(DecodedValue::UnsignedInteger(u)) => u as f64,
+                Some(DecodedValue::SignedInteger(i)) => i as f64,
+                _ => f64::NAN,
+            })
+            .collect()
     }
 
     /// Decode records from a data block slice into values vec.
@@ -1903,9 +2290,10 @@ impl MdfIndex {
         let channel = group.channels.get(channel_index)
             .ok_or_else(|| MdfError::BlockSerializationError("Invalid channel index".to_string()))?;
 
-        // VLSD channels are not supported: decoding their inline SD offsets
-        // as payload would return garbage.
-        Self::ensure_not_vlsd(channel)?;
+        if channel.channel_type == 1 {
+            let vals = self.read_vlsd_channel_values(group, channel, reader)?;
+            return Ok(Self::vlsd_values_to_f64(vals));
+        }
 
         let record_size = Self::checked_record_size(group)?;
 
@@ -1953,9 +2341,10 @@ impl MdfIndex {
         let channel = group.channels.get(channel_index)
             .ok_or_else(|| MdfError::BlockSerializationError("Invalid channel index".to_string()))?;
 
-        // VLSD channels are not supported: decoding their inline SD offsets
-        // as payload would return garbage.
-        Self::ensure_not_vlsd(channel)?;
+        if channel.channel_type == 1 {
+            let mut slice_reader = BorrowedSliceReader { data: file_data };
+            return self.read_vlsd_channel_values(group, channel, &mut slice_reader);
+        }
 
         let record_size = Self::checked_record_size(group)?;
         let mut total_records: usize = 0;
@@ -1998,9 +2387,11 @@ impl MdfIndex {
         let channel = group.channels.get(channel_index)
             .ok_or_else(|| MdfError::BlockSerializationError("Invalid channel index".to_string()))?;
 
-        // VLSD channels are not supported: decoding their inline SD offsets
-        // as payload would return garbage.
-        Self::ensure_not_vlsd(channel)?;
+        if channel.channel_type == 1 {
+            let mut slice_reader = BorrowedSliceReader { data: file_data };
+            let vals = self.read_vlsd_channel_values(group, channel, &mut slice_reader)?;
+            return Ok(Self::vlsd_values_to_f64(vals));
+        }
 
         let record_size = Self::checked_record_size(group)?;
         let mut total_records: usize = 0;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -541,14 +541,19 @@ impl WasmMdfIndex {
     ///
     /// Returns one `(file_offset + 24, size - 24)` span per `##DT`/`##DV`
     /// fragment of the owning group (the 24 skips the block header), merged.
+    /// For a VLSD channel the spans of its `##SD` fragment chain are included
+    /// as well — the decoder resolves each record's inline offset into that
+    /// stream, so its bytes must be fetched alongside the fixed records.
     /// This is exactly what the fragment readers need: `valuesFromFragments` /
     /// `readFromFragments` decode whole data sections, not just the requested
     /// channel's columns, so the fragments must cover each full section.
     fn signal_ranges(&self, name: &str, group: Option<&str>) -> Result<Vec<(u64, u64)>, JsError> {
-        let (g, _c) = self.locate(name, group)?;
+        let (g, c) = self.locate(name, group)?;
         let grp = &self.index.channel_groups[g];
-        let mut ranges = Vec::with_capacity(grp.data_blocks.len());
-        for db in &grp.data_blocks {
+        let channel = &grp.channels[c];
+        let mut ranges =
+            Vec::with_capacity(grp.data_blocks.len() + channel.vlsd_data_blocks.len());
+        for db in grp.data_blocks.iter().chain(channel.vlsd_data_blocks.iter()) {
             if db.is_compressed {
                 return Err(JsError::new(
                     "compressed (##DZ) data blocks are not supported for fragment reads",
@@ -675,8 +680,9 @@ impl WasmMdfIndex {
     /// Full data-section byte ranges for the group owning `name`, merged.
     ///
     /// Returns one span per data-block fragment covering the entire data
-    /// section (block bytes minus the 24-byte header). These are exactly the
-    /// ranges the fragment readers need: `valuesFromFragments` /
+    /// section (block bytes minus the 24-byte header); for a VLSD channel the
+    /// spans of its `##SD` fragment chain are included too. These are exactly
+    /// the ranges the fragment readers need: `valuesFromFragments` /
     /// `readFromFragments` decode whole data sections (all channels are
     /// interleaved per record), so fetch these and pass the fetched fragments
     /// straight through — the requested channel and its master are both

--- a/tests/enhanced_index_conversions.rs
+++ b/tests/enhanced_index_conversions.rs
@@ -262,6 +262,7 @@ fn test_index_serialization_with_resolved_data() -> Result<(), MdfError> {
         pos_invalidation_bit: 0,
         conversion: Some(conversion),
         vlsd_data_address: None,
+        vlsd_data_blocks: Vec::new(),
     };
     
     let indexed_group = IndexedChannelGroup {

--- a/tests/fix_index.rs
+++ b/tests/fix_index.rs
@@ -1,7 +1,9 @@
 //! Regression tests for the index-system fixes:
 //!
-//! - A3: VLSD channels must error on every index read path instead of
-//!   silently decoding the inline 8-byte SD offsets as payload.
+//! - A3: VLSD channels now read correctly through the index (values,
+//!   values_f64, and the lazy Signal path) by resolving each record's inline
+//!   8-byte SD offset into the captured ##SD fragment chain; only the static
+//!   byte-range calculation still refuses VLSD channels.
 //! - B7: cn_flags bit 0 ("all values invalid") must apply on the f64 fast
 //!   path even when the group has no invalidation bytes.
 //! - C6: hostile/stale index JSON (block size < 24, record_size == 0,
@@ -63,37 +65,51 @@ fn write_vlsd_file(path: &str) -> Result<usize, MdfError> {
     Ok(payloads.len())
 }
 
-/// A3: reading a VLSD channel through the index must error on every path,
-/// not return garbage decoded from the inline SD offsets.
+/// A3: reading a VLSD channel through the index must SUCCEED with the correct
+/// values on every value-read path (resolving the inline SD offsets), while
+/// the static byte-range calculation still refuses VLSD channels.
 #[test]
-fn vlsd_channel_reads_error_instead_of_garbage() -> Result<(), MdfError> {
+fn vlsd_channel_reads_resolve_correctly() -> Result<(), MdfError> {
     let path = tmp_path("fix_index_vlsd.mf4");
     let path_str = path.to_str().unwrap();
     let n = write_vlsd_file(path_str)?;
+    let expected = ["alpha", "bravo!", "charlie"];
 
     let index = MdfIndex::from_file(path_str)?;
 
-    // MdfReader::values (DecodedValue path)
+    // MdfReader::values (DecodedValue path) resolves the strings.
     let mut reader = index.open_file(path_str)?;
-    assert!(
-        reader.values("Msg").is_err(),
-        "values() on a VLSD channel must error"
-    );
-    // MdfReader::values_f64 (fast f64 path) — previously decoded garbage
-    assert!(
-        reader.values_f64("Msg").is_err(),
-        "values_f64() on a VLSD channel must error"
-    );
-    // Byte-range calculation
+    let msgs = reader.values("Msg")?;
+    assert_eq!(msgs.len(), n);
+    for (got, want) in msgs.iter().zip(expected.iter()) {
+        match got {
+            Some(DecodedValue::String(s)) => assert_eq!(s, want),
+            other => panic!("expected string {:?}, got {:?}", want, other),
+        }
+    }
+
+    // MdfReader::values_f64 (fast f64 path): strings map to NaN, one per record.
+    let f64s = reader.values_f64("Msg")?;
+    assert_eq!(f64s.len(), n);
+    assert!(f64s.iter().all(|v| v.is_nan()), "string VLSD values must be NaN");
+
+    // Byte-range calculation still refuses VLSD channels.
     assert!(
         index.byte_ranges("Msg").is_err(),
         "byte_ranges() on a VLSD channel must error"
     );
-    // Lazy source-based read (slice path via mmap)
-    assert!(
-        index.read("Msg").is_err(),
-        "read() on a VLSD channel must error"
-    );
+
+    // Lazy source-based read (slice path via mmap) yields a Signal whose
+    // timestamps align with the values (one per record).
+    let sig = index.read("Msg")?;
+    assert_eq!(sig.values.len(), n);
+    assert_eq!(sig.timestamps.len(), n);
+    for (got, want) in sig.values.iter().zip(expected.iter()) {
+        match got {
+            Some(DecodedValue::String(s)) => assert_eq!(s, want),
+            other => panic!("expected string {:?}, got {:?}", want, other),
+        }
+    }
 
     // The fixed-size channel in the same group still reads fine.
     let times = reader.values_f64("Time")?;

--- a/tests/index_vlsd.rs
+++ b/tests/index_vlsd.rs
@@ -1,0 +1,262 @@
+//! VLSD channel reads through the core index reader (`src/index.rs`).
+//!
+//! Covers the single-fragment round trip across the three read entry points
+//! (bound reader, lazy source, explicit `FileRangeReader`), the multi-fragment
+//! offset→fragment resolution with uneven `##SD` fragments, JSON persistence of
+//! the captured fragment list, old-index compatibility (missing
+//! `vlsd_data_blocks`), and Signal timestamp alignment.
+
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::error::MdfError;
+use mf4_rs::index::{FileRangeReader, MdfIndex};
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::writer::MdfWriter;
+
+fn tmp_path(name: &str) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(name);
+    if p.exists() {
+        let _ = std::fs::remove_file(&p);
+    }
+    p
+}
+
+const RECORD_LEN: usize = 16; // 8 bytes time + 8 bytes VLSD offset slot
+
+/// Write a file with a UTF-8 VLSD "Msg" channel next to a float "Time" channel.
+fn write_vlsd_file(path: &str, payloads: &[&[u8]]) -> Result<(), MdfError> {
+    let mut w = MdfWriter::new(path)?;
+    w.init_mdf_file()?;
+    let cg = w.add_channel_group(None, |_| {})?;
+    let t = w.add_channel(&cg, None, |c| {
+        c.data_type = DataType::FloatLE;
+        c.bit_count = 64;
+        c.name = Some("Time".into());
+    })?;
+    w.set_time_channel(&t)?;
+    let vlsd = w.add_channel(&cg, Some(&t), |c| {
+        c.data_type = DataType::StringUtf8;
+        c.bit_count = 64;
+        c.channel_type = 1;
+        c.data = 1;
+        c.name = Some("Msg".into());
+    })?;
+    w.start_data_block_for_cg_raw(&cg, 0, RECORD_LEN as u32, 0)?;
+    w.start_signal_data_block(&vlsd)?;
+
+    let mut running: u64 = 0;
+    for (i, p) in payloads.iter().enumerate() {
+        let mut record = Vec::with_capacity(RECORD_LEN);
+        record.extend_from_slice(&(i as f64 * 0.1).to_le_bytes());
+        record.extend_from_slice(&running.to_le_bytes());
+        w.write_raw_record(&cg, &record)?;
+        w.write_signal_data(&vlsd, p)?;
+        running += 4 + p.len() as u64;
+    }
+    w.finish_signal_data_block(&vlsd)?;
+    w.finish_data_block(&cg)?;
+    w.finalize()?;
+    Ok(())
+}
+
+/// Write a file whose VLSD "Image" channel spans multiple uneven ##SD
+/// fragments (forcing a ##DL). Mirrors tests/vlsd_multi_fragment_offset_read.rs.
+fn write_vlsd_uneven(path: &str) -> Result<Vec<Vec<u8>>, MdfError> {
+    let payloads: Vec<Vec<u8>> = vec![
+        vec![0xAA; 1 * 1024 * 1024], // 1 MB
+        vec![0xBB; 5 * 1024 * 1024], // 5 MB (alone in its fragment)
+        vec![0xCC; 256 * 1024],      // 256 KB
+    ];
+
+    let mut w = MdfWriter::new(path)?;
+    w.init_mdf_file()?;
+    let cg = w.add_channel_group(None, |_| {})?;
+    let t = w.add_channel(&cg, None, |c| {
+        c.data_type = DataType::FloatLE;
+        c.bit_count = 64;
+        c.name = Some("Time".into());
+    })?;
+    w.set_time_channel(&t)?;
+    let vlsd = w.add_channel(&cg, Some(&t), |c| {
+        c.data_type = DataType::ByteArray;
+        c.bit_count = 64;
+        c.channel_type = 1;
+        c.name = Some("Image".into());
+    })?;
+    w.start_data_block_for_cg_raw(&cg, 0, RECORD_LEN as u32, 0)?;
+    w.start_signal_data_block(&vlsd)?;
+
+    let mut running: u64 = 0;
+    for (i, p) in payloads.iter().enumerate() {
+        let mut record = Vec::with_capacity(RECORD_LEN);
+        record.extend_from_slice(&(i as f64 * 0.1).to_le_bytes());
+        record.extend_from_slice(&running.to_le_bytes());
+        w.write_raw_record(&cg, &record)?;
+        w.write_signal_data(&vlsd, p)?;
+        running = running.checked_add(4 + p.len() as u64).unwrap();
+    }
+    w.finish_signal_data_block(&vlsd)?;
+    w.finish_data_block(&cg)?;
+    w.finalize()?;
+    Ok(payloads)
+}
+
+fn assert_string(v: &Option<DecodedValue>, want: &str) {
+    match v {
+        Some(DecodedValue::String(s)) => assert_eq!(s, want),
+        other => panic!("expected string {:?}, got {:?}", want, other),
+    }
+}
+
+/// (a) Single-fragment round trip across all three read entry points.
+#[test]
+fn vlsd_roundtrip_all_entry_points() -> Result<(), MdfError> {
+    let path = tmp_path("index_vlsd_roundtrip.mf4");
+    let path_str = path.to_str().unwrap();
+    let payloads: [&[u8]; 3] = [b"alpha", b"bravo!", b"charlie"];
+    let expected = ["alpha", "bravo!", "charlie"];
+    write_vlsd_file(path_str, &payloads)?;
+
+    let mut index = MdfIndex::from_file(path_str)?;
+
+    // (1) bound reader via open_file (mmap)
+    {
+        let mut reader = index.open_file(path_str)?;
+        let vals = reader.values("Msg")?;
+        assert_eq!(vals.len(), 3);
+        for (v, w) in vals.iter().zip(expected.iter()) {
+            assert_string(v, w);
+        }
+    }
+
+    // (2) lazy index.read via attached source
+    {
+        let sig = index.read("Msg")?;
+        assert_eq!(sig.values.len(), 3);
+        for (v, w) in sig.values.iter().zip(expected.iter()) {
+            assert_string(v, w);
+        }
+    }
+
+    // (3) explicit FileRangeReader through open(...) -> read_channel_values
+    {
+        let mut reader = index.open(FileRangeReader::new(path_str)?);
+        let vals = reader.values("Msg")?;
+        assert_eq!(vals.len(), 3);
+        for (v, w) in vals.iter().zip(expected.iter()) {
+            assert_string(v, w);
+        }
+    }
+
+    // Ensure set_file / source path also works after a manual re-attach.
+    index.set_file(path_str);
+    assert_eq!(index.read("Msg")?.values.len(), 3);
+
+    std::fs::remove_file(&path)?;
+    Ok(())
+}
+
+/// (b) Multi-fragment: uneven ##SD fragments; exercise offset→fragment search.
+#[test]
+fn vlsd_multi_fragment_exact_bytes() -> Result<(), MdfError> {
+    let path = tmp_path("index_vlsd_uneven.mf4");
+    let path_str = path.to_str().unwrap();
+    let payloads = write_vlsd_uneven(path_str)?;
+
+    let index = MdfIndex::from_file(path_str)?;
+    let mut reader = index.open_file(path_str)?;
+    let vals = reader.values("Image")?;
+    assert_eq!(vals.len(), payloads.len());
+    for (i, v) in vals.iter().enumerate() {
+        match v {
+            Some(DecodedValue::ByteArray(b)) => {
+                assert_eq!(b.len(), payloads[i].len(), "entry {} wrong length", i);
+                assert_eq!(b, &payloads[i], "entry {} wrong bytes", i);
+            }
+            other => panic!("expected ByteArray at {}, got {:?}", i, other),
+        }
+    }
+
+    std::fs::remove_file(&path)?;
+    Ok(())
+}
+
+/// (c) JSON persistence: save -> load -> set_file -> read works, proving
+/// vlsd_data_blocks serializes.
+#[test]
+fn vlsd_json_persistence() -> Result<(), MdfError> {
+    let path = tmp_path("index_vlsd_persist.mf4");
+    let path_str = path.to_str().unwrap();
+    let json_path = tmp_path("index_vlsd_persist.idx.json");
+    let json_str = json_path.to_str().unwrap();
+    let payloads: [&[u8]; 3] = [b"one", b"two", b"three"];
+    write_vlsd_file(path_str, &payloads)?;
+
+    MdfIndex::from_file(path_str)?.save_to_file(json_str)?;
+
+    let mut index = MdfIndex::load_from_file(json_str)?;
+    index.set_file(path_str);
+    let sig = index.read("Msg")?;
+    assert_eq!(sig.values.len(), 3);
+    assert_string(&sig.values[0], "one");
+    assert_string(&sig.values[2], "three");
+
+    std::fs::remove_file(&path)?;
+    std::fs::remove_file(&json_path)?;
+    Ok(())
+}
+
+/// (d) Old-index compat: a JSON index without `vlsd_data_blocks` must load
+/// (serde default) and error with a clear rebuild message on VLSD reads, while
+/// fixed-size channels still read fine.
+#[test]
+fn vlsd_missing_fragments_errors_with_rebuild_message() -> Result<(), MdfError> {
+    let path = tmp_path("index_vlsd_oldindex.mf4");
+    let path_str = path.to_str().unwrap();
+    let payloads: [&[u8]; 3] = [b"aa", b"bb", b"cc"];
+    write_vlsd_file(path_str, &payloads)?;
+
+    let index = MdfIndex::from_file(path_str)?;
+    let json = index.to_json()?;
+
+    // Strip vlsd_data_blocks from every channel to emulate an older index.
+    let mut v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    for group in v["channel_groups"].as_array_mut().unwrap() {
+        for ch in group["channels"].as_array_mut().unwrap() {
+            ch.as_object_mut().unwrap().remove("vlsd_data_blocks");
+        }
+    }
+    let mut stripped = MdfIndex::from_json(&v.to_string())?;
+    stripped.set_file(path_str);
+
+    let err = stripped.read("Msg").unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("rebuild the index"),
+        "expected a rebuild hint, got: {msg}"
+    );
+
+    // The fixed-size Time channel still reads fine.
+    let times = stripped.read("Time")?;
+    assert_eq!(times.values.len(), 3);
+
+    std::fs::remove_file(&path)?;
+    Ok(())
+}
+
+/// (e) Signal alignment: read() timestamps length == values length == records.
+#[test]
+fn vlsd_signal_alignment() -> Result<(), MdfError> {
+    let path = tmp_path("index_vlsd_align.mf4");
+    let path_str = path.to_str().unwrap();
+    let payloads: [&[u8]; 4] = [b"w", b"x", b"y", b"z"];
+    write_vlsd_file(path_str, &payloads)?;
+
+    let index = MdfIndex::from_file(path_str)?;
+    let sig = index.read("Msg")?;
+    assert_eq!(sig.values.len(), payloads.len());
+    assert_eq!(sig.timestamps.len(), payloads.len());
+    assert_eq!(sig.timestamps.len(), sig.values.len());
+
+    std::fs::remove_file(&path)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

String and byte-array VLSD channels (`channel_type == 1`) are now readable through `MdfIndex` on every value path — bound readers (`values` / `values_f64` / `signal`), the lazy `read()` path, explicit `ByteRangeReader` sources (HTTP range requests), and the zero-copy mmap-slice path used by the Python bindings. The TypeScript/wasm package's lazy `values()` / `read()` work too.

## How it works

- The index captures each VLSD channel's `##SD` fragment chain at build time (`IndexedChannel.vlsd_data_blocks`, `serde(default)` so old JSON indexes still load — they error on VLSD reads with a "rebuild the index" message).
- Reads are **offset-based**: each fixed record's inline 8-byte virtual offset is resolved into the concatenated `##SD` stream (`[u32 len][payload]` entries), rather than walking the stream sequentially. This keeps one value per record — `Signal` timestamps stay aligned — and honors per-record invalidation bits.
- Chain walking cycle-detects `##DL` chains, validates `##DL` virtual-offset tables against the running data-section sum, and uses checked arithmetic throughout so a forged/stale index errors instead of panicking.
- `byte_ranges()` still refuses VLSD channels (a static range cannot express the offset indirection) with a clearer message; `##DZ` fragments still error as unsupported.
- wasm: `signalByteRanges` now includes the VLSD channel's `##SD` spans, so the TS fragment-based fetch model covers everything the decoder needs.
- Python needed no code changes (routes through the core paths); verified end-to-end via a maturin build.

## Testing

- `cargo test`: all 30 test targets pass. New `tests/index_vlsd.rs` (5 tests: round trip on all entry points, multi-fragment uneven `##SD` with a 5 MB entry, JSON persistence, old-index compat, timestamp alignment); `tests/fix_index.rs` A3 rewritten from "must error" to "must resolve correctly".
- js suite: 28/28 pass (wasm32 + wasm-bindgen build); `js/test/vlsd-index.test.ts` updated to lock in the working index path.
- `--features pyo3` and `--features http` build clean; Python end-to-end check passes (strings via `read`, NaN via `values`, `byte_ranges` refusal, fixed channels unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBno3zxag8T62Z3HRYKR8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBno3zxag8T62Z3HRYKR8d)_