### PR TITLE
feat: defer conversion block resolution to read time for remote indexes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ The codebase is organized into distinct layers. The module structure is defined 
   - Lazy reads via the attached source: `read(name)` / `read_in(group, name)` return a [`Signal`](src/signal.rs) (values paired with the group master/time axis); `source()` / `set_file()` / `set_url()` / `set_source()` manage the source
   - Explicit/custom readers: bind with `open(reader)` / `open_file(path)` → returns an `MdfReader` with `values(name)` / `values_in()` / `values_f64()` / `signal(name)` / `signal_in()`; `reader_mut()` / `into_inner()` expose the underlying `ByteRangeReader`
   - Byte ranges (power-user / partial reads): `byte_ranges(name)`, `byte_ranges_in(group, name)`, `byte_ranges_for_records(name, start, count)` — refused for VLSD channels, whose offset indirection a static range cannot express (use `read()` / `values()` instead)
-  - Conversions are resolved during index creation, enabling reads with empty `file_data` (`&[]`)
+  - Conversions: local builds (`from_file` / `from_bytes`) resolve them eagerly into `IndexedChannel.conversion`, so reads can apply them with empty `file_data` (`&[]`). Remote / range-reader builds (`from_url` / `from_range_reader`) **defer** resolution — they record only `IndexedChannel.conversion_addr` and fetch + resolve the conversion block lazily on the first value read (so building an index never pays for conversion blocks you never read). Read paths prefer a resolved `conversion` and otherwise resolve via `conversion_addr` through the reader; `MdfIndex::conversion(name)` resolves one on demand via the attached source. `CachingRangeReader` in bypass mode now serves reads already covered by cached metadata chunks, so a lazily-resolved conversion block that was pulled in during the walk stays free.
 - `Signal` (`src/signal.rs`) is the Rust equivalent of a pandas `Series`: `{ name, unit, timestamps: Vec<f64>, values: Vec<Option<DecodedValue>> }`, with `values_f64()` / `has_timestamps()`. Produced by `MDF::signal()`, `ChannelGroup::signal()`, `MdfReader::signal()`, and `MdfIndex::read()`.
 
 ### 6. File Operations
@@ -329,9 +329,11 @@ Channels with `channel_type == 1` and a non-zero `data` field store variable-len
 - `OpenDataBlock` tracks all state for an in-progress data block including DT fragment positions for later DL creation
 
 ### When Modifying the Index System
-- The index must be fully self-contained: no file references, all conversions pre-resolved
-- `IndexedChannel.conversion` stores a `ConversionBlock` with `resolved_texts`, `resolved_conversions`, and `default_conversion` populated
-- When reading via index, conversions are applied with empty file data (`&[]`) since all dependencies are resolved
+- The index metadata is self-contained (no file references). Conversions are self-contained only for **local** builds; **remote** (range-reader / URL) builds record only `IndexedChannel.conversion_addr` and resolve lazily on read (see below)
+- `IndexedChannel.conversion` stores a fully resolved `ConversionBlock` (with `resolved_texts`, `resolved_conversions`, and `default_conversion` populated) for local builds; it is `None` for remote builds, where `IndexedChannel.conversion_addr` holds the `##CC` block's file offset instead
+- Conversion resolution at read time is centralized in `MdfIndex::resolve_conversion` (prefers a resolved `conversion`, else fetches + resolves via the reader using `conversion_addr`). The decode helpers (`decode_records_to_values` / `decode_records_to_f64` / `read_vlsd_channel_values`) take the resolved `Option<&ConversionBlock>` as a parameter rather than reading it off the channel
+- When a resolved conversion is present, it is applied with empty file data (`&[]`) since all dependencies are pre-resolved
+- The wasm fragment-read path resolves deferred conversions via `conversionRangesStep` (a `RecordingRangeReader`-driven gap loop in `js/src/mdf-index.ts`), so the JS side fetches the conversion blocks a network-built index needs before decoding
 - `ByteRangeReader` trait allows plugging in HTTP, S3, or other data sources
 - VLSD channels (`channel_type == 1`) are readable through the index: each channel's `##SD` fragment chain is captured at build time in `IndexedChannel.vlsd_data_blocks`, and `read()` / `values()` resolve each record's inline 8-byte offset into that stream. `byte_ranges()` still refuses VLSD channels (a static range cannot express the offset indirection). Old JSON indexes without `vlsd_data_blocks` load fine but error on VLSD reads with a "rebuild the index" message.
 - Compressed blocks (`##DZ`) are not yet supported in the index reader

