### PR TITLE
feat: expose index-build fetch windows as options and reset read-ahead on a seek

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -15,7 +15,7 @@
 import "./wasm-module-node";
 
 export { Mdf } from "./mdf";
-export { MdfIndex } from "./mdf-index";
+export { MdfIndex, type IndexBuildOptions } from "./mdf-index";
 export { MdfWriter, type RecordValue } from "./mdf-writer";
 
 export {

--- a/js/src/mdf-index.ts
+++ b/js/src/mdf-index.ts
@@ -11,22 +11,123 @@ import type { ByteRange, IndexGroupInfo, Signal } from "./types";
  * the front of the file, so seeding this often completes the build in one or
  * two round-trips. */
 const BUILD_SEED_BYTES = 256 * 1024;
-/** Base bytes fetched per build round-trip. The window grows geometrically
- * across rounds (see {@link lookaheadForRound}) so files whose metadata is
- * scattered throughout (interleaved with data blocks) still converge in a
- * handful of requests instead of one per metadata cluster. */
+/** Base bytes fetched per build round-trip, and the window the read-ahead
+ * heuristic falls back to whenever the walk jumps to a new metadata cluster
+ * (see {@link nextLookahead}). Large enough to swallow a typical cluster in one
+ * request. */
 const BUILD_LOOKAHEAD_BYTES = 64 * 1024;
-/** Cap on the per-round fetch window so the geometric growth never asks for an
- * absurd single range on a huge file. */
-const BUILD_MAX_LOOKAHEAD_BYTES = 4 * 1024 * 1024;
+/** Cap on the per-round fetch window, reached only while the walk is streaming
+ * sequentially through one large metadata cluster. */
+const BUILD_MAX_LOOKAHEAD_BYTES = 1024 * 1024;
+/** Distance between two needed ranges that still gets bridged into a single
+ * request. Constant, and deliberately much smaller than the look-ahead cap:
+ * bridging pulls **every** intervening byte, so a large bridge on a file whose
+ * metadata is interleaved with data blocks would transfer the data blocks too. */
+const BUILD_BRIDGE_BYTES = 64 * 1024;
 
-/** Per-round fetch window: `base * 2^round`, capped. Early rounds stay small
- * (cheap for the common case where metadata sits contiguously at the front);
- * later rounds grow large so a scattered-metadata file is covered in
- * logarithmically many requests. */
-function lookaheadForRound(round: number): number {
-  const grown = BUILD_LOOKAHEAD_BYTES * 2 ** Math.min(round, 20);
-  return Math.min(grown, BUILD_MAX_LOOKAHEAD_BYTES);
+/**
+ * Tuning for the incremental index build, for callers who know their file's
+ * shape. All sizes are in bytes; omitted fields keep the defaults.
+ *
+ * The defaults suit files whose metadata sits contiguously at the front. They
+ * are wrong in opposite directions for two other shapes, which is why they are
+ * exposed:
+ *
+ * - **Metadata interleaved with data blocks** (a per-message bus logger, or any
+ *   writer that emits each group's data before the next group's metadata):
+ *   look-ahead spans straddle the data blocks between metadata clusters and
+ *   transfer them. Lowering `maxLookaheadBytes` toward a single cluster's size
+ *   trades more round-trips for far fewer bytes.
+ * - **Very large metadata** (thousands of channels in one group): raising
+ *   `seedBytes` and `maxLookaheadBytes` converges in fewer round-trips.
+ *
+ * There is no universally right answer — it is a bandwidth-versus-latency
+ * trade, so measure against your own files.
+ */
+export interface IndexBuildOptions {
+  /** Prefix fetched before the first pass. Default 256 KiB. */
+  seedBytes?: number;
+  /** Base per-round fetch window, and the size the window resets to whenever
+   * the walk jumps to a new metadata cluster. Default 64 KiB. */
+  lookaheadBytes?: number;
+  /** Ceiling on the per-round fetch window, reached only while the walk streams
+   * sequentially through one large cluster. Default 1 MiB. */
+  maxLookaheadBytes?: number;
+  /** Two needed ranges closer than this are fetched as one request, including
+   * the bytes between them. Default 64 KiB. */
+  bridgeBytes?: number;
+}
+
+interface ResolvedBuildOptions {
+  seedBytes: number;
+  lookaheadBytes: number;
+  maxLookaheadBytes: number;
+  bridgeBytes: number;
+}
+
+function positiveSize(value: number | undefined, fallback: number, what: string): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`MdfIndex build option ${what} must be a positive integer, got ${value}`);
+  }
+  return value;
+}
+
+function resolveBuildOptions(options?: IndexBuildOptions): ResolvedBuildOptions {
+  const lookaheadBytes = positiveSize(
+    options?.lookaheadBytes,
+    BUILD_LOOKAHEAD_BYTES,
+    "lookaheadBytes",
+  );
+  const maxLookaheadBytes = positiveSize(
+    options?.maxLookaheadBytes,
+    BUILD_MAX_LOOKAHEAD_BYTES,
+    "maxLookaheadBytes",
+  );
+  return {
+    seedBytes: positiveSize(options?.seedBytes, BUILD_SEED_BYTES, "seedBytes"),
+    lookaheadBytes,
+    // A base above the ceiling would silently ignore the ceiling.
+    maxLookaheadBytes: Math.max(lookaheadBytes, maxLookaheadBytes),
+    bridgeBytes: positiveSize(options?.bridgeBytes, BUILD_BRIDGE_BYTES, "bridgeBytes"),
+  };
+}
+
+/** Smallest offset in a batch of needed ranges, without spreading a
+ * potentially huge array into `Math.min`. */
+function minOffset(needed: [number, number][]): number {
+  let min = Infinity;
+  for (const [offset] of needed) {
+    if (offset < min) min = offset;
+  }
+  return min;
+}
+
+/**
+ * Next fetch window, using a read-ahead heuristic rather than the round number.
+ *
+ * Growing purely with the round count is wrong on a file whose metadata is
+ * interleaved with data blocks: the window ratchets up to its ceiling within a
+ * few rounds and then stays there for every remaining round, so each small
+ * metadata cluster is fetched with a multi-megabyte request that drags in the
+ * data blocks around it.
+ *
+ * Instead, grow only while the walk is reading *sequentially* — the next thing
+ * it needs continues on from what was just fetched, i.e. we are streaming
+ * through one large metadata cluster and want bigger reads. When the walk
+ * instead jumps somewhere far away (the next channel group's metadata, past a
+ * data block), reset to the base window: the new cluster is probably small, and
+ * a large window here is pure over-fetch.
+ */
+function nextLookahead(
+  needed: [number, number][],
+  previousFetchEnd: number,
+  current: number,
+  opts: ResolvedBuildOptions,
+): number {
+  const sequential = minOffset(needed) <= previousFetchEnd + opts.bridgeBytes;
+  if (!sequential) return opts.lookaheadBytes;
+  return Math.min(current * 2, opts.maxLookaheadBytes);
 }
 
 /**
@@ -122,12 +223,22 @@ export class MdfIndex {
    * locations are recorded. `values`/`read` fetch and resolve a channel's
    * conversion lazily on first read, so building the index never pays for
    * conversion blocks you never read.
+   *
+   * How much gets transferred depends on how the file interleaves metadata with
+   * data, and the fetch-window defaults can be overridden per call — see
+   * {@link IndexBuildOptions}. On a file whose metadata is interleaved with
+   * data blocks, lowering `maxLookaheadBytes` toward one metadata cluster's
+   * size trades extra round-trips for a large reduction in bytes.
    */
