### PR TITLE
fix: initialise the wasm module in the many-channel lazy-index test

### DIFF
--- a/js/test/lazy-index-many-channel.test.ts
+++ b/js/test/lazy-index-many-channel.test.ts
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
+// Register the Node wasm loader (the `.` package entry does this for real
+// consumers; tests import the wrapper classes from source directly).
+import "../src/wasm-module-node";
 import { MdfIndex } from "../src/mdf-index";
 import { MdfWriter } from "../src/mdf-writer";
 import { BytesRangeSource, type RangeSource } from "../src/range-source";


### PR DESCRIPTION
## Problem

The v3.4.1 release published to crates.io and PyPI but the **npm publish failed**. `prepublishOnly` runs `npm test`, and the incremental-index regression test added in that release (`js/test/lazy-index-many-channel.test.ts`) called `new MdfWriter()` without importing `../src/wasm-module-node`, so the Node wasm loader was never registered:

```
not ok 15 - MdfIndex.fromRangeSource builds a many-channel file in few requests
  error: "mf4-rs wasm module is not initialised. On Node, import from 'mf4-rs' ..."
```

The library / perf code is unaffected — only the test's bootstrap was missing.

## Fix

Add `import "../src/wasm-module-node";` at the top of the test, exactly as `helpers.ts` and `vlsd-index.test.ts` do, so the Node wasm loader is registered before the wrapper classes are used.

This patch release re-runs the publish pipeline so the npm package finally ships the incremental-index performance fix (crates.io and PyPI re-publish at the new version too, which is harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013fypyc328iHTez3BXE5nvL)_