### PR TITLE
fix: let npm trusted publishing authenticate the release npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,10 +427,14 @@ jobs:
       # so wasm-pack needs no binaryen download at build time.
       - name: Install wasm-pack
         run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
+      # Deliberately no `registry-url` here: setting it makes setup-node
+      # write an .npmrc with `_authToken=${NODE_AUTH_TOKEN}` (and export a
+      # placeholder value for that variable), and a configured auth token
+      # takes precedence over OIDC — npm then publishes with the bogus
+      # token and fails with E404 instead of using trusted publishing.
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
       # Trusted publishing needs npm >= 11.5.1; Node 22 bundles npm 10.
       - name: Update npm for trusted publishing
         run: npm install -g npm@latest && npm --version


### PR DESCRIPTION
## Summary

The v3.2.1 release published to crates.io and PyPI, but the `publish-npm` job failed with `E404` on `PUT /mf4-rs`. Root cause: `setup-node`'s `registry-url` option writes an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` and exports a placeholder value for that variable. A configured auth token takes precedence over OIDC, so npm never performed the trusted-publishing exchange and published with invalid credentials (the job log shows no provenance/OIDC notice before the 404).

Fix: drop `registry-url` from the `setup-node` step. With no token configured, npm ≥ 11.5.1 detects the GitHub Actions OIDC context and uses the package's Trusted Publisher entry, attaching provenance automatically.

Typed as `fix:` so this release runs the pipeline end-to-end and npm receives its first CI-published version (npm currently sits at the manually published 3.2.0 while crates.io/PyPI are at 3.2.1).

## Verification

The failing step is registry-side auth, only reachable from the release workflow itself — this PR re-runs it for real via the v3.2.2 release. Everything before the publish (wasm build, tsc, 28 js tests, tarball contents incl. `pkg-node/mf4_rs_bg.wasm`) already passed in the v3.2.1 run. YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqmuGLksbp4v9CXBGwmiak

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqmuGLksbp4v9CXBGwmiak)_