-  static async fromRangeSource(source: RangeSource): Promise<MdfIndex> {
+  static async fromRangeSource(
+    source: RangeSource,
+    options?: IndexBuildOptions,
+  ): Promise<MdfIndex> {
     const wasm = getWasmModule();
     if (!source.size) {
       throw new Error("MdfIndex.fromRangeSource requires a RangeSource with a size() method.");
     }
+    const opts = resolveBuildOptions(options);
     const size = await source.size();
 
     const builder = new wasm.IndexBuilder(size);
@@ -146,9 +257,13 @@ export class MdfIndex {
 
       // Seed with a prefix so files whose metadata sits at the front finish in
       // one round-trip.
+      let previousFetchEnd = 0;
       if (size > 0) {
-        await fetchInto(0, Math.min(BUILD_SEED_BYTES, size));
+        const seed = Math.min(opts.seedBytes, size);
+        await fetchInto(0, seed);
+        previousFetchEnd = seed;
       }
+      let lookahead = opts.lookaheadBytes;
 
       // Bounded loop: each round fetches every range the walk still needs
       // (concurrently, with a geometrically growing look-ahead), so a file
@@ -160,13 +275,15 @@ export class MdfIndex {
         if (step.done) {
           return MdfIndex.fromJson(step.json as string);
         }
-        const lookahead = lookaheadForRound(round);
-        const spans = coalesceNeeded(
-          step.needed as [number, number][],
-          lookahead,
-          lookahead,
-          size,
-        );
+        // Bridge and look-ahead are separate knobs: bridging pulls every
+        // intervening byte, so it stays small and constant, while the
+        // per-span look-ahead grows only while the walk reads sequentially.
+        const needed = step.needed as [number, number][];
+        lookahead = nextLookahead(needed, previousFetchEnd, lookahead, opts);
+        const spans = coalesceNeeded(needed, opts.bridgeBytes, lookahead, size);
+        for (const [offset, length] of spans) {
+          previousFetchEnd = Math.max(previousFetchEnd, offset + length);
+        }
         await Promise.all(spans.map(([offset, length]) => fetchInto(offset, length)));
       }
       throw new Error(
@@ -191,9 +308,16 @@ export class MdfIndex {
    * handful of round-trips rather than one request per group. Once built,
    * read with `values`/`read` over a `RangeSource` for lazy, partial sample
    * reads.
+   *
+   * Pass `options` to tune the fetch windows for your file's shape — see
+   * {@link IndexBuildOptions}.
    */
-  static async fromUrl(url: string, fetchImpl?: FetchLike): Promise<MdfIndex> {
-    return MdfIndex.fromRangeSource(new FetchRangeSource(url, fetchImpl));
+  static async fromUrl(
+    url: string,
+    fetchImpl?: FetchLike,
+    options?: IndexBuildOptions,
+  ): Promise<MdfIndex> {
+    return MdfIndex.fromRangeSource(new FetchRangeSource(url, fetchImpl), options);
   }
 
   /** Serialise the index to a JSON string. */

--- a/js/src/web.ts
+++ b/js/src/web.ts
@@ -50,7 +50,7 @@ export function init(input?: InitInput): Promise<void> {
 }
 
 export { Mdf } from "./mdf";
-export { MdfIndex } from "./mdf-index";
+export { MdfIndex, type IndexBuildOptions } from "./mdf-index";
 export { MdfWriter, type RecordValue } from "./mdf-writer";
 
 export {

--- a/js/test/lazy-index-build-options.test.ts
+++ b/js/test/lazy-index-build-options.test.ts
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// Register the Node wasm loader (the `.` package entry does this for real
+// consumers; tests import the wrapper classes from source directly).
+import "../src/wasm-module-node";
+import { MdfIndex } from "../src/mdf-index";
+import { MdfWriter } from "../src/mdf-writer";
+import { BytesRangeSource, type RangeSource } from "../src/range-source";
+
+/**
+ * Build a file whose metadata clusters are separated by **large** data blocks.
+ *
+ * This is the shape a per-message bus logger produces (each channel group's
+ * data written before the next group's metadata) and it is the case the
+ * round-number-based look-ahead handled badly: the window ratcheted up to its
+ * ceiling and every subsequent small metadata cluster was fetched with a
+ * multi-megabyte request that dragged the surrounding data blocks along with
+ * it. `lazy-index-many-channel.test.ts` covers the opposite shape — data blocks
+ * small enough that reading straight through them is the right call.
+ *
+ * 16 channels x 8 bytes = 128 B per record, so `recordsPerGroup` records give a
+ * data block of `recordsPerGroup * 128` bytes between consecutive clusters.
+ */
+function buildWidelySpacedFile(groupCount: number, recordsPerGroup: number): Uint8Array {
+  const writer = new MdfWriter();
+  writer.initMdfFile();
+  writer.setStartTime(1_700_000_000_000_000_000n);
+
+  for (let g = 0; g < groupCount; g++) {
+    const groupId = writer.addChannelGroup(`Group_${g}`);
+    const timeId = writer.addTimeChannel(groupId, "Time");
+    for (let c = 0; c < 15; c++) {
+      writer.addFloatChannel(groupId, `Signal_${g}_${c}`);
+    }
+    writer.setTimeChannel(timeId);
+    writer.startDataBlock(groupId);
+    const row = Array(15).fill(1.5);
+    for (let i = 0; i < recordsPerGroup; i++) {
+      writer.writeRecord(groupId, [i * 0.01, ...row]);
+    }
+    writer.finishDataBlock(groupId);
+  }
+
+  return writer.finalize();
+}
+
+class CountingSource implements RangeSource {
+  reads = 0;
+  bytesRead = 0;
+  constructor(private readonly inner: RangeSource) {}
+  size(): Promise<number> {
+    return this.inner.size!();
+  }
+  async read(offset: number, length: number): Promise<Uint8Array> {
+    this.reads++;
+    const bytes = await this.inner.read(offset, length);
+    this.bytesRead += bytes.length;
+    return bytes;
+  }
+}
+
+const GROUPS = 20;
+const RECORDS = 4000; // 512 KiB data block between clusters
+
+test("MdfIndex.fromRangeSource does not drag in data blocks between metadata clusters", async () => {
+  const bytes = buildWidelySpacedFile(GROUPS, RECORDS);
+
+  const counter = new CountingSource(new BytesRangeSource(bytes));
+  const index = await MdfIndex.fromRangeSource(counter);
+
+  // The acceptance criterion: metadata is a small fraction of this file, so the
+  // build must transfer a small fraction of it. Before the read-ahead window
+  // reset on a seek, this fetched essentially the whole file.
+  assert.ok(
+    counter.bytesRead < bytes.length * 0.3,
+    `expected < 30% of ${bytes.length} bytes, got ${counter.bytesRead} ` +
+      `(${((100 * counter.bytesRead) / bytes.length).toFixed(1)}%)`,
+  );
+
+  // Correctness is not traded away for the smaller transfer.
+  const eager = MdfIndex.fromBytes(bytes);
+  assert.deepEqual(index.channelNames(), eager.channelNames());
+  assert.equal(index.channelNames().length, GROUPS * 16);
+  assert.equal(index.fileSize(), bytes.length);
+
+  index.dispose();
+  eager.dispose();
+});
+
+test("a smaller lookaheadBytes transfers strictly fewer bytes", async () => {
+  const bytes = buildWidelySpacedFile(GROUPS, RECORDS);
+
+  const wide = new CountingSource(new BytesRangeSource(bytes));
+  const wideIndex = await MdfIndex.fromRangeSource(wide, { lookaheadBytes: 64 * 1024 });
+
+  const narrow = new CountingSource(new BytesRangeSource(bytes));
+  const narrowIndex = await MdfIndex.fromRangeSource(narrow, {
+    seedBytes: 32 * 1024,
+    lookaheadBytes: 16 * 1024,
+  });
+
+  assert.ok(
+    narrow.bytesRead < wide.bytesRead,
+    `expected the narrower window to transfer less: narrow=${narrow.bytesRead} wide=${wide.bytesRead}`,
+  );
+  // Both must still produce the same index.
+  assert.deepEqual(narrowIndex.channelNames(), wideIndex.channelNames());
+
+  wideIndex.dispose();
+  narrowIndex.dispose();
+});
+
+test("invalid build options are rejected", async () => {
+  const bytes = buildWidelySpacedFile(2, 10);
+  const source = new BytesRangeSource(bytes);
+
+  await assert.rejects(
+    () => MdfIndex.fromRangeSource(source, { seedBytes: 0 }),
+    /seedBytes must be a positive integer/,
+  );
+  await assert.rejects(
+    () => MdfIndex.fromRangeSource(source, { lookaheadBytes: -1 }),
+    /lookaheadBytes must be a positive integer/,
+  );
+  await assert.rejects(
+    () => MdfIndex.fromRangeSource(source, { bridgeBytes: 1.5 }),
+    /bridgeBytes must be a positive integer/,
+  );
+
+  // A ceiling below the base is raised to the base rather than silently
+  // clamping every window down to it.
+  const index = await MdfIndex.fromRangeSource(source, {
+    lookaheadBytes: 64 * 1024,
+    maxLookaheadBytes: 1024,
+  });
+  assert.equal(index.channelNames().length, 2 * 16);
+  index.dispose();
+});


### PR DESCRIPTION
Building an index over a range source transferred ~91% of a file whose metadata is interleaved with data blocks — a per-message bus logger, or any writer that emits each group's data before the next group's metadata.

## The bug

Two mechanisms over-fetched, and both shared **one value that grew with the round number and never came back down**:

- Spans separated by up to the look-ahead were **bridged** into a single request, pulling every intervening byte. Once the value reached megabytes, two metadata clusters either side of a data block merged and the data block was transferred with them.
- Each span was **padded** to at least the look-ahead, so a 16 KB metadata cluster was fetched with a multi-megabyte request.

Because growth was keyed to the round number, the window hit its 4 MiB ceiling within ~5 rounds and stayed pinned there for every remaining round.

## Changes

**Bridge decoupled from look-ahead.** Bridging always pays for the bytes between two spans, so it is now a small constant (64 KiB) rather than growing.

**Look-ahead grows from a read-ahead heuristic instead of the round number.** Double it only while the walk reads *sequentially* — the next thing it needs continues on from what was just fetched, i.e. it is streaming through one large metadata cluster — and reset to the base window when the walk seeks somewhere far away, since the new cluster is probably small and a large window there is pure over-fetch.

**New `IndexBuildOptions`** (`seedBytes`, `lookaheadBytes`, `maxLookaheadBytes`, `bridgeBytes`) on `fromRangeSource` and `fromUrl`, exported from both the Node and `mf4-rs/web` entry points. The Rust (`from_url_with_chunk_size`, `CachingRangeReader::with_chunk_size`) and Python (`MdfIndex.from_url(url, chunk_size)`) bindings already accepted a chunk size; JS had no equivalent, since the constants were module-private and the entry points took no options. Values are validated as positive integers, and a ceiling below the base is raised to the base rather than clamping every window down to it.

```ts
const idx = await MdfIndex.fromUrl(url, undefined, { lookaheadBytes: 32 * 1024 });
```

## Measured

On a 200-group / 6600-channel / 95.2 MiB fixture (`examples/gen_canape_fixture.rs`) with 482 KB data blocks between metadata clusters:

| | reads | fetched | % of file |
|---|---|---|---|
| before | 28 | 87.0 MiB | 91.4% |
| after (defaults) | 200 | 12.7 MiB | **13.3%** |
| `lookaheadBytes: 32K` | 200 | 6.3 MiB | 6.6% |

The ceiling no longer affects this shape at all — 256K through 4M all yield 13.3%, because the window resets on every seek and never grows.

Trade-off, stated plainly: round-trips go from 28 to 200, since each round now advances one cluster instead of straddling several. That is a win on any realistic link (200 × 30 ms ≈ 6 s plus 12.7 MB, versus 0.8 s plus 87 MB) but worse on a fat, high-latency pipe — which is what the options are for. Avoiding both costs would need speculative stride-based prefetch; not attempted here.

Files with small data blocks are unaffected: the heuristic keeps reading straight through them. The pre-existing `lazy-index-many-channel` test (185 groups, ~26 KB data blocks, asserts `< 50` reads) still passes unchanged, which is the guard for that shape.

## Tests

New `js/test/lazy-index-build-options.test.ts` (fixture with 512 KB data blocks between clusters):
- data blocks between metadata clusters are not dragged in (transfer stays under 30% of the file, and the index matches `fromBytes`)
- a smaller `lookaheadBytes` transfers strictly fewer bytes, with an identical resulting index
- invalid options are rejected, and a ceiling below the base is raised rather than clamping

**35/35 JS tests pass** (32 existing + 3 new); `npm run build` and `npm run build:web` both clean. No Rust changes in this PR.

Known follow-up: the native `CachingRangeReader` still defaults to fixed 1 MiB chunks and hits the same over-fetch on this shape (99.8% measured), so Rust and Python callers must pass a chunk size explicitly. Porting this seek-reset heuristic there is the natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx51cHYkDZyyoDXTFbduoe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rx51cHYkDZyyoDXTFbduoe)_