### PR TITLE
feat: batch gap discovery and add IndexBuilder for wasm index builds

### DIFF
--- a/examples/gen_canape_fixture.rs
+++ b/examples/gen_canape_fixture.rs
@@ -1,0 +1,434 @@
+//! Generate a large, CANape/DBC-flavoured MDF 4 fixture.
+//!
+//! Produces a ~100 MB file shaped like a CAN bus log that a measurement tool
+//! (CANape and friends) would write from a DBC database:
+//!
+//! - **200 channel groups**, one per CAN message, each in its **own data
+//!   group**, and each group's `##DT` block written *immediately* after its
+//!   metadata cluster. That interleaving — metadata, data, metadata, data —
+//!   is what real incremental writers produce, and it is the layout that makes
+//!   a remote index walk expensive (each `next_dg_addr` hop lands past a
+//!   multi-hundred-KB data block).
+//! - **33 channels per group**: one master (`t`) plus 32 DBC-style signals,
+//!   mostly small unsigned integers with a raw→physical factor/offset.
+//! - **Every signal carries a `##CC` conversion** — linear for most, plus
+//!   value-to-text enums (gear position, ignition state, system status), one
+//!   rational and one algebraic per group.
+//! - **Every signal carries a `##SI` source block** describing the bus
+//!   (`source_type = 2 / BUS`, `bus_type = 2 / CAN`), with the bus name shared
+//!   per group and a per-signal `Message.Signal` path, as a bus-logging tool
+//!   would emit.
+//! - Units are written as `##TX` blocks on every channel.
+//!
+//! Run it in release mode — it writes ~1.4 M records:
+//!
+//! ```text
+//! cargo run --release --example gen_canape_fixture -- out.mf4 [groups] [records_per_group]
+//! ```
+//!
+//! Defaults: `canape_like_100mb.mf4`, 200 groups, 7100 records per group.
+//!
+//! Two deliberate caveats, so the fixture is not mistaken for a full CANape
+//! clone: signals are byte-aligned rather than bit-packed into an 8-byte CAN
+//! payload (the writer lays channels out sequentially by byte), and no `##DZ`
+//! compression or `##FH` history block is written — mf4-rs writes neither. At
+//! the default size each group's data lands in a single `##DT` (well under the
+//! 4 MB split threshold), so no `##DL` fragment chains appear; raise
+//! `records_per_group` past ~61 700 if you want to exercise those too.
+
+use mf4_rs::blocks::common::{BlockHeader, DataType};
+use mf4_rs::blocks::conversion::{ConversionBlock, ConversionType};
+use mf4_rs::blocks::text_block::TextBlock;
+use mf4_rs::error::MdfError;
+use mf4_rs::writer::MdfWriter;
+
+/// Link-section byte offsets inside a `##CN` block (24-byte header + 8 links).
+const CN_LINK_SOURCE: u64 = 48;
+const CN_LINK_UNIT: u64 = 72;
+
+const DEFAULT_GROUPS: usize = 200;
+const DEFAULT_RECORDS: usize = 7_100;
+
+/// How a signal's raw value maps to a physical one.
+enum Conv {
+    /// `phys = offset + factor * raw`
+    Linear { offset: f64, factor: f64 },
+    /// Enumerated states, as a DBC value table becomes a `##CC` type 7.
+    ValueToText(&'static [(i64, &'static str)], &'static str),
+    /// `(p1*x² + p2*x + p3) / (p4*x² + p5*x + p6)`
+    Rational([f64; 6]),
+    /// MCD-2 MC text formula over `X`.
+    Algebraic(&'static str),
+}
+
+struct SigSpec {
+    name: &'static str,
+    unit: &'static str,
+    data_type: DataType,
+    bytes: u32,
+    conv: Conv,
+}
+
+const GEAR: &[(i64, &str)] = &[
+    (0, "P"),
+    (1, "R"),
+    (2, "N"),
+    (3, "D"),
+    (4, "S"),
+    (5, "M1"),
+    (6, "M2"),
+    (7, "M3"),
+];
+const IGNITION: &[(i64, &str)] = &[(0, "Off"), (1, "Acc"), (2, "Run"), (3, "Start")];
+const STATUS: &[(i64, &str)] = &[(0, "OK"), (1, "Warning"), (2, "Fault")];
+
+/// The 32-signal catalogue every message carries. Sizes are chosen so a
+/// record is a tidy 68 bytes: 8 (master) + 12×1 + 12×2 + 4×2 + 4×4.
+fn signal_catalogue() -> Vec<SigSpec> {
+    use DataType::{SignedIntegerLE as I, UnsignedIntegerLE as U};
+    macro_rules! lin {
+        ($o:expr, $f:expr) => {
+            Conv::Linear { offset: $o, factor: $f }
+        };
+    }
+    vec![
+        SigSpec { name: "EngSpeed",       unit: "rpm",   data_type: U, bytes: 2, conv: lin!(0.0, 0.25) },
+        SigSpec { name: "VehSpeed",       unit: "km/h",  data_type: U, bytes: 2, conv: lin!(0.0, 0.01) },
+        SigSpec { name: "CoolantTemp",    unit: "degC",  data_type: U, bytes: 1, conv: lin!(-40.0, 1.0) },
+        SigSpec { name: "IntakeAirTemp",  unit: "degC",  data_type: U, bytes: 1, conv: lin!(-40.0, 1.0) },
+        SigSpec { name: "ThrottlePos",    unit: "%",     data_type: U, bytes: 1, conv: lin!(0.0, 0.392157) },
+        SigSpec { name: "AccelPedalPos",  unit: "%",     data_type: U, bytes: 1, conv: lin!(0.0, 0.4) },
+        SigSpec { name: "EngLoad",        unit: "%",     data_type: U, bytes: 1, conv: lin!(0.0, 0.392157) },
+        SigSpec { name: "FuelLevel",      unit: "%",     data_type: U, bytes: 1, conv: lin!(0.0, 0.4) },
+        SigSpec { name: "MAP",            unit: "kPa",   data_type: U, bytes: 1, conv: lin!(0.0, 1.0) },
+        SigSpec { name: "OilPressure",    unit: "bar",   data_type: U, bytes: 1, conv: lin!(0.0, 0.05) },
+        SigSpec { name: "OilTemp",        unit: "degC",  data_type: U, bytes: 1, conv: lin!(-40.0, 1.0) },
+        SigSpec { name: "FuelRate",       unit: "L/h",   data_type: U, bytes: 2, conv: lin!(0.0, 0.05) },
+        SigSpec { name: "MAF",            unit: "g/s",   data_type: U, bytes: 2, conv: lin!(0.0, 0.01) },
+        SigSpec { name: "BatteryVoltage", unit: "V",     data_type: U, bytes: 2, conv: lin!(0.0, 0.001) },
+        SigSpec { name: "BoostPressure",  unit: "kPa",   data_type: U, bytes: 2, conv: lin!(-100.0, 0.1) },
+        SigSpec { name: "WheelSpeedFL",   unit: "km/h",  data_type: U, bytes: 2, conv: lin!(0.0, 0.05625) },
+        SigSpec { name: "WheelSpeedFR",   unit: "km/h",  data_type: U, bytes: 2, conv: lin!(0.0, 0.05625) },
+        SigSpec { name: "WheelSpeedRL",   unit: "km/h",  data_type: U, bytes: 2, conv: lin!(0.0, 0.05625) },
+        SigSpec { name: "WheelSpeedRR",   unit: "km/h",  data_type: U, bytes: 2, conv: lin!(0.0, 0.05625) },
+        SigSpec { name: "EngTorque",      unit: "Nm",    data_type: I, bytes: 2, conv: lin!(0.0, 0.5) },
+        SigSpec { name: "SteeringAngle",  unit: "deg",   data_type: I, bytes: 2, conv: lin!(0.0, 0.1) },
+        SigSpec { name: "YawRate",        unit: "deg/s", data_type: I, bytes: 2, conv: lin!(0.0, 0.01) },
+        SigSpec { name: "LatAccel",       unit: "m/s^2", data_type: I, bytes: 2, conv: lin!(0.0, 0.001) },
+        SigSpec { name: "OdometerTotal",  unit: "km",    data_type: U, bytes: 4, conv: lin!(0.0, 0.125) },
+        SigSpec { name: "EngRunTime",     unit: "s",     data_type: U, bytes: 4, conv: lin!(0.0, 1.0) },
+        SigSpec { name: "TripFuelUsed",   unit: "L",     data_type: U, bytes: 4, conv: lin!(0.0, 0.001) },
+        SigSpec { name: "DTCCount",       unit: "",      data_type: U, bytes: 4, conv: lin!(0.0, 1.0) },
+        SigSpec { name: "GearPos",        unit: "",      data_type: U, bytes: 1, conv: Conv::ValueToText(GEAR, "Unknown") },
+        SigSpec { name: "IgnitionState",  unit: "",      data_type: U, bytes: 1, conv: Conv::ValueToText(IGNITION, "Invalid") },
+        SigSpec { name: "SystemStatus",   unit: "",      data_type: U, bytes: 1, conv: Conv::ValueToText(STATUS, "NotAvailable") },
+        SigSpec { name: "LambdaSensor",   unit: "",      data_type: U, bytes: 2, conv: Conv::Rational([0.0, 1.0, 0.0, 0.0, 0.0, 1024.0]) },
+        SigSpec { name: "PowerEstimate",  unit: "kW",    data_type: U, bytes: 2, conv: Conv::Algebraic("X*0.0736") },
+    ]
+}
+
+/// CAN message names, DBC-style: `<ECU>_<Message>_<nnn>`.
+fn message_name(group: usize) -> String {
+    const ECUS: &[&str] = &["PT", "CH", "BD", "SAS", "ABS", "TCU", "BMS", "EMS", "VCU", "ADAS"];
+    const MSGS: &[&str] = &[
+        "EngineData",
+        "VehicleDynamics",
+        "PowertrainStatus",
+        "BrakeStatus",
+        "SteeringInfo",
+        "BatteryState",
+        "ThermalMgmt",
+        "DriverInput",
+        "GearboxStatus",
+        "EnergyFlow",
+    ];
+    format!(
+        "{}_{}_{:03}",
+        ECUS[group % ECUS.len()],
+        MSGS[(group / ECUS.len()) % MSGS.len()],
+        group
+    )
+}
+
+/// Serialise a `##SI` source block: 24-byte header + 3 links + 3 data bytes,
+/// padded to 56 bytes.
+fn source_block_bytes(
+    name_addr: u64,
+    path_addr: u64,
+    comment_addr: u64,
+) -> Result<Vec<u8>, MdfError> {
+    let header = BlockHeader {
+        id: "##SI".into(),
+        reserved0: 0,
+        block_len: 56,
+        links_nr: 3,
+    };
+    let mut b = Vec::with_capacity(56);
+    b.extend_from_slice(&header.to_bytes()?);
+    b.extend_from_slice(&name_addr.to_le_bytes());
+    b.extend_from_slice(&path_addr.to_le_bytes());
+    b.extend_from_slice(&comment_addr.to_le_bytes());
+    b.push(2); // source_type: 2 = BUS
+    b.push(2); // bus_type:    2 = CAN
+    b.push(0); // flags
+    b.extend_from_slice(&[0u8; 5]); // reserved, pads to 56
+    Ok(b)
+}
+
+/// Write a `##TX` block and return its file offset.
+fn write_text(writer: &mut MdfWriter, id: &str, text: &str) -> Result<u64, MdfError> {
+    let bytes = TextBlock::new(text).to_bytes()?;
+    writer.write_block_with_id(&bytes, id)
+}
+
+/// Build a non-text `##CC` block for one signal.
+fn conversion_block(
+    cc_type: ConversionType,
+    cc_val: Vec<f64>,
+    cc_ref: Vec<u64>,
+    name_addr: u64,
+) -> ConversionBlock {
+    ConversionBlock {
+        header: BlockHeader {
+            id: "##CC".into(),
+            reserved0: 0,
+            block_len: 0, // filled in by to_bytes()
+            links_nr: 0,
+        },
+        cc_tx_name: Some(name_addr),
+        cc_md_unit: None,
+        cc_md_comment: None,
+        cc_cc_inverse: None,
+        cc_ref_count: cc_ref.len() as u16,
+        cc_val_count: cc_val.len() as u16,
+        cc_ref,
+        cc_type,
+        cc_precision: 0,
+        cc_flags: 0,
+        cc_phy_range_min: None,
+        cc_phy_range_max: None,
+        cc_val,
+        formula: None,
+        resolved_texts: None,
+        resolved_conversions: None,
+        default_conversion: None,
+    }
+}
+
+/// Deterministic pseudo-random stream, so the fixture is byte-reproducible.
+struct Lcg(u64);
+
+impl Lcg {
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (self.0 >> 33) as u32
+    }
+}
+
+fn main() -> Result<(), MdfError> {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().unwrap_or_else(|| "canape_like_100mb.mf4".to_string());
+    let groups: usize = args
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_GROUPS);
+    let records: usize = args
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_RECORDS);
+
+    let catalogue = signal_catalogue();
+    // Record layout: master f64 first, then every signal byte-aligned in order.
+    let mut offsets = Vec::with_capacity(catalogue.len());
+    let mut cursor = 8u32;
+    for spec in &catalogue {
+        offsets.push(cursor);
+        cursor += spec.bytes;
+    }
+    let record_size = cursor as usize;
+
+    println!(
+        "writing {path}: {groups} groups x {} channels x {records} records \
+         ({record_size} B/record)",
+        catalogue.len() + 1
+    );
+    let started = std::time::Instant::now();
+
+    let mut writer = MdfWriter::new(&path)?;
+    writer.init_mdf_file()?;
+
+    let mut rng = Lcg(0x5EED_1234_ABCD_0001);
+    let mut record = vec![0u8; record_size];
+
+    for g in 0..groups {
+        let message = message_name(g);
+        let can_id = 0x100 + g;
+
+        // --- channel group -------------------------------------------------
+        // add_channel_group(None, ..) starts a fresh ##DG, so every message
+        // gets its own data group, exactly as a per-message logger writes it.
+        let cg = writer.add_channel_group(None, |_| {})?;
+        writer.set_channel_group_name(&cg, &message)?;
+        writer.set_channel_group_comment(
+            &cg,
+            &format!("CAN1 / id 0x{can_id:03X} / cycle 10 ms / from vehicle.dbc"),
+        )?;
+
+        // --- channels ------------------------------------------------------
+        let master = writer.add_channel(&cg, None, |ch| {
+            ch.data_type = DataType::FloatLE;
+            ch.bit_count = 64;
+            ch.byte_offset = 0;
+            ch.name = Some("t".to_string());
+        })?;
+        writer.set_time_channel(&master)?;
+
+        let mut cn_ids = Vec::with_capacity(catalogue.len());
+        let mut prev = master.clone();
+        for (i, spec) in catalogue.iter().enumerate() {
+            // Signal names are suffixed with the group index: a DBC keeps
+            // signal names unique across messages, and unique names keep
+            // name-based index lookups unambiguous.
+            let signal_name = format!("{}_{:03}", spec.name, g);
+            let byte_offset = offsets[i];
+            let bits = spec.bytes * 8;
+            let dt = spec.data_type.clone();
+            let cn = writer.add_channel(&cg, Some(&prev), move |ch| {
+                ch.data_type = dt;
+                ch.bit_count = bits;
+                ch.byte_offset = byte_offset;
+                ch.name = Some(signal_name);
+            })?;
+            prev = cn.clone();
+            cn_ids.push(cn);
+        }
+
+        // --- per-channel metadata: unit ##TX, ##CC conversion, ##SI source --
+        // Written before this group's ##DT so each group forms one metadata
+        // cluster followed by its data — the interleaved layout real tools
+        // produce.
+        let bus_tx = write_text(&mut writer, &format!("fx_bus_{g}"), "CAN1")?;
+
+        let master_unit = write_text(&mut writer, &format!("fx_unit_{}", master), "s")?;
+        let master_pos = writer.get_block_position(&master).ok_or_else(|| {
+            MdfError::BlockSerializationError("master channel position missing".into())
+        })?;
+        writer.update_link(master_pos + CN_LINK_UNIT, master_unit)?;
+        let master_path = write_text(
+            &mut writer,
+            &format!("fx_sipath_{}", master),
+            &format!("{message}.t"),
+        )?;
+        let master_si = source_block_bytes(bus_tx, master_path, 0)?;
+        let master_si_pos =
+            writer.write_block_with_id(&master_si, &format!("fx_si_{}", master))?;
+        writer.update_link(master_pos + CN_LINK_SOURCE, master_si_pos)?;
+
+        for (i, spec) in catalogue.iter().enumerate() {
+            let cn = &cn_ids[i];
+            let cn_pos = writer.get_block_position(cn).ok_or_else(|| {
+                MdfError::BlockSerializationError(format!("channel {cn} position missing"))
+            })?;
+
+            if !spec.unit.is_empty() {
+                let unit = write_text(&mut writer, &format!("fx_unit_{cn}"), spec.unit)?;
+                writer.update_link(cn_pos + CN_LINK_UNIT, unit)?;
+            }
+
+            // Conversion. The value-to-text case reuses the writer's helper,
+            // which emits the text blocks and patches the ##CN link itself.
+            match &spec.conv {
+                Conv::ValueToText(mapping, default) => {
+                    writer.add_value_to_text_conversion(mapping, default, Some(cn))?;
+                }
+                other => {
+                    let cc_name = write_text(
+                        &mut writer,
+                        &format!("fx_ccname_{cn}"),
+                        &format!("{}_conv", spec.name),
+                    )?;
+                    let (cc_type, cc_val, cc_ref) = match other {
+                        Conv::Linear { offset, factor } => (
+                            ConversionType::Linear,
+                            vec![*offset, *factor],
+                            Vec::new(),
+                        ),
+                        Conv::Rational(p) => (ConversionType::Rational, p.to_vec(), Vec::new()),
+                        Conv::Algebraic(formula) => {
+                            let tx = write_text(
+                                &mut writer,
+                                &format!("fx_ccformula_{cn}"),
+                                formula,
+                            )?;
+                            (ConversionType::Algebraic, Vec::new(), vec![tx])
+                        }
+                        Conv::ValueToText(..) => unreachable!("handled above"),
+                    };
+                    let cc = conversion_block(cc_type, cc_val, cc_ref, cc_name);
+                    let cc_bytes = cc.to_bytes()?;
+                    let cc_pos =
+                        writer.write_block_with_id(&cc_bytes, &format!("fx_cc_{cn}"))?;
+                    // ##CN link slot 5 (offset 56) is cn_cc_conversion.
+                    writer.update_link(cn_pos + 56, cc_pos)?;
+                }
+            }
+
+            // Source: bus name shared per group, per-signal Message.Signal path.
+            let si_path = write_text(
+                &mut writer,
+                &format!("fx_sipath_{cn}"),
+                &format!("{message}.{}", spec.name),
+            )?;
+            let si = source_block_bytes(bus_tx, si_path, 0)?;
+            let si_pos = writer.write_block_with_id(&si, &format!("fx_si_{cn}"))?;
+            writer.update_link(cn_pos + CN_LINK_SOURCE, si_pos)?;
+        }
+
+        // --- data ----------------------------------------------------------
+        writer.start_data_block_for_cg(&cg, 0)?;
+        for r in 0..records {
+            let t = r as f64 * 0.01; // 10 ms cycle
+            record[0..8].copy_from_slice(&t.to_le_bytes());
+            for (i, spec) in catalogue.iter().enumerate() {
+                let at = offsets[i] as usize;
+                let raw = rng.next_u32();
+                match spec.bytes {
+                    1 => {
+                        // Keep enum signals inside their value table so the
+                        // value-to-text conversions resolve to real states.
+                        let v = match &spec.conv {
+                            Conv::ValueToText(mapping, _) => (raw % (mapping.len() as u32 + 1)) as u8,
+                            _ => raw as u8,
+                        };
+                        record[at] = v;
+                    }
+                    2 => {
+                        let v = (raw & 0xFFFF) as u16;
+                        record[at..at + 2].copy_from_slice(&v.to_le_bytes());
+                    }
+                    4 => {
+                        record[at..at + 4].copy_from_slice(&raw.to_le_bytes());
+                    }
+                    n => unreachable!("unexpected signal width {n}"),
+                }
+            }
+            writer.write_raw_record(&cg, &record)?;
+        }
+        writer.finish_data_block(&cg)?;
+
+        if (g + 1) % 25 == 0 {
+            println!("  {} / {groups} groups written", g + 1);
+        }
+    }
+
+    writer.finalize()?;
+
+    let size = std::fs::metadata(&path).map_err(MdfError::IOError)?.len();
+    println!(
+        "done: {path} = {size} bytes ({:.1} MiB), {} channels total, in {:.1?}",
+        size as f64 / (1024.0 * 1024.0),
+        groups * (catalogue.len() + 1),
+        started.elapsed()
+    );
+    Ok(())
+}