--- a/js/src/mdf-index.ts
+++ b/js/src/mdf-index.ts
@@ -64,6 +64,11 @@ export class MdfIndex {
    * typical file this transfers a few KB regardless of the file's size. Use it
    * with `FetchRangeSource` (HTTP), `FileRangeSource` (Node), or any custom
    * source. `source.size()` must be implemented.
+   *
+   * Channel conversions are **not** fetched during the build — only their
+   * locations are recorded. `values`/`read` fetch and resolve a channel's
+   * conversion lazily on first read, so building the index never pays for
+   * conversion blocks you never read.
    */
   static async fromRangeSource(source: RangeSource): Promise<MdfIndex> {
     const wasm = getWasmModule();
@@ -246,6 +251,9 @@ export class MdfIndex {
   async values(name: string, source: RangeSource, group?: string | null): Promise<Float64Array> {
     const ranges = this.signalByteRanges(name, group);
     const fragments = await readAllRanges(source, ranges);
+    // Indexes built over the network resolve conversions lazily; fetch the
+    // channel's conversion blocks (if any) so the decoder can apply them.
+    await this.#fetchConversionRanges(name, group, false, source, ranges, fragments);
     return this.valuesFromFragments(name, group, ranges, fragments);
   }
 
@@ -259,7 +267,47 @@ export class MdfIndex {
   async read(name: string, source: RangeSource, group?: string | null): Promise<Signal> {
     const ranges = this.signalByteRanges(name, group);
     const fragments = await readAllRanges(source, ranges);
+    // A signal read decodes the group master too, so resolve the master's
+    // conversion as well as the channel's (withMaster = true).
+    await this.#fetchConversionRanges(name, group, true, source, ranges, fragments);
     return this.readFromFragments(name, group, ranges, fragments);
+  }
+
+  /**
+   * Fetch the conversion-block byte ranges a lazy (network-built) index needs
+   * to apply conversions, appending them to `ranges`/`fragments` in place.
+   *
+   * A no-op for self-contained indexes (built from bytes) and channels with no
+   * conversion — `conversionRangesStep` reports `done` immediately. Otherwise
+   * it drives the same gap-fetch loop as the index build, fetching each
+   * reported range from `source` until every conversion block for the read is
+   * present.
+   */
+  async #fetchConversionRanges(
+    name: string,
+    group: string | null | undefined,
+    withMaster: boolean,
+    source: RangeSource,
+    ranges: ByteRange[],
+    fragments: Uint8Array[],
+  ): Promise<void> {
+    const size = this.fileSize();
+    // Conversion chains are short; a small look-ahead keeps this to one or two
+    // round-trips even when a block and its text refs sit adjacently.
+    const CONVERSION_LOOKAHEAD_BYTES = 8 * 1024;
+    const maxRounds = 10_000;
+    for (let round = 0; round < maxRounds; round++) {
+      const step = this.inner.conversionRangesStep(name, group, withMaster, ranges, fragments);
+      if (step.done) return;
+      const [offset, length] = step.needed as [number, number];
+      const want = Math.min(Math.max(length, CONVERSION_LOOKAHEAD_BYTES), size - offset);
+      const bytes = await source.read(offset, want);
+      ranges.push([offset, bytes.length]);
+      fragments.push(bytes);
+    }
+    throw new Error(
+      "MdfIndex: conversion resolution did not converge; the index or source may be inconsistent.",
+    );
   }
 
   /** Free the underlying wasm memory. Safe to call multiple times. */

--- a/js/src/wasm-module.ts
+++ b/js/src/wasm-module.ts
@@ -44,6 +44,13 @@ export interface WasmMdfIndex {
   channelNames(): string[];
   fileSize(): number;
   groups(): unknown;
+  conversionRangesStep(
+    name: string,
+    group: string | null | undefined,
+    with_master: boolean,
+    ranges: unknown,
+    fragments: unknown,
+  ): WasmBuildStep;
   readFromFragments(
     name: string,
     group: string | null | undefined,

--- a/src/index.rs
+++ b/src/index.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 use crate::api::mdf::MDF;
-use crate::blocks::common::{DataType, BlockParse};
+use crate::blocks::common::{DataType, BlockHeader, BlockParse};
 use crate::blocks::conversion::{ConversionBlock, ConversionType};
 use crate::error::MdfError;
 use crate::parsing::decoder::{check_value_validity, decode_channel_value, decode_channel_value_with_validity, decode_f64_from_record, DecodedValue};
@@ -44,8 +44,26 @@ pub struct IndexedChannel {
     pub flags: u32,
     /// Position of invalidation bit within invalidation bytes
     pub pos_invalidation_bit: u32,
-    /// Conversion block for unit conversion (if any)
+    /// Conversion block for unit conversion (if any).
+    ///
+    /// May be `None` even when the channel *has* a conversion: index builds
+    /// that read a file over the network ([`MdfIndex::from_url`] /
+    /// [`MdfIndex::from_range_reader`]) do **not** fetch and resolve the
+    /// conversion block up front — they only record its file offset in
+    /// [`conversion_addr`](Self::conversion_addr) and resolve it lazily on the
+    /// first value read. Indexes built from a local file or an in-memory buffer
+    /// still resolve eagerly, so this stays populated for them. Read paths
+    /// prefer a resolved conversion here and otherwise fall back to
+    /// `conversion_addr`.
     pub conversion: Option<ConversionBlock>,
+    /// File offset of the channel's `##CC` conversion block (0 = none).
+    ///
+    /// Recorded so the conversion can be resolved lazily at read time when it
+    /// was not resolved during index building (the remote / range-reader
+    /// path). Defaults to 0 for older serialized indexes, which carry the fully
+    /// resolved [`conversion`](Self::conversion) instead.
+    #[serde(default)]
+    pub conversion_addr: u64,
     /// For VLSD channels: address of signal data blocks
     pub vlsd_data_address: Option<u64>,
     /// For VLSD channels: locations of the ##SD fragments in chain order.
@@ -436,9 +454,12 @@ impl<R: ByteRangeReader<Error = MdfError>> CachingRangeReader<R> {
         }
     }
 
-    /// When set, every read forwards directly to the underlying reader.
-    /// Use during value-read phases so large data-block fetches do not
-    /// populate the cache.
+    /// When set, reads are served from already-cached chunks when fully
+    /// covered, and otherwise forward directly to the underlying reader without
+    /// populating the cache. Use during value-read phases so large data-block
+    /// fetches do not pollute the cache, while small metadata reads that were
+    /// already pulled in during the index walk (such as a conversion block
+    /// resolved lazily on first read) remain free.
     pub fn set_bypass(&mut self, bypass: bool) {
         self.bypass = bypass;
     }
@@ -459,6 +480,47 @@ impl<R: ByteRangeReader<Error = MdfError>> CachingRangeReader<R> {
             return Ok(());
         }
         self.read_range(offset, length).map(|_| ())
+    }
+
+    /// Try to satisfy a read entirely from chunks already in the cache,
+    /// without issuing any underlying request. Returns `None` if any covering
+    /// chunk is absent or too short (e.g. an EOF-clamped tail), leaving the
+    /// caller to fetch. Used in bypass mode so small reads that land in
+    /// already-fetched metadata chunks (e.g. a lazily-resolved conversion
+    /// block) stay free, while large uncached data reads still forward straight
+    /// through.
+    fn try_serve_from_cache(&self, offset: u64, length: u64) -> Option<Vec<u8>> {
+        let first = offset / self.chunk_size;
+        let last = (offset + length - 1) / self.chunk_size;
+        let read_end = offset + length;
+        for i in first..=last {
+            let chunk = self.chunks.get(&i)?;
+            let chunk_start = i * self.chunk_size;
+            let cached_end = chunk_start + chunk.len() as u64;
+            let needed_end = read_end.min(chunk_start + self.chunk_size);
+            if cached_end < needed_end {
+                return None;
+            }
+        }
+        let mut out = Vec::with_capacity(length.min(1 << 24) as usize);
+        let mut remaining = length as usize;
+        let mut cursor = offset;
+        while remaining > 0 {
+            let chunk_index = cursor / self.chunk_size;
+            let chunk_offset = (cursor % self.chunk_size) as usize;
+            let chunk = self.chunks.get(&chunk_index)?;
+            if chunk_offset >= chunk.len() {
+                return None;
+            }
+            let take = std::cmp::min(remaining, chunk.len() - chunk_offset);
+            out.extend_from_slice(&chunk[chunk_offset..chunk_offset + take]);
+            cursor += take as u64;
+            remaining -= take;
+            if take == 0 {
+                return None;
+            }
+        }
+        Some(out)
     }
 
     fn ensure_chunks(&mut self, first: u64, last: u64, requested_end: u64) -> Result<(), MdfError> {
@@ -548,6 +610,14 @@ impl<R: ByteRangeReader<Error = MdfError>> ByteRangeReader for CachingRangeReade
             return Ok(Vec::new());
         }
         if self.bypass {
+            // Serve from already-cached chunks when possible (e.g. a small
+            // conversion block lazily resolved at read time that lands in a
+            // metadata chunk fetched during the index walk); otherwise forward
+            // the (typically large data-block) read straight through.
+            if let Some(bytes) = self.try_serve_from_cache(offset, length) {
+                self.cache_hits += 1;
+                return Ok(bytes);
+            }
             let bytes = self.inner.read_range(offset, length)?;
             self.underlying_requests += 1;
             return Ok(bytes);
@@ -864,6 +934,7 @@ impl MdfIndex {
                     flags: block.flags,
                     pos_invalidation_bit: block.pos_invalidation_bit,
                     conversion: resolved_conversion,
+                    conversion_addr: block.conversion_addr,
                     vlsd_data_address: if block.channel_type == 1 && block.data != 0 {
                         Some(block.data)
                     } else {
@@ -1018,7 +1089,11 @@ impl MdfIndex {
                     channel_type: block.channel_type,
                     flags: block.flags,
                     pos_invalidation_bit: block.pos_invalidation_bit,
-                    conversion: ch.conversion,
+                    // Remote / range-reader builds defer conversion resolution:
+                    // only the block's location is recorded here; it is fetched
+                    // and resolved lazily on the first value read.
+                    conversion: None,
+                    conversion_addr: ch.conversion_addr,
                     vlsd_data_address: if block.channel_type == 1 && block.data != 0 {
                         Some(block.data)
                     } else {
@@ -1417,17 +1492,74 @@ impl MdfIndex {
         let channel = group.channels.get(channel_index)
             .ok_or_else(|| MdfError::BlockSerializationError("Invalid channel index".to_string()))?;
 
+        let conversion = Self::resolve_conversion(channel, reader)?;
+
         if channel.channel_type == 1 {
-            return self.read_vlsd_channel_values(group, channel, reader);
+            return self.read_vlsd_channel_values(group, channel, conversion.as_ref(), reader);
         }
 
         // For regular channels, read from data blocks
-        self.read_regular_channel_values(group, channel, reader)
+        self.read_regular_channel_values(group, channel, conversion.as_ref(), reader)
+    }
+
+    /// Resolve a channel's conversion for reading.
+    ///
+    /// Prefers a conversion already resolved into the index (local-file /
+    /// in-memory builds, and older serialized indexes). Otherwise — the remote
+    /// / range-reader build path, which records only
+    /// [`IndexedChannel::conversion_addr`] — it fetches the `##CC` block and
+    /// resolves its dependency chain through `reader`, exactly when the caller
+    /// asks to read values. Returns `None` when the channel has no conversion.
+    fn resolve_conversion<R: ByteRangeReader<Error = MdfError>>(
+        channel: &IndexedChannel,
+        reader: &mut R,
+    ) -> Result<Option<ConversionBlock>, MdfError> {
+        if let Some(conv) = &channel.conversion {
+            return Ok(Some(conv.clone()));
+        }
+        if channel.conversion_addr == 0 {
+            return Ok(None);
+        }
+        let addr = channel.conversion_addr;
+        let header_bytes = reader.read_range(addr, 24)?;
+        let header = BlockHeader::from_bytes(&header_bytes)?;
+        if header.id != "##CC" {
+            return Err(MdfError::BlockIDError {
+                actual: header.id,
+                expected: "##CC".to_string(),
+            });
+        }
+        let full = reader.read_range(addr, header.block_len)?;
+        let mut cc = ConversionBlock::from_bytes(&full)?;
+        cc.resolve_all_dependencies_via_reader(reader, addr)?;
+        Ok(Some(cc))
+    }
+
+    /// Resolve the conversion of the channel at `(g, c)` using `reader`,
+    /// following the same lazy rules as the read paths. Crate-visible so the
+    /// wasm bindings can drive fragment-based conversion resolution: pointing a
+    /// gap-reporting reader at this lets the JS side discover exactly which
+    /// conversion-block byte ranges it must fetch before a fragment read.
+    #[allow(dead_code)] // used by the wasm bindings (wasm feature)
+    pub(crate) fn resolve_channel_conversion<R: ByteRangeReader<Error = MdfError>>(
+        &self,
+        g: usize,
+        c: usize,
+        reader: &mut R,
+    ) -> Result<Option<ConversionBlock>, MdfError> {
+        let channel = self
+            .channel_groups
+            .get(g)
+            .and_then(|grp| grp.channels.get(c))
+            .ok_or_else(|| {
+                MdfError::BlockSerializationError("Invalid channel index".to_string())
+            })?;
+        Self::resolve_conversion(channel, reader)
     }
 
     /// Extract linear conversion coefficients (a, b) for inline application.
-    fn get_linear_coeffs(channel: &IndexedChannel) -> Option<(f64, f64)> {
-        channel.conversion.as_ref().and_then(|conv| {
+    fn get_linear_coeffs(conversion: Option<&ConversionBlock>) -> Option<(f64, f64)> {
+        conversion.and_then(|conv| {
             if conv.cc_type == ConversionType::Linear && conv.cc_val.len() >= 2 {
                 Some((conv.cc_val[0], conv.cc_val[1]))
             } else {
@@ -1441,6 +1573,7 @@ impl MdfIndex {
         &self,
         group: &IndexedChannelGroup,
         channel: &IndexedChannel,
+        conversion: Option<&ConversionBlock>,
         reader: &mut R,
     ) -> Result<Vec<Option<DecodedValue>>, MdfError> {
         let record_size = Self::checked_record_size(group)?;
@@ -1462,7 +1595,7 @@ impl MdfIndex {
         for data_block in &group.data_blocks {
             let block_data = reader
                 .read_range(data_block.file_offset + 24, Self::data_section_size(data_block)?)?;
-            Self::decode_records_to_values(&block_data, record_size, group, channel, &temp_cb, &mut values)?;
+            Self::decode_records_to_values(&block_data, record_size, group, conversion, &temp_cb, &mut values)?;
         }
 
         Ok(values)
@@ -1480,6 +1613,7 @@ impl MdfIndex {
         &self,
         group: &IndexedChannelGroup,
         channel: &IndexedChannel,
+        conversion: Option<&ConversionBlock>,
         reader: &mut R,
     ) -> Result<Vec<Option<DecodedValue>>, MdfError> {
         // Compressed fragments (either the fixed records or the SD stream) are
@@ -1628,7 +1762,7 @@ impl MdfIndex {
                 let payload = &frag[start..end];
 
                 if let Some(value) = decode_channel_value(payload, 0, &payload_cb) {
-                    let final_value = if let Some(conversion) = &channel.conversion {
+                    let final_value = if let Some(conversion) = conversion {
                         conversion.apply_decoded(value, &[])?
                     } else {
                         value
@@ -1664,7 +1798,7 @@ impl MdfIndex {
         block_data: &[u8],
         record_size: usize,
         group: &IndexedChannelGroup,
-        channel: &IndexedChannel,
+        conversion: Option<&ConversionBlock>,
         temp_cb: &crate::blocks::channel_block::ChannelBlock,
         values: &mut Vec<Option<DecodedValue>>,
     ) -> Result<(), MdfError> {
@@ -1691,7 +1825,7 @@ impl MdfIndex {
                 record, record_id_len, cg_data_bytes, temp_cb,
             ) {
                 if decoded.is_valid {
-                    let final_value = if let Some(conversion) = &channel.conversion {
+                    let final_value = if let Some(conversion) = conversion {
                         conversion.apply_decoded(decoded.value, &[])?
                     } else {
                         decoded.value
@@ -1715,6 +1849,7 @@ impl MdfIndex {
         record_size: usize,
         group: &IndexedChannelGroup,
         channel: &IndexedChannel,
+        conversion: Option<&ConversionBlock>,
         temp_cb: &crate::blocks::channel_block::ChannelBlock,
         linear_coeffs: Option<(f64, f64)>,
         has_conversion: bool,
@@ -1772,7 +1907,7 @@ impl MdfIndex {
                     if let Some(decoded) = decode_channel_value_with_validity(
                         record, record_id_len, cg_data_bytes, temp_cb,
                     ) {
-                        match channel.conversion.as_ref().unwrap().apply_decoded(decoded.value, &[])? {
+                        match conversion.unwrap().apply_decoded(decoded.value, &[])? {
                             DecodedValue::Float(v) => values.push(v),
                             DecodedValue::UnsignedInteger(v) => values.push(v as f64),
                             DecodedValue::SignedInteger(v) => values.push(v as f64),
@@ -1798,7 +1933,7 @@ impl MdfIndex {
                         if let Some(decoded) = decode_channel_value_with_validity(
                             record, record_id_len, cg_data_bytes, temp_cb,
                         ) {
-                            match channel.conversion.as_ref().unwrap().apply_decoded(decoded.value, &[])? {
+                            match conversion.unwrap().apply_decoded(decoded.value, &[])? {
                                 DecodedValue::Float(v) => values.push(v),
                                 DecodedValue::UnsignedInteger(v) => values.push(v as f64),
                                 DecodedValue::SignedInteger(v) => values.push(v as f64),
@@ -2037,6 +2172,45 @@ impl MdfIndex {
                 let mut cached = CachingRangeReader::new(http);
                 cached.set_bypass(true);
                 self.read_channel_values(g, c, &mut cached)
+            }
+        }
+    }
+
+    /// Resolve a channel's conversion, fetching it through the attached source
+    /// if it was not resolved at index-build time (the remote / range-reader
+    /// path records only its location — see [`IndexedChannel::conversion_addr`]).
+    ///
+    /// Returns `None` when the channel has no conversion. Errors if resolution
+    /// needs the source (a deferred conversion) but none is attached — attach
+    /// one with [`set_file`](Self::set_file) / [`set_url`](Self::set_url).
+    pub fn conversion(&self, name: &str) -> Result<Option<ConversionBlock>, MdfError> {
+        let (g, c) = self.locate(name).ok_or_else(|| {
+            MdfError::BlockSerializationError(format!("Channel '{}' not found", name))
+        })?;
+        let channel = &self.channel_groups[g].channels[c];
+        if let Some(conv) = &channel.conversion {
+            return Ok(Some(conv.clone()));
+        }
+        if channel.conversion_addr == 0 {
+            return Ok(None);
+        }
+        match self.require_source()? {
+            #[cfg(not(target_arch = "wasm32"))]
+            Source::File(path) => {
+                let file = std::fs::File::open(path).map_err(MdfError::IOError)?;
+                let mmap = unsafe { memmap2::Mmap::map(&file) }.map_err(MdfError::IOError)?;
+                let mut slice_reader = BorrowedSliceReader { data: &mmap };
+                Self::resolve_conversion(channel, &mut slice_reader)
+            }
+            #[cfg(target_arch = "wasm32")]
+            Source::File(_) => Err(MdfError::BlockSerializationError(
+                "file sources are not available on wasm32".to_string(),
+            )),
+            #[cfg(feature = "http")]
+            Source::Url(url) => {
+                let http = HttpRangeReader::new(url)?;
+                let mut cached = CachingRangeReader::new(http);
+                Self::resolve_conversion(channel, &mut cached)
             }
         }
     }
@@ -2290,8 +2464,10 @@ impl MdfIndex {
         let channel = group.channels.get(channel_index)
             .ok_or_else(|| MdfError::BlockSerializationError("Invalid channel index".to_string()))?;
 
+        let conversion = Self::resolve_conversion(channel, reader)?;
+
         if channel.channel_type == 1 {
-            let vals = self.read_vlsd_channel_values(group, channel, reader)?;
+            let vals = self.read_vlsd_channel_values(group, channel, conversion.as_ref(), reader)?;
             return Ok(Self::vlsd_values_to_f64(vals));
         }
 
@@ -2312,13 +2488,13 @@ impl MdfIndex {
         let mut values = Vec::with_capacity(total_records.min(1 << 24));
 
         let temp_cb = channel.to_decode_only_channel_block();
-        let linear_coeffs = Self::get_linear_coeffs(channel);
-        let has_conversion = channel.conversion.is_some();
+        let linear_coeffs = Self::get_linear_coeffs(conversion.as_ref());
+        let has_conversion = conversion.is_some();
 
         for data_block in &group.data_blocks {
             let block_data = reader
                 .read_range(data_block.file_offset + 24, Self::data_section_size(data_block)?)?;
-            Self::decode_records_to_f64(&block_data, record_size, group, channel, &temp_cb, linear_coeffs, has_conversion, &mut values)?;
+            Self::decode_records_to_f64(&block_data, record_size, group, channel, conversion.as_ref(), &temp_cb, linear_coeffs, has_conversion, &mut values)?;
         }
 
         Ok(values)
@@ -2341,9 +2517,11 @@ impl MdfIndex {
         let channel = group.channels.get(channel_index)
             .ok_or_else(|| MdfError::BlockSerializationError("Invalid channel index".to_string()))?;
 
+        let mut slice_reader = BorrowedSliceReader { data: file_data };
+        let conversion = Self::resolve_conversion(channel, &mut slice_reader)?;
+
         if channel.channel_type == 1 {
-            let mut slice_reader = BorrowedSliceReader { data: file_data };
-            return self.read_vlsd_channel_values(group, channel, &mut slice_reader);
+            return self.read_vlsd_channel_values(group, channel, conversion.as_ref(), &mut slice_reader);
         }
 
         let record_size = Self::checked_record_size(group)?;
@@ -2364,7 +2542,7 @@ impl MdfIndex {
 
         for data_block in &group.data_blocks {
             let block_data = Self::slice_data_block(file_data, data_block)?;
-            Self::decode_records_to_values(block_data, record_size, group, channel, &temp_cb, &mut values)?;
+            Self::decode_records_to_values(block_data, record_size, group, conversion.as_ref(), &temp_cb, &mut values)?;
         }
 
         Ok(values)
@@ -2387,9 +2565,11 @@ impl MdfIndex {
         let channel = group.channels.get(channel_index)
             .ok_or_else(|| MdfError::BlockSerializationError("Invalid channel index".to_string()))?;
 
+        let mut slice_reader = BorrowedSliceReader { data: file_data };
+        let conversion = Self::resolve_conversion(channel, &mut slice_reader)?;
+
         if channel.channel_type == 1 {
-            let mut slice_reader = BorrowedSliceReader { data: file_data };
-            let vals = self.read_vlsd_channel_values(group, channel, &mut slice_reader)?;
+            let vals = self.read_vlsd_channel_values(group, channel, conversion.as_ref(), &mut slice_reader)?;
             return Ok(Self::vlsd_values_to_f64(vals));
         }
 
@@ -2408,12 +2588,12 @@ impl MdfIndex {
         // vector still grows as needed; real reads fail earlier at the reader.
         let mut values = Vec::with_capacity(total_records.min(1 << 24));
         let temp_cb = channel.to_decode_only_channel_block();
-        let linear_coeffs = Self::get_linear_coeffs(channel);
-        let has_conversion = channel.conversion.is_some();
+        let linear_coeffs = Self::get_linear_coeffs(conversion.as_ref());
+        let has_conversion = conversion.is_some();
 
         for data_block in &group.data_blocks {
             let block_data = Self::slice_data_block(file_data, data_block)?;
-            Self::decode_records_to_f64(block_data, record_size, group, channel, &temp_cb, linear_coeffs, has_conversion, &mut values)?;
+            Self::decode_records_to_f64(block_data, record_size, group, channel, conversion.as_ref(), &temp_cb, linear_coeffs, has_conversion, &mut values)?;
         }
 
         Ok(values)

--- a/src/parsing/reader_walk.rs
+++ b/src/parsing/reader_walk.rs
@@ -9,8 +9,7 @@
 
 use crate::blocks::channel_block::ChannelBlock;
 use crate::blocks::channel_group_block::ChannelGroupBlock;
-use crate::blocks::common::{read_string_block_via_reader, BlockHeader, BlockParse};
-use crate::blocks::conversion::ConversionBlock;
+use crate::blocks::common::{read_string_block_via_reader, BlockParse};
 use crate::blocks::data_group_block::DataGroupBlock;
 use crate::blocks::header_block::HeaderBlock;
 use crate::blocks::identification_block::IdentificationBlock;
@@ -21,7 +20,14 @@ pub(crate) struct WalkedChannel {
     pub block: ChannelBlock,
     pub name: Option<String>,
     pub unit: Option<String>,
-    pub conversion: Option<ConversionBlock>,
+    /// File offset of the channel's `##CC` conversion block (0 = none).
+    ///
+    /// The walk deliberately does **not** fetch or resolve the conversion
+    /// block: doing so up front would issue a burst of range requests (the
+    /// block, its referenced text blocks, and any nested conversions) for
+    /// every channel while building the index. Only the address is recorded;
+    /// the index resolves it lazily on the first value read.
+    pub conversion_addr: u64,
 }
 
 pub(crate) struct WalkedGroup {
@@ -85,30 +91,15 @@ where
                 let name = read_string_block_via_reader(reader, cn.name_addr)?;
                 let unit = read_string_block_via_reader(reader, cn.unit_addr)?;
 
-                let conversion = if cn.conversion_addr != 0 {
-                    let cc_header_bytes = reader.read_range(cn.conversion_addr, 24)?;
-                    let cc_header = BlockHeader::from_bytes(&cc_header_bytes)?;
-                    let cc_full =
-                        reader.read_range(cn.conversion_addr, cc_header.block_len)?;
-                    let mut cc = ConversionBlock::from_bytes(&cc_full)?;
-                    if let Err(e) =
-                        cc.resolve_all_dependencies_via_reader(reader, cn.conversion_addr)
-                    {
-                        eprintln!(
-                            "Warning: failed to resolve conversion for channel {:?}: {e}",
-                            name.as_deref().unwrap_or("<unnamed>")
-                        );
-                    }
-                    Some(cc)
-                } else {
-                    None
-                };
+                // Record where the conversion lives, but do not fetch/resolve
+                // it now — that happens lazily on the first value read.
+                let conversion_addr = cn.conversion_addr;
 
                 channels.push(WalkedChannel {
                     block: cn,
                     name,
                     unit,
-                    conversion,
+                    conversion_addr,
                 });
 
                 ch_addr = next_ch_addr;

--- a/src/python.rs
+++ b/src/python.rs
@@ -1383,12 +1383,15 @@ impl PyMdfIndex {
     /// describing it (``conversion_type``, ``values``, ``resolved_texts``,
     /// ``formula`` …).
     fn conversion_info(&self, name: &str) -> PyResult<Option<HashMap<String, PyObject>>> {
-        let (g, c) = self.index.locate(name).ok_or_else(|| {
-            MdfException::new_err(format!("Channel '{}' not found", name))
-        })?;
-        let channel = &self.index.groups()[g].channels[c];
+        // Resolve lazily through the attached source: indexes built over the
+        // network record only the conversion block's location, fetching it on
+        // demand (here, or on the first value read).
+        let resolved = self
+            .index
+            .conversion(name)
+            .map_err(|e| MdfException::new_err(e.to_string()))?;
 
-        if let Some(conversion) = &channel.conversion {
+        if let Some(conversion) = resolved.as_ref() {
             Python::with_gil(|py| {
                 let mut info = HashMap::new();
                 info.insert("conversion_type".to_string(), format!("{:?}", conversion.cc_type).to_object(py));

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -605,6 +605,15 @@ impl WasmMdfIndex {
         })
     }
 
+    /// Index of the group's master channel, if any, excluding `c` itself.
+    fn master_index(&self, g: usize, c: usize) -> Option<usize> {
+        let grp = self.index.channel_groups.get(g)?;
+        grp.channels
+            .iter()
+            .position(|ch| ch.is_master())
+            .filter(|&m| m != c)
+    }
+
     /// Full data-section byte ranges for the group owning `name`.
     ///
     /// Returns one `(file_offset + 24, size - 24)` span per `##DT`/`##DV`
@@ -700,6 +709,64 @@ impl WasmMdfIndex {
                 None => Err(err_to_js(e)),
             },
         }
+    }
+
+    /// Report the next conversion-block byte range still needed to read `name`
+    /// from fragments, or that all the conversion metadata is already present.
+    ///
+    /// Indexes built over the network (`fromUrl`/`fromRangeSource`) record only
+    /// each channel's conversion-block **location** and resolve it lazily on
+    /// the first read — so the fragment readers need those bytes fetched
+    /// alongside the data sections. Drive this like `buildIndexStep`: it
+    /// returns `{ done: true }` once every conversion block required for the
+    /// read is present in `fragments`, or `{ done: false, needed: [offset,
+    /// length] }` naming the next range to fetch and feed back. Pass
+    /// `withMaster = true` for a signal read (`read`/`readFromFragments`),
+    /// whose timestamps decode the group master and thus also need the
+    /// master's conversion; `false` for a plain values read. For a
+    /// self-contained index (built from bytes, or a channel with no
+    /// conversion) it returns `done` immediately with no fetching.
+    #[wasm_bindgen(js_name = conversionRangesStep)]
+    pub fn conversion_ranges_step(
+        &self,
+        name: &str,
+        group: Option<String>,
+        with_master: bool,
+        ranges: JsValue,
+        fragments: JsValue,
+    ) -> Result<JsValue, JsError> {
+        let (g, c) = self.locate(name, group.as_deref())?;
+        let parsed = build_fragment_reader(&ranges, &fragments)?;
+        let mut reader = RecordingRangeReader { fragments: parsed.fragments, miss: None };
+
+        let mut targets = vec![c];
+        if with_master {
+            if let Some(m) = self.master_index(g, c) {
+                targets.push(m);
+            }
+        }
+
+        for idx in targets {
+            reader.miss = None;
+            if let Err(e) = self.index.resolve_channel_conversion(g, idx, &mut reader) {
+                match reader.miss {
+                    Some((offset, length)) => {
+                        let step = BuildStepJs {
+                            done: false,
+                            json: None,
+                            needed: Some([offset as f64, length as f64]),
+                        };
+                        return serde_wasm_bindgen::to_value(&step)
+                            .map_err(|e| JsError::new(&e.to_string()));
+                    }
+                    // A real error (not a missing-range abort) — surface it.
+                    None => return Err(err_to_js(e)),
+                }
+            }
+        }
+
+        let step = BuildStepJs { done: true, json: None, needed: None };
+        serde_wasm_bindgen::to_value(&step).map_err(|e| JsError::new(&e.to_string()))
     }
 
     /// Serialise the index to a JSON string.

--- a/tests/enhanced_index_conversions.rs
+++ b/tests/enhanced_index_conversions.rs
@@ -261,6 +261,7 @@ fn test_index_serialization_with_resolved_data() -> Result<(), MdfError> {
         flags: 0,
         pos_invalidation_bit: 0,
         conversion: Some(conversion),
+        conversion_addr: 0,
         vlsd_data_address: None,
         vlsd_data_blocks: Vec::new(),
     };

--- a/tests/index_deferred_conversion.rs
+++ b/tests/index_deferred_conversion.rs
@@ -1,0 +1,93 @@
+//! Verifies that indexes built over a [`ByteRangeReader`] (the remote / URL
+//! path) defer conversion resolution: only the conversion block's location is
+//! recorded at build time, and the conversion is fetched + applied lazily on
+//! the first value read. Uses an in-memory [`SliceRangeReader`] so it runs
+//! without the `http` feature.
+
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::error::MdfError;
+use mf4_rs::index::{MdfIndex, SliceRangeReader};
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::writer::MdfWriter;
+
+/// Build a small file with a value-to-text conversion on a "State" channel and
+/// return its raw bytes.
+fn build_fixture() -> Result<Vec<u8>, MdfError> {
+    let tmp = std::env::temp_dir().join(format!(
+        "deferred_conv_{}.mf4",
+        std::process::id()
+    ));
+    let path = tmp.to_str().unwrap().to_string();
+
+    let mut writer = MdfWriter::new(&path)?;
+    writer.init_mdf_file()?;
+
+    let cg_id = writer.add_channel_group(None, |_| {})?;
+    let time_id = writer.add_channel(&cg_id, None, |ch| {
+        ch.data_type = DataType::FloatLE;
+        ch.name = Some("Time".to_string());
+        ch.bit_count = 64;
+    })?;
+    writer.set_time_channel(&time_id)?;
+
+    let state_id = writer.add_channel(&cg_id, Some(&time_id), |ch| {
+        ch.data_type = DataType::UnsignedIntegerLE;
+        ch.name = Some("State".to_string());
+        ch.bit_count = 32;
+    })?;
+    writer.add_value_to_text_conversion(&[(0, "OFF"), (1, "ON")], "UNKNOWN", Some(&state_id))?;
+
+    writer.start_data_block_for_cg(&cg_id, 0)?;
+    for r in 0..6u64 {
+        writer.write_record(
+            &cg_id,
+            &[
+                DecodedValue::Float(r as f64 * 0.1),
+                DecodedValue::UnsignedInteger(r % 3),
+            ],
+        )?;
+    }
+    writer.finish_data_block(&cg_id)?;
+    writer.finalize()?;
+
+    let bytes = std::fs::read(&path)?;
+    let _ = std::fs::remove_file(&path);
+    Ok(bytes)
+}
+
+#[test]
+fn range_reader_build_defers_conversion_and_reads_lazily() -> Result<(), MdfError> {
+    let bytes = build_fixture()?;
+    let file_size = bytes.len() as u64;
+
+    // Build the index over a byte-range reader (the remote path).
+    let mut reader = SliceRangeReader::new(bytes.clone());
+    let index = MdfIndex::from_range_reader(&mut reader, file_size)?;
+
+    // The conversion must NOT be resolved at build time — only its location
+    // recorded.
+    let state = index.channel("State").expect("State channel present");
+    assert!(
+        state.conversion.is_none(),
+        "conversion should be resolved lazily, not at build time"
+    );
+    assert!(
+        state.conversion_addr != 0,
+        "the conversion block location should be recorded for lazy resolution"
+    );
+
+    // Reading applies the (now lazily fetched) conversion: raw 0/1/2 map to
+    // OFF / ON / UNKNOWN (the default).
+    let mut bound = index.open(SliceRangeReader::new(bytes));
+    let values = bound.values("State")?;
+    let strings: Vec<String> = values
+        .into_iter()
+        .map(|v| match v {
+            Some(DecodedValue::String(s)) => s,
+            other => panic!("expected converted String value, got {:?}", other),
+        })
+        .collect();
+    assert_eq!(strings, vec!["OFF", "ON", "UNKNOWN", "OFF", "ON", "UNKNOWN"]);
+
+    Ok(())
+}


### PR DESCRIPTION
## What & why

Building an `MdfIndex` over a byte-range reader (`from_url` / `from_range_reader`) previously fetched and resolved **every** channel's conversion chain up front — the `##CC` block, its referenced text blocks, and any nested conversions — issuing a burst of range requests during the metadata walk for conversions you might never read.

This changes the remote path to **only record where the conversion lives** and resolve it lazily on the first value read. The benefit is consistent across all three packages (Rust crate, Python, npm/wasm).

## Changes

**Core (`src/index.rs`, `src/parsing/reader_walk.rs`)**
- New `IndexedChannel.conversion_addr` (serde-default, backward compatible). The range-reader walk records this instead of resolving the chain; `conversion` stays `None`.
- Local builds (`from_file` / `from_bytes`) still resolve eagerly, so those indexes remain fully self-contained.
- Reads resolve via a new `resolve_conversion` helper: prefer an already-resolved conversion (local builds + older JSON indexes), otherwise fetch + resolve via `conversion_addr` through the active reader. Decode helpers now take the resolved `Option<&ConversionBlock>` as a parameter.
- New `MdfIndex::conversion(name)` resolves one on demand via the attached source.
- `CachingRangeReader` in bypass mode now serves reads already covered by cached metadata chunks, so a lazily-resolved conversion block pulled in during the walk stays free at read time.

**Python (`src/python.rs`)**
- `conversion_info()` resolves lazily through the attached source (works on URL-built indexes). No signature change.

**wasm / npm (`src/wasm.rs`, `js/src/`)**
- New `MdfIndex.conversionRangesStep` drives a `RecordingRangeReader` gap loop; the JS `values()` / `read()` wrappers fetch the conversion blocks a network-built index needs before decoding. No-op for self-contained (`fromBytes`) indexes and channels without conversions.

## Testing
- `cargo test` (all suites) ✅, `cargo test --features http` (incl. `cloud_index` end-to-end — round-trip budget **drops from ≤10 to 2**) ✅
- New `tests/index_deferred_conversion.rs` locks in the deferred behavior ✅
- `cargo check --features pyo3` / `--features wasm` ✅
- `wasm-pack build` + `npm test` → 30 pass / 1 skipped (web) ✅, plus a targeted end-to-end check confirming a network-built index defers the conversion (`conversion: null`, `conversion_addr` set) and `read()` lazily applies it to the correct strings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtQ87a5wyoqndrCCEqk6PL)_