--- a/js/src/mdf-index.ts
+++ b/js/src/mdf-index.ts
@@ -106,11 +106,16 @@ export class MdfIndex {
    * Build a fresh index over any `RangeSource`, fetching **only** the file's
    * metadata blocks — never the bulk sample data.
    *
-   * The metadata walk runs incrementally in wasm: it reports which byte ranges
-   * it still needs, this loop fetches them (with look-ahead to keep the number
-   * of requests low), and the two repeat until the index is built. For a
-   * typical file this transfers a few KB regardless of the file's size. Use it
-   * with `FetchRangeSource` (HTTP), `FileRangeSource` (Node), or any custom
+   * The metadata walk runs incrementally in wasm, driven by a stateful
+   * `IndexBuilder`: each pass reports the byte ranges it still needs — a
+   * *batch* covering every independent gap discovered so far (a scattered
+   * file's metadata across many channel groups converges in a handful of
+   * passes, not one per group) — this loop fetches all of them **concurrently**
+   * and pushes the results into the builder, and the two repeat until the
+   * index is built. Fetched bytes are copied into wasm memory once, via
+   * `push`, and stay there across passes (no re-marshalling every round). For
+   * a typical file this transfers a few KB regardless of the file's size. Use
+   * it with `FetchRangeSource` (HTTP), `FileRangeSource` (Node), or any custom
    * source. `source.size()` must be implemented.
    *
    * Channel conversions are **not** fetched during the build — only their
@@ -125,47 +130,53 @@ export class MdfIndex {
     }
     const size = await source.size();
 
-    const ranges: ByteRange[] = [];
-    const fragments: Uint8Array[] = [];
+    const builder = new wasm.IndexBuilder(size);
+    try {
+      const fetchInto = async (offset: number, length: number): Promise<void> => {
+        const clamped = Math.min(length, size - offset);
+        if (offset < 0 || offset >= size || clamped <= 0) {
+          throw new Error(
+            `MdfIndex.fromRangeSource: build requested bytes [${offset}, ${offset + length}) ` +
+              `outside the file (size ${size}); the source may be truncated or not an MDF file.`,
+          );
+        }
+        const bytes = await source.read(offset, clamped);
+        builder.push(offset, bytes);
+      };
 
-    const fetchInto = async (offset: number, length: number): Promise<void> => {
-      const clamped = Math.min(length, size - offset);
-      if (offset < 0 || offset >= size || clamped <= 0) {
-        throw new Error(
-          `MdfIndex.fromRangeSource: build requested bytes [${offset}, ${offset + length}) ` +
-            `outside the file (size ${size}); the source may be truncated or not an MDF file.`,
+      // Seed with a prefix so files whose metadata sits at the front finish in
+      // one round-trip.
+      if (size > 0) {
+        await fetchInto(0, Math.min(BUILD_SEED_BYTES, size));
+      }
+
+      // Bounded loop: each round fetches every range the walk still needs
+      // (concurrently, with a geometrically growing look-ahead), so a file
+      // with N metadata blocks converges in a handful of rounds rather than
+      // one per block. The cap is a safety net against a malformed source.
+      const maxRounds = 10_000;
+      for (let round = 0; round < maxRounds; round++) {
+        const step = builder.step();
+        if (step.done) {
+          return MdfIndex.fromJson(step.json as string);
+        }
+        const lookahead = lookaheadForRound(round);
+        const spans = coalesceNeeded(
+          step.needed as [number, number][],
+          lookahead,
+          lookahead,
+          size,
         );
+        await Promise.all(spans.map(([offset, length]) => fetchInto(offset, length)));
       }
-      const bytes = await source.read(offset, clamped);
-      ranges.push([offset, bytes.length]);
-      fragments.push(bytes);
-    };
-
-    // Seed with a prefix so files whose metadata sits at the front finish in
-    // one round-trip.
-    if (size > 0) {
-      await fetchInto(0, Math.min(BUILD_SEED_BYTES, size));
+      throw new Error(
+        "MdfIndex.fromRangeSource: index build did not converge; the source may not be a valid MDF file.",
+      );
+    } finally {
+      // The builder holds wasm-side fragment memory; release it on both the
+      // success and error paths.
+      builder.free();
     }
-
-    // Bounded loop: each round fetches every range the walk still needs (with a
-    // geometrically growing look-ahead), so a file with N metadata blocks
-    // converges in a handful of rounds rather than one per block. The cap is a
-    // safety net against a malformed source.
-    const maxRounds = 10_000;
-    for (let round = 0; round < maxRounds; round++) {
-      const step = wasm.MdfIndex.buildIndexStep(size, ranges, fragments);
-      if (step.done) {
-        return MdfIndex.fromJson(step.json as string);
-      }
-      const lookahead = lookaheadForRound(round);
-      const spans = coalesceNeeded(step.needed as [number, number][], lookahead, lookahead, size);
-      for (const [offset, length] of spans) {
-        await fetchInto(offset, length);
-      }
-    }
-    throw new Error(
-      "MdfIndex.fromRangeSource: index build did not converge; the source may not be a valid MDF file.",
-    );
   }
 
   /**
@@ -174,8 +185,12 @@ export class MdfIndex {
    * Convenience wrapper over `fromRangeSource` with a `FetchRangeSource`, so
    * only the file's metadata blocks are downloaded (a few KB) rather than the
    * whole file — as long as the server honours `Range` requests. Servers that
-   * ignore `Range` fall back to a single full download. Once built, read with
-   * `values`/`read` over a `RangeSource` for lazy, partial sample reads.
+   * ignore `Range` fall back to a single full download. Each round of the
+   * build fetches every byte range the walk still needs concurrently (see
+   * `fromRangeSource`), so a file with many channel groups converges in a
+   * handful of round-trips rather than one request per group. Once built,
+   * read with `values`/`read` over a `RangeSource` for lazy, partial sample
+   * reads.
    */
   static async fromUrl(url: string, fetchImpl?: FetchLike): Promise<MdfIndex> {
     return MdfIndex.fromRangeSource(new FetchRangeSource(url, fetchImpl));
@@ -358,9 +373,14 @@ export class MdfIndex {
         CONVERSION_LOOKAHEAD_BYTES,
         size,
       );
-      for (const [offset, length] of spans) {
-        const bytes = await source.read(offset, length);
-        ranges.push([offset, bytes.length]);
+      const fetched = await Promise.all(
+        spans.map(async ([offset, length]): Promise<[ByteRange, Uint8Array]> => {
+          const bytes = await source.read(offset, length);
+          return [[offset, bytes.length], bytes];
+        }),
+      );
+      for (const [range, bytes] of fetched) {
+        ranges.push(range);
         fragments.push(bytes);
       }
     }

--- a/js/src/wasm-module.ts
+++ b/js/src/wasm-module.ts
@@ -71,11 +71,33 @@ export interface WasmMdfIndex {
 export interface WasmMdfIndexConstructor {
   fromBytes(data: Uint8Array): WasmMdfIndex;
   fromJson(json: string): WasmMdfIndex;
+  /**
+   * Thin compatibility shim: re-marshals the whole `ranges`/`fragments`
+   * arrays from JS on every call (`O(F)` copy per round). Prefer
+   * `IndexBuilder`, which copies each fetched fragment into wasm memory
+   * exactly once and keeps them across `step()` calls.
+   */
   buildIndexStep(
     file_size: number,
     ranges: unknown,
     fragments: unknown,
   ): WasmBuildStep;
+}
+
+/**
+ * Stateful, non-quadratic driver for an incremental range-fetched index
+ * build (see `WasmMdfIndexConstructor.buildIndexStep` for the shim this
+ * replaces). Fragments pushed via `push` are copied into wasm memory once and
+ * kept in a sorted store across `step()` calls.
+ */
+export interface WasmIndexBuilder {
+  free(): void;
+  push(offset: number, bytes: Uint8Array): void;
+  step(): WasmBuildStep;
+}
+
+export interface WasmIndexBuilderConstructor {
+  new (file_size: number): WasmIndexBuilder;
 }
 
 /** One step of the incremental `buildIndexStep` index build. */
@@ -116,6 +138,7 @@ export interface WasmModule {
   Mdf: WasmMdfConstructor;
   MdfIndex: WasmMdfIndexConstructor;
   MdfWriter: WasmMdfWriterConstructor;
+  IndexBuilder: WasmIndexBuilderConstructor;
 }
 
 let cached: WasmModule | undefined;

--- a/src/index.rs
+++ b/src/index.rs
@@ -266,6 +266,17 @@ pub trait ByteRangeReader {
     ) -> Result<Option<Vec<u8>>, Self::Error> {
         self.read_range(offset, length).map(Some)
     }
+
+    /// True when this reader is a gap-discovery probe: it cannot serve every
+    /// range and records the misses instead of returning data. Metadata walks
+    /// may then skip an unreadable subtree and keep discovering gaps elsewhere
+    /// rather than aborting on the first miss.
+    ///
+    /// A walk driven by a probing reader produces a **partial** result: callers
+    /// MUST discard it and retry once the recorded ranges have been supplied.
+    fn is_probing(&self) -> bool {
+        false
+    }
 }
 
 /// Local file reader implementation.
@@ -1149,6 +1160,18 @@ impl MdfIndex {
 
     /// Mirror of [`Self::extract_data_blocks`] that fetches headers via a
     /// [`ByteRangeReader`] instead of slicing into a memory map.
+    ///
+    /// When `reader.is_probing()` (an incremental gap-discovery pass — see
+    /// [`ByteRangeReader::is_probing`]), a failed read stops walking this
+    /// group's data-block chain and returns what was collected so far instead
+    /// of propagating the error: the reader has already recorded the miss, so
+    /// the caller can fetch it and retry. The resulting index is **partial**
+    /// and must be discarded while any reader miss remains — this is exactly
+    /// the batched gap-discovery contract `MdfIndex::from_range_reader`
+    /// callers (`buildIndexStep`/`IndexBuilder::step`) already enforce by only
+    /// reporting `done` once a pass records zero misses. On-demand readers
+    /// (the default `is_probing() == false`) are unaffected: a failed read is
+    /// still fatal, exactly as before.
     fn extract_data_blocks_via_reader<R>(
         reader: &mut R,
         data_block_addr: u64,
@@ -1157,10 +1180,28 @@ impl MdfIndex {
         R: ByteRangeReader<Error = MdfError>,
     {
         let mut data_blocks = Vec::new();
+
+        // Read a range, but when probing and the read fails, stop walking
+        // this chain and hand back what's been collected so far rather than
+        // aborting the whole build.
+        macro_rules! probe_read {
+            ($offset:expr, $len:expr) => {
+                match reader.read_range($offset, $len) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        if reader.is_probing() {
+                            return Ok(data_blocks);
+                        }
+                        return Err(e);
+                    }
+                }
+            };
+        }
+
         let mut current_block_address = data_block_addr;
 
         while current_block_address != 0 {
-            let header_bytes = reader.read_range(current_block_address, 24)?;
+            let header_bytes = probe_read!(current_block_address, 24);
             let block_header =
                 crate::blocks::common::BlockHeader::from_bytes(&header_bytes)?;
 
@@ -1182,13 +1223,12 @@ impl MdfIndex {
                     current_block_address = 0;
                 }
                 "##DL" => {
-                    let dl_bytes =
-                        reader.read_range(current_block_address, block_header.block_len)?;
+                    let dl_bytes = probe_read!(current_block_address, block_header.block_len);
                     let data_list_block =
                         crate::blocks::data_list_block::DataListBlock::from_bytes(&dl_bytes)?;
 
                     for &fragment_address in &data_list_block.data_links {
-                        let frag_header_bytes = reader.read_range(fragment_address, 24)?;
+                        let frag_header_bytes = probe_read!(fragment_address, 24);
                         let fragment_header = crate::blocks::common::BlockHeader::from_bytes(
                             &frag_header_bytes,
                         )?;
@@ -1224,6 +1264,12 @@ impl MdfIndex {
     /// validates that a variable-length `##DL`'s per-fragment virtual offsets
     /// reproduce the running sum of prior fragments' data-section sizes — the
     /// invariant the offset-based reader relies on.
+    ///
+    /// When `reader.is_probing()`, a failed read stops walking this VLSD
+    /// chain and returns what was collected so far instead of propagating the
+    /// error — see the identical rationale on
+    /// [`Self::extract_data_blocks_via_reader`]. Non-probing readers keep
+    /// today's fatal-on-first-miss behavior.
     fn extract_vlsd_data_blocks<R>(
         reader: &mut R,
         data_addr: u64,
@@ -1232,6 +1278,24 @@ impl MdfIndex {
         R: ByteRangeReader<Error = MdfError>,
     {
         let mut data_blocks: Vec<DataBlockInfo> = Vec::new();
+
+        // See `extract_data_blocks_via_reader`'s `probe_read!` for the
+        // rationale: batched gap discovery skips an unreadable subtree
+        // instead of aborting the whole pass, but only when probing.
+        macro_rules! probe_read {
+            ($offset:expr, $len:expr) => {
+                match reader.read_range($offset, $len) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        if reader.is_probing() {
+                            return Ok(data_blocks);
+                        }
+                        return Err(e);
+                    }
+                }
+            };
+        }
+
         let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
         // Running sum of fragment data-section sizes (size - 24), i.e. the
         // virtual start offset of the next fragment in the concatenated stream.
@@ -1239,7 +1303,7 @@ impl MdfIndex {
         let mut current = data_addr;
 
         while current != 0 {
-            let header_bytes = reader.read_range(current, 24)?;
+            let header_bytes = probe_read!(current, 24);
             let header = crate::blocks::common::BlockHeader::from_bytes(&header_bytes)?;
 
             match header.id.as_str() {
@@ -1268,14 +1332,14 @@ impl MdfIndex {
                             current
                         )));
                     }
-                    let dl_bytes = reader.read_range(current, header.block_len)?;
+                    let dl_bytes = probe_read!(current, header.block_len);
                     let dl = crate::blocks::data_list_block::DataListBlock::from_bytes(&dl_bytes)?;
 
                     for (i, &fragment_address) in dl.data_links.iter().enumerate() {
                         if fragment_address == 0 {
                             continue;
                         }
-                        let frag_header_bytes = reader.read_range(fragment_address, 24)?;
+                        let frag_header_bytes = probe_read!(fragment_address, 24);
                         let frag_header =
                             crate::blocks::common::BlockHeader::from_bytes(&frag_header_bytes)?;
                         let is_compressed = match frag_header.id.as_str() {

--- a/src/parsing/reader_walk.rs
+++ b/src/parsing/reader_walk.rs
@@ -6,6 +6,24 @@
 //! blocks, conversion blocks). Sample data is not touched. This is the
 //! foundation for building an [`crate::index::MdfIndex`] from a remote source
 //! such as an HTTP URL or S3 object without downloading the whole file.
+//!
+//! ## Tolerant walking for gap-discovery probes
+//!
+//! When the reader is a gap-discovery probe ([`ByteRangeReader::is_probing`]
+//! returns `true` — e.g. the wasm `RecordingRangeReader` driving an
+//! incremental, range-fetched build), a failed structural read no longer
+//! aborts the whole walk. Instead it **skips just the unreadable subtree**
+//! (the rest of this channel's fields, this group's remaining channels, or
+//! this data group's remaining channel groups) and keeps walking everywhere
+//! else the chain is already known. The reader has already recorded the miss
+//! before returning the error, so nothing is lost — the next pass, fed the
+//! fetched bytes, picks up where this one skipped. This turns "one gap
+//! discovered per pass" into "every independent subtree's frontier gap
+//! discovered in one pass", so a JS driver batching the reported ranges
+//! converges in a handful of round-trips instead of one per metadata block.
+//! On-demand readers (the default `is_probing() == false`: local files, plain
+//! HTTP, `CachingRangeReader`) are completely unaffected — every read stays
+//! fatal, exactly as before this was added.
 
 use crate::blocks::channel_block::ChannelBlock;
 use crate::blocks::channel_group_block::ChannelGroupBlock;
@@ -66,7 +84,23 @@ where
     let mut groups = Vec::new();
     let mut dg_addr = header.first_dg_addr;
     while dg_addr != 0 {
-        let dg_bytes = reader.read_range(dg_addr, DG_BLOCK_LEN)?;
+        let dg_bytes = match reader.read_range(dg_addr, DG_BLOCK_LEN) {
+            Ok(b) => b,
+            Err(e) => {
+                // Batched gap discovery (see the module doc comment): the
+                // reader already recorded this miss. The ##DG chain cannot be
+                // chased any further without these bytes (next_dg_addr lives
+                // inside them), but every group discovered so far is kept —
+                // this pass' result is partial and callers MUST discard it
+                // and retry once the miss has been supplied (enforced by
+                // `MdfIndex::from_range_reader`'s callers, which only accept
+                // a build once a pass records zero misses).
+                if reader.is_probing() {
+                    break;
+                }
+                return Err(e);
+            }
+        };
         let dg = DataGroupBlock::from_bytes(&dg_bytes)?;
         let next_dg_addr = dg.next_dg_addr;
         let mut cg_addr = dg.first_cg_addr;
@@ -74,7 +108,20 @@ where
 
         while cg_addr != 0 {
             cg_count += 1;
-            let cg_bytes = reader.read_range(cg_addr, CG_BLOCK_LEN)?;
+            let cg_bytes = match reader.read_range(cg_addr, CG_BLOCK_LEN) {
+                Ok(b) => b,
+                Err(e) => {
+                    // Same batched gap discovery rationale as the ##DG read
+                    // above: stop walking this data group's channel-group
+                    // chain, but `next_dg_addr` is already known (read above),
+                    // so move on to the next data group instead of aborting
+                    // the whole walk.
+                    if reader.is_probing() {
+                        break;
+                    }
+                    return Err(e);
+                }
+            };
             let cg = ChannelGroupBlock::from_bytes(&cg_bytes)?;
             let next_cg_addr = cg.next_cg_addr;
 
@@ -84,7 +131,20 @@ where
             let mut channels = Vec::new();
             let mut ch_addr = cg.first_ch_addr;
             while ch_addr != 0 {
-                let cn_bytes = reader.read_range(ch_addr, CN_BLOCK_LEN)?;
+                let cn_bytes = match reader.read_range(ch_addr, CN_BLOCK_LEN) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        // Same batched gap discovery rationale again: stop
+                        // walking this group's channel chain (keeping the
+                        // channels already found), and continue with the
+                        // group and the next channel group — `next_cg_addr`
+                        // is already known.
+                        if reader.is_probing() {
+                            break;
+                        }
+                        return Err(e);
+                    }
+                };
                 let cn = ChannelBlock::from_bytes(&cn_bytes)?;
                 let next_ch_addr = cn.next_ch_addr;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -209,16 +209,6 @@ fn misses_to_needed(misses: Vec<(u64, u64)>) -> Vec<[f64; 2]> {
 // Fragment-backed byte-range reader
 // ---------------------------------------------------------------------------
 
-/// A [`ByteRangeReader`] that serves absolute `(offset, length)` requests from a
-/// caller-provided list of file fragments, each tagged with its absolute file
-/// offset. A request is satisfied if the union of fragments fully covers it
-/// (assembled across fragments when necessary); otherwise a clear error is
-/// returned naming the first uncovered offset.
-struct FragmentRangeReader {
-    /// `(absolute_offset, bytes)` pairs.
-    fragments: Vec<(u64, Vec<u8>)>,
-}
-
 /// Narrow a `u64` byte count/offset to `usize`, erroring instead of truncating
 /// on a 32-bit (wasm) target where the value exceeds `usize::MAX`.
 fn u64_to_usize(v: u64) -> Result<usize, MdfError> {
@@ -243,64 +233,146 @@ enum Coverage {
     Gap { offset: u64, length: u64 },
 }
 
-/// Try to assemble the absolute range `[offset, offset + length)` from
-/// `fragments` (each an `(absolute_offset, bytes)` pair, possibly
-/// overlapping). Returns [`Coverage::Full`] with the bytes, or
-/// [`Coverage::Gap`] naming the first uncovered sub-range.
-fn assemble_from_fragments(
-    fragments: &[(u64, Vec<u8>)],
-    offset: u64,
-    length: u64,
-) -> Result<Coverage, MdfError> {
-    let req_end = offset.checked_add(length).ok_or_else(|| {
-        MdfError::BlockSerializationError(
-            "requested byte range offset + length overflows u64".to_string(),
-        )
-    })?;
-    let len = u64_to_usize(length)?;
+/// A store of file fragments — `(absolute_offset, bytes)` pairs, possibly
+/// overlapping or exactly adjacent — kept sorted by `offset` so a read is
+/// served by two binary searches (`partition_point`) instead of scanning
+/// every stored fragment. This is what makes repeated reads against a
+/// steadily growing fragment set (an incremental index build accumulating
+/// fetched bytes across many passes) subquadratic: each `push` inserts once,
+/// each `assemble`/read is `O(log F + w)` where `w` is the number of
+/// fragments actually overlapping the request (typically tiny), not `O(F)`.
+///
+/// Alongside the sorted fragments, `running_max_end[i]` tracks the largest
+/// end offset among `fragments[..=i]`. Because `fragments` is sorted by start
+/// and `running_max_end` is therefore monotonically non-decreasing, binary
+/// searching it finds the true lower bound of the fragments that can
+/// possibly overlap a query — even when an early, large fragment fully spans
+/// later, smaller ones — so no candidate that could satisfy a read is ever
+/// skipped. This is the standard "stabbing query" trick for interval sets.
+struct FragmentStore {
+    fragments: Vec<(u64, Vec<u8>)>,
+    running_max_end: Vec<u64>,
+}
 
-    // Fast path: a single fragment fully contains the request.
-    for (start, bytes) in fragments {
-        let fstart = *start;
-        let fend = fragment_end(fstart, bytes.len())?;
-        if offset >= fstart && req_end <= fend {
-            let s = u64_to_usize(offset - fstart)?;
-            return Ok(Coverage::Full(bytes[s..s + len].to_vec()));
-        }
+impl FragmentStore {
+    fn new() -> Self {
+        Self { fragments: Vec::new(), running_max_end: Vec::new() }
     }
 
-    // Assembly path: stitch the request together from overlapping fragments.
-    let mut out = vec![0u8; len];
-    let mut covered = vec![false; len];
-    for (start, bytes) in fragments {
-        let fstart = *start;
-        let fend = fragment_end(fstart, bytes.len())?;
-        let lo = offset.max(fstart);
-        let hi = req_end.min(fend);
-        if lo < hi {
-            let dst_lo = u64_to_usize(lo - offset)?;
-            let dst_hi = u64_to_usize(hi - offset)?;
-            let src_lo = u64_to_usize(lo - fstart)?;
-            out[dst_lo..dst_hi].copy_from_slice(&bytes[src_lo..src_lo + (dst_hi - dst_lo)]);
-            for c in &mut covered[dst_lo..dst_hi] {
-                *c = true;
+    /// Build a store from an unordered `(offset, bytes)` list (e.g. the
+    /// ranges/fragments arrays marshalled from JS in one shot), sorting once.
+    fn from_pairs(mut fragments: Vec<(u64, Vec<u8>)>) -> Result<Self, MdfError> {
+        fragments.sort_by_key(|(start, _)| *start);
+        let mut store = Self { fragments, running_max_end: Vec::new() };
+        store.rebuild_running_max()?;
+        Ok(store)
+    }
+
+    /// Insert one fragment, keeping the store sorted by `offset`.
+    fn push(&mut self, offset: u64, bytes: Vec<u8>) -> Result<(), MdfError> {
+        let idx = self.fragments.partition_point(|(start, _)| *start <= offset);
+        self.fragments.insert(idx, (offset, bytes));
+        self.rebuild_running_max()
+    }
+
+    fn rebuild_running_max(&mut self) -> Result<(), MdfError> {
+        self.running_max_end.clear();
+        self.running_max_end.reserve(self.fragments.len());
+        let mut max_end = 0u64;
+        for (start, bytes) in &self.fragments {
+            let end = fragment_end(*start, bytes.len())?;
+            max_end = max_end.max(end);
+            self.running_max_end.push(max_end);
+        }
+        Ok(())
+    }
+
+    /// The minimal contiguous slice of `fragments` that could possibly
+    /// overlap `[offset, req_end)`, found via two binary searches instead of
+    /// a linear scan over every stored fragment.
+    fn candidates(&self, offset: u64, req_end: u64) -> &[(u64, Vec<u8>)] {
+        // Fragments beyond `hi` start at/after `req_end`, so they cannot
+        // overlap a half-open request ending at `req_end`.
+        let hi = self.fragments.partition_point(|(start, _)| *start < req_end);
+        if hi == 0 {
+            return &[];
+        }
+        // `running_max_end` is non-decreasing, so the first index whose
+        // running max exceeds `offset` is the earliest fragment that could
+        // possibly reach into the request — every fragment before it has
+        // `end <= offset` and so cannot overlap.
+        let lo = self.running_max_end[..hi].partition_point(|&end| end <= offset);
+        &self.fragments[lo..hi]
+    }
+
+    /// Try to assemble the absolute range `[offset, offset + length)`.
+    /// Returns [`Coverage::Full`] with the bytes, or [`Coverage::Gap`] naming
+    /// the first uncovered sub-range — identical semantics to the original
+    /// (pre-binary-search) linear-scan implementation.
+    fn assemble(&self, offset: u64, length: u64) -> Result<Coverage, MdfError> {
+        if length == 0 {
+            return Ok(Coverage::Full(Vec::new()));
+        }
+        let req_end = offset.checked_add(length).ok_or_else(|| {
+            MdfError::BlockSerializationError(
+                "requested byte range offset + length overflows u64".to_string(),
+            )
+        })?;
+        let len = u64_to_usize(length)?;
+        let window = self.candidates(offset, req_end);
+
+        // Fast path: a single fragment fully contains the request.
+        for (start, bytes) in window {
+            let fstart = *start;
+            let fend = fragment_end(fstart, bytes.len())?;
+            if offset >= fstart && req_end <= fend {
+                let s = u64_to_usize(offset - fstart)?;
+                return Ok(Coverage::Full(bytes[s..s + len].to_vec()));
+            }
+        }
+
+        // Assembly path: stitch the request together from overlapping fragments.
+        let mut out = vec![0u8; len];
+        let mut covered = vec![false; len];
+        for (start, bytes) in window {
+            let fstart = *start;
+            let fend = fragment_end(fstart, bytes.len())?;
+            let lo = offset.max(fstart);
+            let hi = req_end.min(fend);
+            if lo < hi {
+                let dst_lo = u64_to_usize(lo - offset)?;
+                let dst_hi = u64_to_usize(hi - offset)?;
+                let src_lo = u64_to_usize(lo - fstart)?;
+                out[dst_lo..dst_hi].copy_from_slice(&bytes[src_lo..src_lo + (dst_hi - dst_lo)]);
+                for c in &mut covered[dst_lo..dst_hi] {
+                    *c = true;
+                }
+            }
+        }
+        match covered.iter().position(|&c| !c) {
+            None => Ok(Coverage::Full(out)),
+            Some(pos) => {
+                let miss_off = offset + pos as u64;
+                Ok(Coverage::Gap { offset: miss_off, length: req_end - miss_off })
             }
         }
     }
-    match covered.iter().position(|&c| !c) {
-        None => Ok(Coverage::Full(out)),
-        Some(pos) => {
-            let miss_off = offset + pos as u64;
-            Ok(Coverage::Gap { offset: miss_off, length: req_end - miss_off })
-        }
-    }
+}
+
+/// A [`ByteRangeReader`] that serves absolute `(offset, length)` requests from a
+/// caller-provided list of file fragments, each tagged with its absolute file
+/// offset. A request is satisfied if the union of fragments fully covers it
+/// (assembled across fragments when necessary); otherwise a clear error is
+/// returned naming the first uncovered offset.
+struct FragmentRangeReader {
+    store: FragmentStore,
 }
 
 impl ByteRangeReader for FragmentRangeReader {
     type Error = MdfError;
 
     fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, MdfError> {
-        match assemble_from_fragments(&self.fragments, offset, length)? {
+        match self.store.assemble(offset, length)? {
             Coverage::Full(bytes) => Ok(bytes),
             Coverage::Gap { offset: miss, .. } => Err(MdfError::BlockSerializationError(format!(
                 "requested byte range {}..{} is not fully covered by the provided fragments \
@@ -314,9 +386,14 @@ impl ByteRangeReader for FragmentRangeReader {
 }
 
 /// A [`ByteRangeReader`] that drives an incremental, range-fetched index
-/// build. It serves reads from the fragments gathered so far and **gathers**
+/// build. It serves reads from the fragments gathered so far (borrowed from a
+/// [`FragmentStore`] — see there for the lookup complexity) and **gathers**
 /// the ranges it still needs in [`misses`](Self::misses) rather than fetching
-/// them on demand.
+/// them on demand. [`is_probing`](ByteRangeReader::is_probing) reports `true`:
+/// this is precisely the kind of reader the tolerant metadata walk (see
+/// [`crate::parsing::reader_walk`]) is for — it cannot serve every range, so a
+/// failed structural read skips just the unreadable subtree instead of
+/// aborting the whole pass.
 ///
 /// The key to avoiding an O(N²) fetch-restart loop is that a single walk does
 /// not stop at the first miss:
@@ -328,24 +405,25 @@ impl ByteRangeReader for FragmentRangeReader {
 /// - A *structural* read (a block header whose bytes yield the next link
 ///   address, via [`read_range`](ByteRangeReader::read_range)) cannot be
 ///   satisfied with a placeholder, so it records the gap and returns an error
-///   to end this pass — but every optional gap seen up to that point is already
-///   recorded.
+///   — but because this reader is a probe (`is_probing() == true`), the walk
+///   only skips the affected subtree rather than aborting entirely, so every
+///   other independent gap is still discovered in the same pass.
 ///
 /// The JS driver fetches all recorded ranges (coalesced, with look-ahead) and
 /// retries, so a file with N metadata blocks builds in O(passes) ≈ a handful,
 /// not O(N). Only metadata blocks are ever requested, so the bulk sample data
 /// is never downloaded (unless look-ahead over-fetches interspersed metadata,
 /// which the driver accepts to keep the request count low).
-struct RecordingRangeReader {
-    fragments: Vec<(u64, Vec<u8>)>,
+struct RecordingRangeReader<'a> {
+    store: &'a FragmentStore,
     misses: Vec<(u64, u64)>,
 }
 
-impl ByteRangeReader for RecordingRangeReader {
+impl<'a> ByteRangeReader for RecordingRangeReader<'a> {
     type Error = MdfError;
 
     fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, MdfError> {
-        match assemble_from_fragments(&self.fragments, offset, length)? {
+        match self.store.assemble(offset, length)? {
             Coverage::Full(bytes) => Ok(bytes),
             Coverage::Gap { offset: miss, length: needed } => {
                 self.misses.push((miss, needed));
@@ -361,13 +439,17 @@ impl ByteRangeReader for RecordingRangeReader {
         offset: u64,
         length: u64,
     ) -> Result<Option<Vec<u8>>, MdfError> {
-        match assemble_from_fragments(&self.fragments, offset, length)? {
+        match self.store.assemble(offset, length)? {
             Coverage::Full(bytes) => Ok(Some(bytes)),
             Coverage::Gap { offset: miss, length: needed } => {
                 self.misses.push((miss, needed));
                 Ok(None)
             }
         }
+    }
+
+    fn is_probing(&self) -> bool {
+        true
     }
 }
 
@@ -417,7 +499,8 @@ fn build_fragment_reader(
         }
         fragments_out.push((offset, bytes));
     }
-    Ok(FragmentRangeReader { fragments: fragments_out })
+    let store = FragmentStore::from_pairs(fragments_out).map_err(err_to_js)?;
+    Ok(FragmentRangeReader { store })
 }
 
 /// Validate a JS number is a non-negative, finite integer and return it as
@@ -721,8 +804,17 @@ impl WasmMdfIndex {
     /// Returns `{ done: true, json }` with the finished index once the walk
     /// completes, or `{ done: false, needed: [[offset, length], ...] }` listing
     /// **all** the byte ranges the walk still needs (gathered in one pass) to
-    /// fetch and feed back. The JS `MdfIndex.fromRangeSource` wrapper loops over
-    /// this; call it directly only for a custom driver.
+    /// fetch and feed back.
+    ///
+    /// This is a **thin compatibility shim** kept for existing custom drivers:
+    /// every call re-marshals the whole `ranges`/`fragments` arrays from JS
+    /// into a fresh [`FragmentStore`] (an `O(F)` copy each round), so a build
+    /// with many rounds still does `O(passes × F)` copying overall. Prefer
+    /// [`IndexBuilder`] for new code — it copies each fetched fragment into
+    /// wasm memory exactly once and keeps them in the sorted store across
+    /// `step()` calls, so building the index no longer re-copies previously
+    /// fetched bytes on every pass. The JS `MdfIndex.fromRangeSource` wrapper
+    /// drives `IndexBuilder` for this reason.
     ///
     /// `fileSize` is the total file length (from a HEAD request or
     /// `RangeSource.size()`); it is stored on the resulting index. `ranges` is
@@ -736,7 +828,7 @@ impl WasmMdfIndex {
     ) -> Result<JsValue, JsError> {
         let file_size = f64_to_u64(Some(file_size), "file size")?;
         let parsed = build_fragment_reader(&ranges, &fragments)?;
-        let mut reader = RecordingRangeReader { fragments: parsed.fragments, misses: Vec::new() };
+        let mut reader = RecordingRangeReader { store: &parsed.store, misses: Vec::new() };
         let walk = MdfIndex::from_range_reader(&mut reader, file_size);
 
         // The walk may have finished the linked-list traversal while still
@@ -789,7 +881,7 @@ impl WasmMdfIndex {
     ) -> Result<JsValue, JsError> {
         let (g, c) = self.locate(name, group.as_deref())?;
         let parsed = build_fragment_reader(&ranges, &fragments)?;
-        let mut reader = RecordingRangeReader { fragments: parsed.fragments, misses: Vec::new() };
+        let mut reader = RecordingRangeReader { store: &parsed.store, misses: Vec::new() };
 
         let mut targets = vec![c];
         if with_master {
@@ -972,6 +1064,86 @@ impl WasmMdfIndex {
             None => bound.signal(name).map_err(err_to_js)?,
         };
         signal_to_js(signal)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IndexBuilder
+// ---------------------------------------------------------------------------
+
+/// Stateful driver for an incremental, range-fetched [`WasmMdfIndex`] build.
+///
+/// Preferred over the static [`WasmMdfIndex::build_index_step`] shim: fetched
+/// fragments are copied from JS into wasm memory exactly once, in [`push`](Self::push),
+/// and kept in a [`FragmentStore`] across every [`step`](Self::step) call
+/// rather than being re-marshalled from JS on each pass. Typical use (mirrors
+/// the JS `MdfIndex.fromRangeSource` loop):
+///
+/// 1. `new(fileSize)`, then `push(0, seedBytes)` with an initial prefix fetch.
+/// 2. Call `step()`. If `done`, the finished index JSON is ready. Otherwise
+///    fetch every `[offset, length]` span in `needed` (concurrently) and
+///    `push` each result.
+/// 3. Repeat step 2 until `done`.
+/// 4. `free()` the builder once finished (or let it drop) to release its
+///    wasm-side fragment memory.
+#[wasm_bindgen]
+pub struct IndexBuilder {
+    file_size: u64,
+    store: FragmentStore,
+}
+
+#[wasm_bindgen]
+impl IndexBuilder {
+    /// Start a new incremental build for a file of `fileSize` bytes (from a
+    /// HEAD request or `RangeSource.size()`).
+    #[wasm_bindgen(constructor)]
+    pub fn new(file_size: f64) -> Result<IndexBuilder, JsError> {
+        let file_size = f64_to_u64(Some(file_size), "file size")?;
+        Ok(IndexBuilder { file_size, store: FragmentStore::new() })
+    }
+
+    /// Add fetched bytes at the given absolute file `offset`. Copies into
+    /// wasm memory once; the store stays sorted for `O(log F)` lookups on the
+    /// next `step()`.
+    pub fn push(&mut self, offset: f64, bytes: &[u8]) -> Result<(), JsError> {
+        let offset = f64_to_u64(Some(offset), "fragment offset")?;
+        self.store.push(offset, bytes.to_vec()).map_err(err_to_js)?;
+        Ok(())
+    }
+
+    /// Run one gap-discovery pass of the metadata walk against the fragments
+    /// accumulated so far via `push`.
+    ///
+    /// Returns `{ done: true, json }` with the finished index once the walk
+    /// completes with no misses, or `{ done: false, needed: [[offset,
+    /// length], ...] }` listing **all** the byte ranges this pass still
+    /// needs (gathered in one batched pass — see [`crate::parsing::reader_walk`] —
+    /// rather than one gap per call) for the caller to fetch and `push` back.
+    pub fn step(&mut self) -> Result<JsValue, JsError> {
+        let mut reader = RecordingRangeReader { store: &self.store, misses: Vec::new() };
+        let walk = MdfIndex::from_range_reader(&mut reader, self.file_size);
+
+        // Mirrors `build_index_step`: only report `done` once the walk
+        // succeeded *and* this pass recorded zero misses — a pass with
+        // misses is by construction partial (see `ByteRangeReader::is_probing`).
+        if !reader.misses.is_empty() {
+            let step = BuildStepJs {
+                done: false,
+                json: None,
+                needed: Some(misses_to_needed(reader.misses)),
+            };
+            return serde_wasm_bindgen::to_value(&step).map_err(|e| JsError::new(&e.to_string()));
+        }
+
+        match walk {
+            Ok(index) => {
+                let json = index.to_json().map_err(err_to_js)?;
+                let step = BuildStepJs { done: true, json: Some(json), needed: None };
+                serde_wasm_bindgen::to_value(&step).map_err(|e| JsError::new(&e.to_string()))
+            }
+            // No misses recorded, so this is a real parse error — surface it.
+            Err(e) => Err(err_to_js(e)),
+        }
     }
 }
 

--- a/tests/index_probe_walk.rs
+++ b/tests/index_probe_walk.rs
@@ -1,0 +1,326 @@
+//! Regression test for the tolerant, batched gap-discovery metadata walk
+//! ([`ByteRangeReader::is_probing`]).
+//!
+//! Before this fix, `reader_walk::walk` treated every structural read (##DG /
+//! ##CG / ##CN block bytes) as fatal: the first missing range aborted the
+//! *entire* pass with an `Err`, even when the walk already knew about (and
+//! could have kept discovering) other, independent gaps elsewhere in the
+//! file. For a file with many channel groups this meant one network
+//! round-trip per group instead of a handful for the whole file.
+//!
+//! The fix lets a **probing** reader (`is_probing() == true`) skip just the
+//! unreadable subtree — the rest of one channel group's channels, or one data
+//! group's remaining channel groups — instead of aborting the whole walk, so
+//! a single pass reports the frontier gap of *every* independent subtree at
+//! once. Readers that are not probes (the trait's default, `is_probing() ==
+//! false` — local files, plain HTTP, `CachingRangeReader`) are completely
+//! unaffected: a failed read stays fatal, exactly as before.
+//!
+//! This test builds a fixture whose `##DG`/`##CG` headers for every group are
+//! clustered near the front of the file (so the whole group chain is
+//! discoverable from a small seed) while each group's `##CN` channel blocks
+//! and `##DT` data sit later, scattered behind the *other* groups' clusters —
+//! adapted from the scattering recipe in
+//! `tests/cloud_index.rs::cloud_index_handles_scattered_metadata`. Seeding
+//! the probe with only the first metadata cluster and running **one** pass
+//! must report misses spanning more than one group, proving the walk no
+//! longer stops at the first gap.
+
+use mf4_rs::blocks::common::DataType;
+use mf4_rs::error::MdfError;
+use mf4_rs::index::{ByteRangeReader, MdfIndex};
+use mf4_rs::parsing::decoder::DecodedValue;
+use mf4_rs::writer::MdfWriter;
+
+const GROUPS: usize = 6;
+const CHANNELS_PER_GROUP: usize = 4; // 1 master + 3 data, all f64
+const RECORDS: usize = 50;
+
+/// A [`ByteRangeReader`] that serves reads only from a fixed set of
+/// `(offset, bytes)` fragments it was seeded with, and records every miss
+/// instead of fetching on demand.
+///
+/// `probing` controls [`ByteRangeReader::is_probing`]: `true` mirrors the
+/// wasm `RecordingRangeReader` (the tolerant, batching walk); `false` proves
+/// the on-demand/native behavior is unchanged (fatal on the first miss).
+struct FragReader {
+    fragments: Vec<(u64, Vec<u8>)>,
+    misses: Vec<(u64, u64)>,
+    probing: bool,
+}
+
+impl FragReader {
+    fn seeded(fragments: Vec<(u64, Vec<u8>)>, probing: bool) -> Self {
+        Self { fragments, misses: Vec::new(), probing }
+    }
+
+    /// Assemble `[offset, offset+length)` from the stored fragments, or
+    /// report the first uncovered sub-range.
+    fn cover(&self, offset: u64, length: u64) -> Result<Vec<u8>, (u64, u64)> {
+        let req_end = offset + length;
+        let len = length as usize;
+        let mut out = vec![0u8; len];
+        let mut covered = vec![false; len];
+        for (start, bytes) in &self.fragments {
+            let fstart = *start;
+            let fend = fstart + bytes.len() as u64;
+            let lo = offset.max(fstart);
+            let hi = req_end.min(fend);
+            if lo < hi {
+                let dlo = (lo - offset) as usize;
+                let dhi = (hi - offset) as usize;
+                let slo = (lo - fstart) as usize;
+                out[dlo..dhi].copy_from_slice(&bytes[slo..slo + (dhi - dlo)]);
+                for c in &mut covered[dlo..dhi] {
+                    *c = true;
+                }
+            }
+        }
+        match covered.iter().position(|&c| !c) {
+            None => Ok(out),
+            Some(pos) => {
+                let miss = offset + pos as u64;
+                Err((miss, req_end - miss))
+            }
+        }
+    }
+}
+
+impl ByteRangeReader for FragReader {
+    type Error = MdfError;
+
+    fn read_range(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, MdfError> {
+        match self.cover(offset, length) {
+            Ok(bytes) => Ok(bytes),
+            Err(gap) => {
+                self.misses.push(gap);
+                Err(MdfError::BlockSerializationError("gap".into()))
+            }
+        }
+    }
+
+    fn read_range_optional(
+        &mut self,
+        offset: u64,
+        length: u64,
+    ) -> Result<Option<Vec<u8>>, MdfError> {
+        match self.cover(offset, length) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(gap) => {
+                self.misses.push(gap);
+                Ok(None)
+            }
+        }
+    }
+
+    fn is_probing(&self) -> bool {
+        self.probing
+    }
+}
+
+/// Fixture layout: all `##DG`/`##CG` (+ name/comment `##TX`) blocks for every
+/// group are written first (Phase 1), clustered near the front of the file.
+/// Only afterwards (Phase 2) does each group get its `##CN` channels and its
+/// `##DT` data, group by group — so group *g*'s channel blocks sit behind
+/// every earlier group's data. `seed_end` is the exact byte length of Phase 1
+/// (via `MdfWriter::offset()`), so a seed of `bytes[0..seed_end]` covers every
+/// group's `##DG`/`##CG` but none of their channels or data.
+struct Fixture {
+    bytes: Vec<u8>,
+    file_size: u64,
+    seed_end: u64,
+    /// File offset of each group's first (master/time) channel block —
+    /// used to check which group a recorded miss belongs to.
+    first_channel_addr: Vec<u64>,
+}
+
+fn build_fixture() -> Fixture {
+    // A per-test temp directory (rather than a fixed path derived from the
+    // process id) avoids collisions between tests running in parallel
+    // threads within the same test binary.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("probe_walk_fixture.mf4");
+    let path = path.to_str().unwrap();
+    let mut w = MdfWriter::new(path).unwrap();
+    w.init_mdf_file().unwrap();
+
+    // Phase 1: create every group's ##DG + ##CG + name/comment ##TX blocks,
+    // clustering all structural headers near the front of the file.
+    let mut cg_ids = Vec::with_capacity(GROUPS);
+    for g in 0..GROUPS {
+        let cg_id = w.add_channel_group(None, |_| {}).unwrap();
+        w.set_channel_group_name(&cg_id, &format!("Group {g}")).unwrap();
+        w.set_channel_group_comment(&cg_id, &format!("Comment {g}")).unwrap();
+        cg_ids.push(cg_id);
+    }
+    let seed_end = w.offset();
+
+    // Phase 2: for each group (in order), add its channels and write its
+    // data block — scattering each group's ##CN cluster behind every
+    // earlier group's ##DT block.
+    let mut first_channel_addr = Vec::with_capacity(GROUPS);
+    for (g, cg_id) in cg_ids.iter().enumerate() {
+        let time_id = w
+            .add_channel(cg_id, None, |ch| {
+                ch.data_type = DataType::FloatLE;
+                ch.bit_count = 64;
+                ch.name = Some(format!("t_{g}"));
+            })
+            .unwrap();
+        w.set_time_channel(&time_id).unwrap();
+        first_channel_addr.push(w.get_block_position(&time_id).unwrap());
+
+        let mut prev = time_id;
+        for c in 1..CHANNELS_PER_GROUP {
+            prev = w
+                .add_channel(cg_id, Some(&prev), |ch| {
+                    ch.data_type = DataType::FloatLE;
+                    ch.bit_count = 64;
+                    ch.name = Some(format!("ch_{g}_{c}"));
+                })
+                .unwrap();
+        }
+
+        w.start_data_block_for_cg(cg_id, 0).unwrap();
+        for r in 0..RECORDS {
+            let mut record = Vec::with_capacity(CHANNELS_PER_GROUP);
+            for k in 0..CHANNELS_PER_GROUP {
+                record.push(DecodedValue::Float((g * 1000 + r * 10 + k) as f64));
+            }
+            w.write_record(cg_id, &record).unwrap();
+        }
+        w.finish_data_block(cg_id).unwrap();
+    }
+    w.finalize().unwrap();
+
+    let bytes = std::fs::read(path).unwrap();
+    let _ = std::fs::remove_file(path);
+    let file_size = bytes.len() as u64;
+
+    Fixture { bytes, file_size, seed_end, first_channel_addr }
+}
+
+/// A single probing pass, seeded with only the first metadata cluster,
+/// reports misses spanning more than one group — the walk no longer stops at
+/// the first gap.
+#[test]
+fn probing_walk_batches_gaps_across_groups() {
+    let fx = build_fixture();
+    assert!(
+        fx.seed_end < fx.file_size,
+        "fixture too small to scatter channels/data behind the seed"
+    );
+
+    let seed = fx.bytes[..fx.seed_end as usize].to_vec();
+    let mut reader = FragReader::seeded(vec![(0, seed)], /* probing = */ true);
+
+    let result = MdfIndex::from_range_reader(&mut reader, fx.file_size);
+
+    // The whole point of the fix: the pass does not abort with an error just
+    // because most of the file's channels/data are still missing.
+    assert!(
+        result.is_ok(),
+        "a probing reader must not abort the walk on a structural miss: {:?}",
+        result.err()
+    );
+    assert!(
+        !reader.misses.is_empty(),
+        "expected the pass to record misses for the not-yet-fetched channels/data"
+    );
+
+    // Count how many distinct groups have a recorded miss covering their
+    // first channel's address — i.e. how many groups' metadata the single
+    // pass made progress on discovering, not just the first one.
+    let groups_with_miss = fx
+        .first_channel_addr
+        .iter()
+        .filter(|&&addr| {
+            reader
+                .misses
+                .iter()
+                .any(|&(off, len)| off <= addr && addr < off + len)
+        })
+        .count();
+
+    assert!(
+        groups_with_miss > 1,
+        "expected misses spanning more than one group's metadata in a single pass, got {} \
+         (misses: {:?})",
+        groups_with_miss,
+        reader.misses
+    );
+    // With this fixture every group's ##DG/##CG is in the seed but every
+    // group's first channel is scattered behind data, so all of them should
+    // miss in this one pass.
+    assert_eq!(
+        groups_with_miss, GROUPS,
+        "expected every group's first channel to miss in the first pass"
+    );
+}
+
+/// Feeding the recorded misses back in rounds converges to an index
+/// identical (group/channel names and counts) to one built directly from the
+/// full bytes via `MdfIndex::from_bytes`.
+#[test]
+fn probing_walk_converges_to_full_index() {
+    let fx = build_fixture();
+    let seed = fx.bytes[..fx.seed_end as usize].to_vec();
+    let mut fragments = vec![(0u64, seed)];
+
+    let mut built: Option<MdfIndex> = None;
+    for _round in 0..200 {
+        let mut reader = FragReader::seeded(fragments.clone(), true);
+        let result = MdfIndex::from_range_reader(&mut reader, fx.file_size);
+        if reader.misses.is_empty() {
+            built = Some(result.expect("walk with no misses must succeed"));
+            break;
+        }
+        assert!(
+            result.is_ok() || !reader.misses.is_empty(),
+            "a probing reader's failed pass must always record a miss"
+        );
+        for (off, len) in reader.misses {
+            let off_u = off as usize;
+            let end_u = (off + len) as usize;
+            fragments.push((off, fx.bytes[off_u..end_u].to_vec()));
+        }
+    }
+
+    let built = built.expect("probing build did not converge within the round budget");
+    let direct = MdfIndex::from_bytes(fx.bytes.clone()).unwrap();
+
+    assert_eq!(built.channel_groups.len(), direct.channel_groups.len());
+    assert_eq!(built.channel_names(), direct.channel_names());
+    assert_eq!(built.channel_names().len(), GROUPS * CHANNELS_PER_GROUP);
+    for (bg, dg) in built.channel_groups.iter().zip(direct.channel_groups.iter()) {
+        assert_eq!(bg.name, dg.name);
+        assert_eq!(bg.channels.len(), dg.channels.len());
+        assert_eq!(bg.record_count, dg.record_count);
+    }
+}
+
+/// Regression guard: a reader that is *not* a probe (`is_probing() ==
+/// false`, the trait default) must still abort the whole walk on the first
+/// missing range — native/on-demand readers (local files, plain HTTP) keep
+/// today's fatal-on-first-miss behavior unchanged.
+#[test]
+fn non_probing_reader_still_fails_hard_on_missing_range() {
+    let fx = build_fixture();
+    let seed = fx.bytes[..fx.seed_end as usize].to_vec();
+    let mut reader = FragReader::seeded(vec![(0, seed)], /* probing = */ false);
+
+    let result = MdfIndex::from_range_reader(&mut reader, fx.file_size);
+
+    assert!(
+        result.is_err(),
+        "a non-probing reader must fail the whole walk on a missing structural range"
+    );
+    // Exactly one miss: the walk aborted at the very first unreadable read
+    // instead of continuing to discover the other groups' gaps.
+    assert_eq!(
+        reader.misses.len(),
+        1,
+        "a non-probing reader must abort after the first miss, not batch further gaps: {:?}",
+        reader.misses
+    );
+}


### PR DESCRIPTION
Building an `MdfIndex` over a range source in wasm was pathologically slow on files with many channel groups. Three defects compounded:

1. **A pass aborted on the first structural gap.** `RecordingRangeReader::read_range` recorded the miss and returned `Err`, so one missing `##CN` block anywhere prevented every *other* group from being walked — each pass discovered roughly one gap, giving one network round per group / per data-block fragment.
2. **Quadratic replay.** `buildIndexStep` re-marshalled the entire `ranges`/`fragments` arrays from JS on every call (copying every fetched byte into wasm each round), and fragment lookup scanned every stored fragment linearly.
3. **Sequential fetching.** The JS driver awaited each span one at a time.

## Changes

**Batched gap discovery** — new `ByteRangeReader::is_probing()`, defaulted `false`, so every existing reader and all native paths are byte-for-byte unchanged. When probing, a failed structural read skips only the unreadable subtree instead of aborting the pass: the `##DG` chain stops (its `next_dg_addr` lives in the missing bytes), but a failed `##CG` read continues to the next data group and a failed `##CN` read continues to the next channel group. `extract_data_blocks_via_reader` and `extract_vlsd_data_blocks` return the blocks collected so far. One pass now reports the frontier gap of every independent subtree, so a driver fetches them all in one batch. The partial index is discarded while any miss remains — an invariant callers already enforced by only reporting `done` on a zero-miss pass.

**`FragmentStore`** — replaces the linear fragment scan with fragments sorted by offset plus a running-max-end prefix array, so a read binary-searches the minimal candidate window. This is a stabbing query, correct for arbitrary overlap patterns (a plain "last fragment with start ≤ offset, walk forward" would miss an early large fragment spanning later small ones). Shared by `valuesFromFragments`, `readFromFragments` and `conversionRangesStep`, so those get it too.

**`IndexBuilder` wasm class** (`new` / `push` / `step`) — fetched bytes are copied into wasm memory once and reused across passes. `RecordingRangeReader` now borrows the store rather than cloning it. `buildIndexStep` is retained as a documented compatibility shim for custom drivers.

**Concurrent fetching** — `MdfIndex.fromRangeSource` drives `IndexBuilder` and fetches each round's spans with `Promise.all`; same change in the conversion-range loop. The builder is freed in a `finally`. Tuning constants (`BUILD_SEED_BYTES`, look-ahead growth, `maxRounds`) are unchanged.

Also adds `examples/gen_canape_fixture.rs`, a deterministic generator for a CANape/DBC-shaped fixture: 200 channel groups (one CAN message each, own data group, data written immediately after its metadata so the layout is interleaved), 33 channels per group, every signal carrying a `##CC` conversion (linear with DBC factor/offset, value-to-text enums, one rational, one algebraic) and a `##SI` source block (BUS / CAN).

## Tests

New `tests/index_probe_walk.rs`:
- `probing_walk_batches_gaps_across_groups` — seeded with only the first metadata cluster, one pass records misses spanning **all** groups, not just the first.
- `probing_walk_converges_to_full_index` — feeding misses back round by round yields an index matching `MdfIndex::from_bytes` in group/channel names and counts.
- `non_probing_reader_still_fails_hard_on_missing_range` — regression guard that the default non-probing behavior still aborts on the first miss.

## Verification

- `cargo test` — all green
- `cargo check --features wasm` / `--features http` — clean
- `cargo check --features wasm --target wasm32-unknown-unknown` — clean
- `wasm-pack build` (nodejs + web targets), `npm run build` / `build:web`, `npm test` — **32/32 JS tests pass**, including the web entry point

Measured on the 200-group / 6600-channel / 95.2 MiB fixture above, the JS build now completes in **28 range reads** and produces a complete 6600-channel index.

Known follow-up, not in this PR: the build still transfers ~91% of that file's bytes, because the geometric look-ahead (4 MiB cap) and the native `CachingRangeReader` default (1 MiB chunks) both straddle metadata clusters spaced ~499 KB apart. Chunk/look-ahead sizing is a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx51cHYkDZyyoDXTFbduoe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rx51cHYkDZyyoDXTFbduoe)_